### PR TITLE
RFC: Addition/update of various dictionary, set variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This package implements a variety of data structures, including
 * Disjoint Sets
 * Binary Heap
 * Mutable Binary Heap
+* Ordered Dicts and Sets
+* Dictionaries with Defaults
 
 ## Deque
 
@@ -168,18 +170,61 @@ h = mutable_binary_minheap([1,4,3,2])
 h = mutable_binary_maxheap([1,4,3,2])    # create a mutable min/max heap from a vector
 ```
 
+## OrderedDicts and OrderedSets
 
-## DefaultDict
+``OrderedDicts`` are simply dictionaries whose entries have a
+particular order.  For ``OrderedDicts`` (and ``OrderedSets``), order
+refers to *insertion order*, which allows deterministic iteration over
+the dictionary or set.
+
+```julia
+d = OrderedDict(Char,Int)
+for c in 'a':'e'
+    d[c] = c-'a'+1
+end
+collect(d) # => [('a',1),('b',2),('c',3),('d',4),('e',5)]
+
+s = OrderedSet(π,e,γ,catalan,φ)
+collect(s) # => [π = 3.1415926535897...,
+           #     e = 2.7182818284590...,
+           #     γ = 0.5772156649015...,
+		   #     catalan = 0.9159655941772...,
+		   #	 φ = 1.6180339887498...]
+```
+
+All standard ``Associative`` and ``Dict`` functions are available for
+``OrderedDicts``, and all ``Set`` operations are available for
+OrderedSets.
+
+Note that to create an OrderedSet of a particular type, you must
+specify the type in curly-braces:
+
+```julia
+# create an OrderedSet of Strings
+strs = OrderedSet{String}()
+```
+
+
+## DefaultDict and DefaultOrderedDict
 
 A DefaultDict allows specification of a default value to return when a requested key is not in a dictionary.
 
-The version of ``DefaultDict`` provided here is a wrapper around an ``Associative`` type, which defaults to ``Dict``.  All ``Associative`` and ``Dict`` methods are supported.
+While the implementation is slightly different, a ``DefaultDict`` can be thought to provide a normal ``Dict``
+with a default value.  A ``DefaultOrderedDict`` does the same for an ``OrderedDict``.
 
-Constructors for ``DefaultDict`` include
+Constructors:
 ```julia
-DefaultDict(default, d::Associative=Dict())  # create a DefaultDict with a default value or function,
-                                             # optionally wrapping an existing dictionary
-DefaultDict(KeyType, ValueType, default)     # create a DefaultDict with Dict type (KeyType,ValueType)
+DefaultDict(default, kv)                        # create a DefaultDict with a default value or function,
+                                                # optionally wrapping an existing dictionary
+										        # or array of key-value pairs
+
+DefaultDict(KeyType, ValueType, default)        # create a DefaultDict with Dict type (KeyType,ValueType)
+
+OrderedDefaultDict(default, kv)                 # create a OrderedDefaultDict with a default value or function,
+                                                # optionally wrapping an existing dictionary
+							  	                # or array of key-value pairs
+
+OrderedDefaultDict(KeyType, ValueType, default) # create a OrderedDefaultDict with Dict type (KeyType,ValueType)
 ```
 
 Examples using ``DefaultDict``:
@@ -190,14 +235,14 @@ dd = DefaultDict(String, Int, 0)  # create a (String=>Int) DefaultDict with a de
 d = ['a'=>1, 'b'=>2]
 dd = DefaultDict(0, d)            # provide a default value to an existing dictionary
 dd['c'] == 0                      # true
-d['c']  == 0                      # true
+#d['c'] == 0                      # false
 
-dd = DefaultDict(time)            # call time() to provide the default value
+dd = DefaultOrderedDict(time)     # call time() to provide the default value for an OrderedDict
 dd = DefaultDict(Dict)            # Create a dictionary of dictionaries
                                   # Dict() is called to provide the default value
 dd = DefaultDict(()->myfunc())    # call function myfunc to provide the default value
 
-# create a Dictionary of String=>DefaultDict{String, Int}, where the default of the
+# create a Dictionary of type String=>DefaultDict{String, Int}, where the default of the
 # inner set of DefaultDicts is zero
 dd = DefaultDict(String, DefaultDict, ()->DefaultDict(String,Int,0))
 ```

--- a/run_tests.jl
+++ b/run_tests.jl
@@ -5,7 +5,9 @@ tests = ["deque",
 		 "disjoint_set", 
 		 "binheap", 
 		 "mutable_binheap",
-		 "defaultdict"]
+		 "defaultdict",
+		 "ordereddict",
+		 "orderedset"]
 
 for t in tests
 	fp = joinpath("test", "test_$t.jl")

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -1,10 +1,11 @@
 module DataStructures
     
     import Base: length, isempty, start, next, done,
-                 show, dump, empty!, getindex, setindex!, get,
+                 show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy,
                  push!, pop!, shift!, unshift!, add!,
-                 union!, delete!, similar, sizehint
+                 union!, delete!, similar, sizehint, 
+                 isequal, hash
     
     export Deque, Stack, Queue
     export deque, stack, queue, enqueue!, dequeue!, update!
@@ -20,8 +21,11 @@ module DataStructures
     export BinaryHeap, binary_minheap, binary_maxheap
     export MutableBinaryHeap, mutable_binary_minheap, mutable_binary_maxheap
 
-    export DefaultDict
+    export OrderedDict, OrderedSet
+    export DefaultDict, DefaultOrderedDict
     
+    include("delegate.jl")
+
     include("deque.jl") 
     include("stack.jl")   
     include("queue.jl")
@@ -29,5 +33,9 @@ module DataStructures
     include("classifiedcollections.jl")
     include("disjoint_set.jl")
     include("heaps.jl")
+
+    include("hashdict.jl")
+    include("ordereddict.jl")
+    include("orderedset.jl")
     include("defaultdict.jl")
 end

--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -1,73 +1,166 @@
 # Dictionary which returns (and sets) a default value for a requested item not
 # already in to the dictionary
 
-immutable DefaultDict{K,V,F,D<:Associative} <: Associative{K,V}
+# DefaultDictBase is the main class used to in Default*Dicts.
+#
+# Each related (immutable) Default*Dict class contains a single
+# DefautlDictBase object as a member, and delegates almost all
+# functions to this object.
+#
+# The main rationale for doing this instead of using type aliases is
+# that this way, we can have actual class names and constructors for
+# each of the DefaultDictBase "subclasses", in some sense getting
+# around the Julia limitation of not allowing concrete classes to be
+# subclassed.
+# 
+
+immutable DefaultDictBase{K,V,F,D<:Associative{K,V}} <: Associative{K,V}
     default::F
     d::D
 
-    DefaultDict(x::F, kv::AbstractArray{(K,V)}) = new(x, D{K,V}(kv))
-    DefaultDict(x::F, d::DefaultDict) = DefaultDict(x, d.d)
-    DefaultDict(x::F, d::D=D{K,V}()) = new(x, d)
-    DefaultDict(x, ks, vs) = new(x, D{K,V}(ks,vs))
+    DefaultDictBase(x::F, kv::AbstractArray{(K,V)}) = new(x, D(kv))
+    DefaultDictBase(x::F, d::DefaultDictBase) = DefaultDictBase(x, d.d)
+    DefaultDictBase(x::F, d::D=D()) = new(x, d)
+    DefaultDictBase(x, ks, vs) = new(x, D(ks,vs))
+
 end
 
-DefaultDict() = error("DefaultDict: no default specified")
-DefaultDict(k,v) = error("DefaultDict: no default specified")
+# Constructors
+
+DefaultDictBase() = error("no default specified")
+DefaultDictBase(k,v) = error("no default specified")
 
 # TODO: these mimic similar Dict constructors, but may not be needed
-DefaultDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = DefaultDict{K,V,F,Dict}(default,ks,vs)
-DefaultDict{F}(default::F,ks,vs) = DefaultDict{Any,Any,F,Dict}(default, ks, vs)
+DefaultDictBase{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = 
+    DefaultDictBase{K,V,F,Dict{K,V}}(default,ks,vs)
+DefaultDictBase{F}(default::F,ks,vs) = DefaultDictBase{Any,Any,F,Dict}(default, ks, vs)
 
 # syntax entry points
-DefaultDict{F}(default::F) = DefaultDict{Any,Any,F,Dict}(default)
-DefaultDict{K,V,F}(::Type{K}, ::Type{V}, default::F) = DefaultDict{K,V,F,Dict}(default)
-DefaultDict{K,V,F}(default::F, kv::AbstractArray{(K,V)}) = DefaultDict{K,V,F,Dict}(default, kv)
-DefaultDict{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultDict{K,V,F,D}(default, d))
+DefaultDictBase{F}(default::F) = DefaultDictBase{Any,Any,F,Dict}(default)
+DefaultDictBase{K,V,F}(::Type{K}, ::Type{V}, default::F) = DefaultDictBase{K,V,F,Dict}(default)
+DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{(K,V)}) = DefaultDictBase{K,V,F,Dict}(default, kv)
 
-similar{K,V,F,D}(d::DefaultDict{K,V,F,D}) = DefaultDict{K,V,F,D}()
+DefaultDictBase{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultDictBase{K,V,F,D}(default, d))
 
-sizehint(d::DefaultDict) = sizehint(d.d)
-empty!(d::DefaultDict) = empty!(d.d)
-setindex!(d::DefaultDict, v, k) = setindex!(d.d, v, k)
+# Functions
 
-# Note that getindex depends on the particular implementation of Dict in Base.
-# If the Dict implementation changes, this may break.
-# Also note that we hash twice here if the key is not in the dictionary: once
-# when retrieving, and once when assigning.
-function getindex{K,V,F<:Base.Callable}(d::DefaultDict{K,V,F}, key)
-    index = Base.ht_keyindex(d.d, key)
-    if index < 0
-        d.d[key] = ret = convert(V, d.default())
-        return ret::V
+# most functions are simply delegated to the wrapped dictionary
+@delegate DefaultDictBase.d [ sizehint, empty!, setindex!, get, haskey,
+                              getkey, pop!, delete!, start, done, next,
+                              isempty, length ]
+
+similar{K,V,F}(d::DefaultDictBase{K,V,F}) = DefaultDictBase{K,V,F}()
+in{T<:DefaultDictBase}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d)
+next{T<:DefaultDictBase}(v::Base.KeyIterator{T}, i) = (v.dict.d.keys[i], Base.skip_deleted(v.dict.d,i+1))
+next{T<:DefaultDictBase}(v::Base.ValueIterator{T}, i) = (v.dict.d.vals[i], Base.skip_deleted(v.dict.d,i+1))
+
+getindex(d::DefaultDictBase, key) = get!(d.d, key, d.default)
+
+# TODO: remove these if/when https://github.com/JuliaLang/julia/pull/5519 is committed
+if !applicable(get!, (Dict,))
+    global getindex
+    function getindex{K,V,F<:Base.Callable}(d::DefaultDictBase{K,V,F,Dict}, key)
+        if !haskey(d.d, key) 
+            return (d.d[key] = d.default())
+        end
+        return d.d[key]
+    end    
+
+    function getindex{K,V,F}(d::DefaultDictBase{K,V,F,Dict}, key)
+        if !haskey(d.d, key) 
+            return (d.d[key] = d.default)
+        end
+        return d.d[key]
     end
-    return d.d.vals[index]::V
+end    
+
+
+################
+
+# Here begins the actual definition of the DefaultDict and
+# DefaultOrderedDict classes.  As noted above, these are simply
+# wrappers around a DefaultDictBase object, and delegate all functions
+# to that object
+
+for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Ordered)]
+    @eval begin
+        immutable $DefaultDict{K,V,F} <: Associative{K,V}
+            d::DefaultDictBase{K,V,F,HashDict{K,V,$O}}
+
+            $DefaultDict(x, kv::AbstractArray{(K,V)}) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, kv))
+            $DefaultDict(x, d::$DefaultDict) = $DefaultDict(x, d.d)
+            $DefaultDict(x, d::HashDict) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, d))
+            $DefaultDict(x) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x))
+            $DefaultDict(x, ks, vs) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x,ks,vs))
+        end
+
+        ## Constructors
+
+        $DefaultDict() = error("$DefaultDict: no default specified")
+        $DefaultDict(k,v) = error("$DefaultDict: no default specified")
+
+        # TODO: these mimic similar Dict constructors, but may not be needed
+        $DefaultDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = $DefaultDict{K,V,F}(default,ks,vs)
+        $DefaultDict{F}(default::F,ks,vs) = $DefaultDict{Any,Any,F}(default, ks, vs)
+
+        # syntax entry points
+        $DefaultDict{F}(default::F) = $DefaultDict{Any,Any,F}(default)
+        $DefaultDict{K,V,F}(::Type{K}, ::Type{V}, default::F) = $DefaultDict{K,V,F}(default)
+        $DefaultDict{K,V,F}(default::F, kv::AbstractArray{(K,V)}) = $DefaultDict{K,V,F}(default, kv)
+
+        $DefaultDict{F}(default::F, d::Associative) = ((K,V)=eltype(d); $DefaultDict{K,V,F}(default, HashDict(d)))
+
+        ## Functions
+
+        # Most functions are simply delegated to the wrapped DefaultDictBase object
+        @delegate $DefaultDict.d [ sizehint, empty!, setindex!,
+                                   getindex, get, get!, haskey,
+                                   getkey, pop!, delete!, start, next,
+                                   done, next, isempty, length]
+
+        similar{K,V,F}(d::$DefaultDict{K,V,F}) = $DefaultDict{K,V,F}()
+        in{T<:$DefaultDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)
+    end
 end
 
-function getindex{K,V}(d::DefaultDict{K,V}, key)
-    index = Base.ht_keyindex(d.d, key)
-    if index < 0
-        d.d[key] = ret = convert(V, d.default)
-        return ret::V
-    end
-    return d.d.vals[index]::V
-end
 
-get(d::DefaultDict, key, deflt) = get(d.d, key, deflt)
+## If/when a SortedDict becomes available, this should be uncommented to provide a DefaultSortedDict
 
-haskey(d::DefaultDict, key) = haskey(d.d, key)
-in{T<:DefaultDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d)
-getkey(d::DefaultDict, key, deflt) = getkey(d.d, key, deflt)
+# immutable DefaultSortedDict{K,V,F} <: Associative{K,V}
+#     d::DefaultDictBase{K,V,F,SortedDict{K,V}}
 
-pop!(d::DefaultDict, key) = pop!(d.d, key)
-delete!(d::DefaultDict, key) = delete!(d.d, key)
+#     DefaultSortedDict(x, kv::AbstractArray{(K,V)}) = new(DefaultDictBase{K,V,F,SortedDict{K,V}}(x, kv))
+#     DefaultSortedDict(x, d::DefaultSortedDict) = DefaultSortedDict(x, d.d)
+#     DefaultSortedDict(x, d::SortedDict) = new(DefaultDictBase{K,V,F,SortedDict{K,V}}(x, d))
+#     DefaultSortedDict(x) = new(DefaultDictBase{K,V,F,SortedDict{K,V}}(x))
+#     DefaultSortedDict(x, ks, vs) = new(DefaultDictBase{K,V,F,SortedDict{K,V}}(x,ks,vs))
+# end
 
-start(d::DefaultDict) = start(d.d)
-done(d::DefaultDict, i) = done(d.d,i)
-next(d::DefaultDict, i) = next(d.d,i)
+## Constructors
 
-isempty(d::DefaultDict) = isempty(d.d)
-length(d::DefaultDict) = length(d.d)
+# DefaultSortedDict() = error("DefaultSortedDict: no default specified")
+# DefaultSortedDict(k,v) = error("DefaultSortedDict: no default specified")
 
-next{T<:DefaultDict}(v::Base.KeyIterator{T}, i) = (v.dict.d.keys[i], Base.skip_deleted(v.dict.d,i+1))
-next{T<:DefaultDict}(v::Base.ValueIterator{T}, i) = (v.dict.d.vals[i], Base.skip_deleted(v.dict.d,i+1))
+# # TODO: these mimic similar Dict constructors, but may not be needed
+# DefaultSortedDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = DefaultSortedDict{K,V,F}(default,ks,vs)
+# DefaultSortedDict{F}(default::F,ks,vs) = DefaultSortedDict{Any,Any,F}(default, ks, vs)
+
+# # syntax entry points
+# DefaultSortedDict{F}(default::F) = DefaultSortedDict{Any,Any,F}(default)
+# DefaultSortedDict{K,V,F}(::Type{K}, ::Type{V}, default::F) = DefaultSortedDict{K,V,F}(default)
+# DefaultSortedDict{K,V,F}(default::F, kv::AbstractArray{(K,V)}) = DefaultSortedDict{K,V,F}(default, kv)
+
+# DefaultSortedDict{F}(default::F, d::Associative) = ((K,V)=eltype(d); DefaultSortedDict{K,V,F}(default, SortedDict(d)))
+
+## Functions
+
+## Most functions are simply delegated to the wrapped DefaultDictBase object
+
+# @delegate DefaultSortedDict.d [ sizehint, empty!, setindex!,
+#                            getindex, get, get!, haskey,
+#                            getkey, pop!, delete!, start, next,
+#                            done, next, isempty, length]
+
+# similar{K,V,F}(d::DefaultSortedDict{K,V,F}) = DefaultSortedDict{K,V,F}()
+# in{T<:DefaultSortedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)
 

--- a/src/delegate.jl
+++ b/src/delegate.jl
@@ -1,0 +1,16 @@
+# by JMW
+macro delegate(source, targets)
+    typename = esc(source.args[1])
+    fieldname = esc(Expr(:quote, source.args[2].args[1]))
+    funcnames = targets.args
+    n = length(funcnames)
+    fdefs = Array(Any, n)
+    for i in 1:n
+        funcname = esc(funcnames[i])
+        fdefs[i] = quote
+                     ($funcname)(a::($typename), args...) =
+                       ($funcname)(a.($fieldname), args...)
+                   end
+    end
+    return Expr(:block, fdefs...)
+end

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -1,0 +1,500 @@
+# HashDict
+
+import Base: KeyIterator, ValueIterator, haskey, get, getkey, delete!,
+             pop!, empty!, filter!, setindex!, getindex, similar,
+             sizehint, length, filter, isempty, start, next, done,
+             keys, values, _tablesz, skip_deleted
+
+typealias Unordered Nothing
+typealias Ordered   Int
+
+type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
+    slots::Array{Uint8,1}
+    keys::Array{K,1}
+    vals::Array{V,1}
+    idxs::Array{O,1}
+    order::Array{O,1}
+    ndel::Int
+    count::Int
+    deleter::Function
+
+    function HashDict()
+        n = 16
+        new(zeros(Uint8,n), Array(K,n), Array(V,n), Array(O,n), Array(O,0), 0, 0, identity)
+    end
+    function HashDict(ks, vs)
+        n = length(ks)
+        h = HashDict{K,V,O}()
+        for i=1:n
+            h[ks[i]] = vs[i]
+        end
+        return h
+    end
+    function HashDict(kv)
+        h = HashDict{K,V,O}()
+        for (k,v) in kv
+            h[k] = v
+        end
+        return h
+    end
+end
+
+HashDict() = HashDict{Any,Any,Unordered}()
+
+HashDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = HashDict{K,V,Unordered}(ks,vs)
+HashDict(ks, vs) = HashDict{Any,Any,Unordered}(ks, vs)
+HashDict{K,V}(kv::AbstractArray{(K,V)}) = HashDict{K,V,Unordered}(kv)
+
+# TODO: these could be more efficient
+HashDict{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}(collect(kv))
+HashDict{K,V}(d::Associative{K,V}) = HashDict{K,V,Unordered}(collect(d))
+
+similar{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}()
+
+function serialize(s, t::HashDict)
+    serialize_type(s, typeof(t))
+    write(s, int32(length(t)))
+    for (k,v) in t
+        serialize(s, k)
+        serialize(s, v)
+    end
+end
+
+function deserialize{K,V,O}(s, T::Type{HashDict{K,V,O}})
+    n = read(s, Int32)
+    t = T(); sizehint(t, n)
+    for i = 1:n
+        k = deserialize(s)
+        v = deserialize(s)
+        t[k] = v
+    end
+    return t
+end
+
+hashindex(key, sz) = (int(hash(key)) & (sz-1)) + 1
+
+isslotempty(h::HashDict, i::Int) = h.slots[i] == 0x0
+isslotfilled(h::HashDict, i::Int) = h.slots[i] == 0x1
+isslotmissing(h::HashDict, i::Int) = h.slots[i] == 0x2
+
+function rehash{K,V}(h::HashDict{K,V,Unordered}, newsz)
+    newsz = _tablesz(newsz)
+
+    if h.count == 0
+        resize!(h.slots, newsz)
+        fill!(h.slots, 0)
+        resize!(h.keys, newsz)
+        resize!(h.vals, newsz)
+        h.ndel = 0
+        return h
+    end
+
+    olds = h.slots
+    oldk = h.keys
+    oldv = h.vals
+    sz = length(olds)
+
+    slots = zeros(Uint8,newsz)
+    keys = Array(K, newsz)
+    vals = Array(V, newsz)
+    count0 = h.count
+    count = 0
+
+    for i = 1:sz
+        if olds[i] == 0x1
+            k = oldk[i]
+            v = oldv[i]
+            index = hashindex(k, newsz)
+            while slots[index] != 0
+                index = (index & (newsz-1)) + 1
+            end
+            slots[index] = 0x1
+            keys[index] = k
+            vals[index] = v
+            count += 1
+
+            if h.count != count0
+                # if items are removed by finalizers, retry
+                return rehash(h, newsz)
+            end
+        end
+    end
+
+    h.slots = slots
+    h.keys = keys
+    h.vals = vals
+    h.count = count
+    h.ndel = 0
+
+    return h
+end
+
+function rehash{K,V}(h::HashDict{K,V,Ordered}, newsz)
+    newsz = _tablesz(newsz)
+
+    if h.count == 0
+        resize!(h.slots, newsz)
+        fill!(h.slots, 0)
+        resize!(h.keys, newsz)
+        resize!(h.vals, newsz)
+        resize!(h.idxs, newsz)
+        resize!(h.order, 0)
+        h.ndel = 0
+        return h
+    end
+
+    _compact_order(h)
+
+    olds = h.slots
+    oldk = h.keys
+    oldv = h.vals
+    oldi = h.idxs
+    oldo = h.order
+    sz = length(olds)
+
+    slots = zeros(Uint8,newsz)
+    keys = Array(K, newsz)
+    vals = Array(V, newsz)
+    idxs = Array(Int, newsz)
+    order = Array(Int, h.count)
+    count0 = h.count
+    count = 0
+
+    for i = 1:sz
+        if olds[i] == 0x1
+            k = oldk[i]
+            v = oldv[i]
+            idx = oldi[i]
+            index = hashindex(k, newsz)
+            while slots[index] != 0
+                index = (index & (newsz-1)) + 1
+            end
+            slots[index] = 0x1
+            keys[index] = k
+            vals[index] = v
+            idxs[index] = idx
+            order[idx] = index
+            count += 1
+
+            if h.count != count0
+                # if items are removed by finalizers, retry
+                return rehash(h, newsz)
+            end
+        end
+    end
+
+    h.slots = slots
+    h.keys = keys
+    h.vals = vals
+    h.idxs = idxs
+    h.order = order
+    h.count = count
+    h.ndel = 0
+
+    return h
+end
+
+
+function _compact_order{K,V}(h::HashDict{K,V,Ordered})
+    if h.count == length(h.order)
+        return
+    end
+
+    i = 1
+    while h.order[i] > 0;  i += 1; end
+
+    j = i+1
+    while h.order[j] == 0; j += 1; end
+
+    for k = j:length(h.order)
+        idx = h.order[k]
+        if idx > 0
+            h.order[i] = idx
+            h.idxs[idx] = i
+            i += 1
+        end
+    end
+
+    resize!(h.order, h.count)
+
+    nothing
+end
+
+function sizehint(d::HashDict, newsz)
+    oldsz = length(d.slots)
+    if newsz <= oldsz
+        # todo: shrink
+        # be careful: rehash() assumes everything fits. it was only designed
+        # for growing.
+        return d
+    end
+    # grow at least 25%
+    newsz = max(newsz, (oldsz*5)>>2)
+    rehash(d, newsz)
+end
+
+function empty!{K,V}(h::HashDict{K,V})
+    fill!(h.slots, 0x0)
+    sz = length(h.slots)
+    h.keys = Array(K, sz)
+    h.vals = Array(V, sz)
+    h.ndel = 0
+    h.count = 0
+    return h
+end
+
+function empty!{K,V}(h::HashDict{K,V,Ordered})
+    sz = length(h.slots)
+    fill!(h.slots, 0x0)
+    h.keys = Array(K, sz)
+    h.vals = Array(V, sz)
+    h.idxs = Array(Int, sz)
+    h.order = Array(Int, 0)
+    h.ndel = 0
+    h.count = 0
+    return h
+end
+
+# get the index where a key is stored, or -1 if not present
+function ht_keyindex{K,V}(h::HashDict{K,V}, key)
+    sz = length(h.keys)
+    iter = 0
+    maxprobe = max(16, sz>>6)
+    index = hashindex(key, sz)
+    keys = h.keys
+
+    while true
+        if isslotempty(h,index)
+            break
+        end
+        if !isslotmissing(h,index) && isequal(key,keys[index])
+            return index
+        end
+
+        index = (index & (sz-1)) + 1
+        iter+=1
+        iter > maxprobe && break
+    end
+
+    return -1
+end
+
+# get the index where a key is stored, or -pos if not present
+# and the key would be inserted at pos
+# This version is for use by setindex! and get!
+function ht_keyindex2{K,V}(h::HashDict{K,V}, key)
+    sz = length(h.keys)
+
+    if h.ndel >= ((3*sz)>>2) || h.count*3 > sz*2
+        # > 3/4 deleted or > 2/3 full
+        rehash(h, h.count > 64000 ? h.count*2 : h.count*4)
+        sz = length(h.keys)  # rehash may resize the table at this point!
+    end
+
+    iter = 0
+    maxprobe = max(16, sz>>6)
+    index = hashindex(key, sz)
+    avail = 0
+    keys = h.keys
+
+    while true
+        if isslotempty(h,index)
+            avail < 0 && return avail
+            return -index
+        end
+
+        if isslotmissing(h,index)
+            if avail == 0
+                # found an available slot, but need to keep scanning
+                # in case "key" already exists in a later collided slot.
+                avail = -index
+            end
+        elseif isequal(key, keys[index])
+            return index
+        end
+
+        index = (index & (sz-1)) + 1
+        iter+=1
+        iter > maxprobe && break
+    end
+
+    avail < 0 && return avail
+
+    rehash(h, h.count > 64000 ? sz*2 : sz*4)
+
+    return ht_keyindex2(h, key)
+end
+
+function _setindex!(h::HashDict, v, key, index)
+    h.slots[index] = 0x1
+    h.keys[index] = key
+    h.vals[index] = v
+    h.count += 1
+    return h
+end
+
+function _setindex!{K,V}(h::HashDict{K,V,Ordered}, v, key, index)
+    h.slots[index] = 0x1
+    h.keys[index] = key
+    h.vals[index] = v
+    push!(h.order, index)
+    h.idxs[index] = length(h.order)
+    h.count += 1
+    return h
+end
+
+function setindex!{K,V}(h::HashDict{K,V}, v0, key0)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        error(key0, " is not a valid key for type ", K)
+    end
+    v   = convert(V,  v0)
+
+    index = ht_keyindex2(h, key)
+
+    if index > 0
+        h.vals[index] = v
+    else
+        _setindex!(h, v, key, -index)
+    end
+
+    return h
+end
+
+function get!{K,V}(h::HashDict{K,V}, key0, default)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        error(key0, " is not a valid key for type ", K)
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default)
+    _setindex!(h, v, key, -index)
+    return v
+end
+
+function get!{K,V}(h::HashDict{K,V}, key0, default)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        error(key0, " is not a valid key for type ", K)
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default)
+    _setindex!(h, v, key, -index)
+    return v
+end
+
+# TODO: this makes it challenging to have V<:Base.Callable
+function get!{K,V,F<:Base.Callable}(h::HashDict{K,V}, key0, default::F)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        error(key0, " is not a valid key for type ", K)
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default())
+    _setindex!(h, v, key, -index)
+    return v
+end
+
+function getindex{K,V}(h::HashDict{K,V}, key)
+    index = ht_keyindex(h, key)
+    return (index<0) ? throw(KeyError(key)) : h.vals[index]::V
+end
+
+function get{K,V}(h::HashDict{K,V}, key, deflt)
+    index = ht_keyindex(h, key)
+    return (index<0) ? deflt : h.vals[index]::V
+end
+
+haskey(h::HashDict, key) = (ht_keyindex(h, key) >= 0)
+contains{T<:HashDict}(v::KeyIterator{T}, key) = (ht_keyindex(v.dict, key) >= 0)
+
+function getkey{K,V}(h::HashDict{K,V}, key, deflt)
+    index = ht_keyindex(h, key)
+    return (index<0) ? deflt : h.keys[index]::K
+end
+
+function _pop!(h::HashDict, index)
+    val = h.vals[index]
+    _delete!(h, index)
+    return val
+end
+
+function pop!(h::HashDict, key)
+    index = ht_keyindex(h, key)
+    index > 0 ? _pop!(h, index) : throw(KeyError(key))
+end
+
+function pop!(h::HashDict, key, default)
+    index = ht_keyindex(h, key)
+    index > 0 ? _pop!(h, index) : default
+end
+
+
+function _delete!(h::HashDict, index)
+    h.slots[index] = 0x2
+    ccall(:jl_arrayunset, Void, (Any, Uint), h.keys, index-1)
+    ccall(:jl_arrayunset, Void, (Any, Uint), h.vals, index-1)
+    h.ndel += 1
+    h.count -= 1
+    return h
+end
+
+function _delete!{K,V}(h::HashDict{K,V,Ordered}, index)
+    h.slots[index] = 0x2
+    ccall(:jl_arrayunset, Void, (Any, Uint), h.keys, index-1)
+    ccall(:jl_arrayunset, Void, (Any, Uint), h.vals, index-1)
+    h.order[h.idxs[index]] = 0
+    h.ndel += 1
+    h.count -= 1
+    return h
+end
+
+function delete!(h::HashDict, key)
+    index = ht_keyindex(h, key)
+    index > 0 && _delete!(h, index)
+    return h
+end
+
+function skip_deleted{K,V,O}(h::HashDict{K,V,O}, i)
+    L = length(h.slots)
+    while i<=L && !isslotfilled(h,i)
+        i += 1
+    end
+    return i
+end
+
+function skip_deleted{K,V}(h::HashDict{K,V,Ordered}, i)
+    L = length(h.order)
+    while i<=L && h.order[i] == 0
+        i += 1
+    end
+    return i
+end
+
+start(t::HashDict) = skip_deleted(t, 1)
+done(t::HashDict, i) = done(t.vals, i)
+next(t::HashDict, i) = ((t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+
+done{K,V}(t::HashDict{K,V,Ordered}, i) = done(t.order, i)
+next{K,V}(t::HashDict{K,V,Ordered}, i) = ((t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+
+isempty(t::HashDict) = (t.count == 0)
+length(t::HashDict) = t.count
+
+next(v::KeyIterator{HashDict}, i) = (v.dict.keys[i], skip_deleted(v.dict,i+1))
+next(v::ValueIterator{HashDict}, i) = (v.dict.vals[i], skip_deleted(v.dict,i+1))
+
+next{K,V}(v::KeyIterator{HashDict{K,V,Ordered}}, i) = (v.dict.keys[v.dict.order[i]], skip_deleted(v.dict,i+1))
+next{K,V}(v::ValueIterator{HashDict{K,V,Ordered}}, i) = (v.dict.vals[v.dict.order[i]], skip_deleted(v.dict,i+1))

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -1,0 +1,44 @@
+# ordered dict
+
+import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
+             setindex!, getindex, sizehint, length, isempty, start,
+             next, done, keys, values, setdiff, setdiff!,
+             union, union!, intersect, isequal, filter, filter!,
+             hash, eltype
+
+# This is just a simple wrapper around a HashDict, which is a modified
+# implementation of the Dict implementation in Base allowing ordering
+# information to be maintained.
+
+# In particular, the HashDict stored in an OrderedDict is a 
+# HashDict{K,V,Ordered}
+
+# A HashDict{K,V,Unordered} would be equivalent to Base.Dict
+
+immutable OrderedDict{K,V} <: Associative{K,V}
+    d::HashDict{K,V,Ordered}
+
+    OrderedDict() = new(HashDict{K,V,Ordered}())
+    OrderedDict(kv) = new(HashDict{K,V,Ordered}(kv))
+    OrderedDict(ks,vs) = new(HashDict{K,V,Ordered}(ks,vs))
+end
+
+OrderedDict() = OrderedDict{Any,Any}()
+
+OrderedDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = OrderedDict{K,V}(ks,vs)
+OrderedDict{K,V}(::Type{K},::Type{V}) = OrderedDict{K,V}()
+OrderedDict(ks,vs) = OrderedDict{eltype(ks),eltype(vs)}(ks, vs)
+
+OrderedDict{K,V}(kv::AbstractArray{(K,V)}) = OrderedDict{K,V}(kv)
+
+## Functions
+
+## Most functions are simply delegated to the wrapped HashDict
+
+@delegate OrderedDict.d [ haskey, get, get!, getkey, delete!, pop!,
+                          empty!, setindex!, getindex, sizehint,
+                          length, isempty, start, next, done, keys,
+                          values ]
+
+similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()
+in{T<:OrderedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/orderedset.jl
+++ b/src/orderedset.jl
@@ -1,0 +1,96 @@
+# ordered sets
+
+# This was largely copied and modified from Base
+
+# TODO: Most of these functions should be removed once AbstractSet is introduced there
+# (see https://github.com/JuliaLang/julia/issues/5533)
+
+immutable OrderedSet{T}
+    dict::HashDict{T,Nothing,Ordered}
+
+    OrderedSet() = new(HashDict{T,Nothing,Ordered}())
+    OrderedSet(x...) = union!(new(HashDict{T,Nothing,Ordered}()), x)
+end
+OrderedSet() = OrderedSet{Any}()
+OrderedSet(x...) = OrderedSet{Any}(x...)
+OrderedSet{T}(x::T...) = OrderedSet{T}(x...)
+
+show(io::IO, s::OrderedSet) = (show(io, typeof(s)); Base.show_comma_array(io, s,'(',')'))
+
+@delegate OrderedSet.dict [isempty, length, sizehint]
+
+eltype{T}(s::OrderedSet{T}) = T
+
+in(x, s::OrderedSet) = haskey(s.dict, x)
+
+push!(s::OrderedSet, x) = (s.dict[x] = nothing; s)
+pop!(s::OrderedSet, x) = (pop!(s.dict, x); x)
+pop!(s::OrderedSet, x, deflt) = pop!(s.dict, x, deflt) == deflt ? deflt : x
+delete!(s::OrderedSet, x) = (delete!(s.dict, x); s)
+
+union!(s::OrderedSet, xs) = (for x in xs; push!(s,x); end; s)
+setdiff!(s::OrderedSet, xs) = (for x in xs; delete!(s,x); end; s)
+setdiff!(s::Set, xs::OrderedSet) = (for x in xs; delete!(s,x); end; s)
+
+similar{T}(s::OrderedSet{T}) = OrderedSet{T}()
+copy(s::OrderedSet) = union!(similar(s), s)
+
+empty!{T}(s::OrderedSet{T}) = (empty!(s.dict); s)
+
+start(s::OrderedSet)       = start(s.dict)
+done(s::OrderedSet, state) = done(s.dict, state)
+# NOTE: manually optimized to take advantage of Dict representation
+next(s::OrderedSet, i)     = (s.dict.keys[s.dict.order[i]], skip_deleted(s.dict,i+1))
+
+# TODO: simplify me?
+pop!(s::OrderedSet) = (val = s.dict.keys[start(s.dict)]; delete!(s.dict, val); val)
+
+union(s::OrderedSet) = copy(s)
+function union(s::OrderedSet, sets...)
+    u = OrderedSet{Base.join_eltype(s, sets...)}()
+    union!(u,s)
+    for t in sets
+        union!(u,t)
+    end
+    return u
+end
+
+intersect(s::OrderedSet) = copy(s)
+function intersect(s::OrderedSet, sets...)
+    i = copy(s)
+    for x in s
+        for t in sets
+            if !in(x,t)
+                delete!(i,x)
+                break
+            end
+        end
+    end
+    return i
+end
+
+function setdiff(a::OrderedSet, b)
+    d = similar(a)
+    for x in a
+        if !(x in b)
+            push!(d, x)
+        end
+    end
+    d
+end
+
+isequal(l::OrderedSet, r::OrderedSet) = (length(l) == length(r)) && (l <= r)
+<(l::OrderedSet, r::OrderedSet) = (length(l) < length(r)) && (l <= r)
+<=(l::OrderedSet, r::OrderedSet) = issubset(l, r)
+
+function filter!(f::Function, s::OrderedSet)
+    for x in s
+        if !f(x)
+            delete!(s, x)
+        end
+    end
+    return s
+end
+filter(f::Function, s::OrderedSet) = filter!(f, copy(s))
+
+hash(s::OrderedSet) = (_compact_order(s.dict); hash(s.dict.keys[s.dict.order]))

--- a/test/test_defaultdict.jl
+++ b/test/test_defaultdict.jl
@@ -1,6 +1,10 @@
 using DataStructures
 using Base.Test
 
+##############
+# DefaultDicts
+##############
+
 # construction
 @test_throws DefaultDict()
 @test_throws DefaultDict(String, Int)
@@ -42,10 +46,56 @@ end
 @test sort(collect(values(d))) == [1:26]
 
 # Starting from an existing dictionary
+# Note: dictionary is copied upon construction
 e = ['a'=>1, 'b'=>3, 'c'=>5]
 f = DefaultDict(0, e)
-@test_throws e['d']
 @test f['d'] == 0
-f['e'] = 9
-@test e['d'] == 0
+@test_throws e['d']
+e['e'] = 9
 @test e['e'] == 9
+@test f['e'] == 0
+
+
+#####################
+# DefaultOrderedDicts
+#####################
+
+# construction
+@test_throws DefaultOrderedDict()
+@test_throws DefaultOrderedDict(String, Int)
+
+# empty dictionary
+d = DefaultOrderedDict(Char, Int, 1)
+@test length(d) == 0
+@test isempty(d)
+@test d['c'] == 1
+@test !isempty(d)
+empty!(d)
+@test isempty(d)
+
+# access, modification
+@test (d['a'] += 1) == 2
+@test 'a' in keys(d)
+@test haskey(d, 'a')
+@test get(d, 'b', 0) == 0
+@test !('b' in keys(d))
+@test !haskey(d, 'b')
+@test pop!(d, 'a') == 2
+@test isempty(d)
+
+for c in 'a':'z'
+    d[c] = c-'a'+1
+end
+
+@test d['z'] == 26
+@test d['@'] == 1
+@test length(d) == 27
+delete!(d, '@')
+@test length(d) == 26
+
+for (k,v) in d
+    @test v == k-'a'+1
+end
+
+@test collect(keys(d)) == ['a':'z']
+@test collect(values(d)) == [1:26]

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -1,0 +1,37 @@
+using DataStructures
+using Base.Test
+
+# construction
+
+@test typeof(OrderedDict()) == OrderedDict{Any,Any}
+@test typeof(OrderedDict('a',1)) == OrderedDict{Char,Int}
+@test typeof(OrderedDict([("a",1),("b",2)])) == OrderedDict{ASCIIString,Int}
+
+# empty dictionary
+d = OrderedDict(Char, Int)
+@test length(d) == 0
+@test isempty(d)
+@test_throws d['c'] == 1
+d['c'] = 1
+@test !isempty(d)
+empty!(d)
+@test isempty(d)
+
+# access, modification
+
+for c in 'a':'z'
+    d[c] = c-'a'+1
+end
+
+@test (d['a'] += 1) == 2
+@test 'a' in keys(d)
+@test haskey(d, 'a')
+@test get(d, 'B', 0) == 0
+@test !('B' in keys(d))
+@test !haskey(d, 'B')
+@test pop!(d, 'a') == 2
+
+@test collect(keys(d)) == ['b':'z']
+@test collect(values(d)) == [2:26]
+@test collect(d) == [(a,i) for (a,i) in zip('b':'z', 2:26)]
+

--- a/test/test_orderedset.jl
+++ b/test/test_orderedset.jl
@@ -1,0 +1,31 @@
+using DataStructures
+using Base.Test
+
+# construction
+
+@test typeof(OrderedSet()) == OrderedSet{Any}
+@test typeof(OrderedSet('a')) == OrderedSet{Char}
+@test typeof(OrderedSet(1,2,3,4)) == OrderedSet{Int}
+
+# empty set
+d = OrderedSet{Char}()
+@test length(d) == 0
+@test isempty(d)
+@test !('c' in d)
+push!(d, 'c')
+@test !isempty(d)
+empty!(d)
+@test isempty(d)
+
+# access, modification
+
+for c in 'a':'z'
+    push!(d, c)
+end
+
+for c in 'a':'z'
+    @test c in d
+end
+
+@test collect(d) == ['a':'z']
+


### PR DESCRIPTION
- `OrderedDict` (new)
- `OrderedSet` (new)
- `DefaultDict` (updated)
- `DefaultOrderedDict` (new)

The basic structure is there, but not yet any tests or documentation.  Bugs are likely still lurking...

cc: @toivoh

**Edit** Here's an account of the evolution of `OrderedDicts`:

I've tried various approaches to implement ordered dicts, and this was pretty much the only one with reasonable performance (about 10% slower than `Dicts`).

Background: In `Dicts`, for efficiency, keys and values are stored in separate arrays, as:

``` julia
type Dict{K,V} <: Associative{K,V}
    slots::Array{Uint8,1}
    keys::Array{K,1}
    vals::Array{V,1}
...
```

An easy way to implement `OrderedDicts` is to use a type or tuple for `vals` which contains ordering information (generally, a doubly linked list).  Unfortunately, this kills performance, because `vals` is (generally) no longer contiguous.  (Note that I originally did this long before @loladiro's tuple updates).

So, the most performant method is to include ordering information as part of the `Dict` type.  `HashDict` implements this. It is parametrized as `Ordered` or `Unordered`, which are aliases for `Int` and `Nothing`, respectively.

`Nothing` arrays take up little or no space, so other than two additional variables in the `Dict` type, there is no memory difference and no performance difference between `HashDict{K,V,Unordered}` and`Base.Dict{K,V}`.  (The idea for `Nothing` came from Base.Set.)  Ideally, I'd like to see `Base.Dict` implemented based on `HashDict`.

In https://github.com/JuliaLang/julia/pull/4038, I did this:

``` julia
type Dict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
```

Unfortunately, it had its own issues
   a. Constructing plain `Dicts` using constructor notation always required the `Unordered` type parameter.
   b. `(Type1=>Type2)[]` produced `Dict{Type1,Type2,Unordered}`, which required a bit of mucking around in the parser to get things working.  It was kinda fun, but it takes a bit of work.
   c. `OrderedDict` could be a typealias or constructor, but not both (see https://github.com/JuliaLang/julia/issues/3427)

Given all of this, I chose to make the `HashDict` type, and implement `OrderedDicts` a thin wrapper around it (for aesthetics), and hope that at some point, `HashDict` will become the base for both `Dict` and `OrderedDict`.
# 

One other consideration for the `OrderedDict`/`HashDict` implementation (for the future)
- The current implementation of `HashDict` uses two additional arrays to maintain ordering information:
  -  `order` is an ordering of indices in the `keys`/`vals` array
  - `idxs` is the same size as `keys` and `vals`, and points back into the `order` array, for easy updating
    This could allow direct access to the `nth` key-value pair (which was the original inspiration).  

Instead, these could be implemented as `prev` and `next` in a doubly linked list, which might actually allow some simplification.  (Should probably try this.)
