### PR TITLE
Add make_set! to add a new set with a single element for IntDisjointSets and DisjointSets

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -16,7 +16,7 @@ module DataStructures
     export classified_lists, classified_sets, classified_counters
     
     export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set
-    export make_set!
+    export add_singleton!
 
     export AbstractHeap, compare, extract_all!
     export BinaryHeap, binary_minheap, binary_maxheap

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -63,7 +63,7 @@ end
 
 # make a new subset with a given new element x
 #
-function make_set!(s::IntDisjointSets, x::Integer)
+function add_singleton!(s::IntDisjointSets, x::Integer)
     push!(s.parents, x)
     push!(s.ranks, 0)
     s.ngroups += 1
@@ -72,9 +72,9 @@ end
 # make a new subset with an automatically chosen new element x
 # returns the new element
 #
-function make_set!(s::IntDisjointSets)
+function add_singleton!(s::IntDisjointSets)
     x = length(s) + 1
-    make_set!(s, x)
+    add_singleton!(s, x)
     return x
 end
 
@@ -115,8 +115,8 @@ function union!{T}(s::DisjointSets{T}, x::T, y::T)
     union!(s.internal, s.intmap[x], s.intmap[y])
 end
 
-function make_set!{T}(s::DisjointSets{T}, x::T)
-    id = make_set!(s.internal)
+function add_singleton!{T}(s::DisjointSets{T}, x::T)
+    id = add_singleton!(s.internal)
     s.intmap[x] = id
 end
 

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -38,7 +38,7 @@ r = [find_root(s, i) for i in 1 : 10]
 @test isa(r, Vector{Int})
 @test isequal(r, r0)
 
-make_set!(s, 17)
+add_singleton!(s, 17)
 
 @test length(s) == 11
 @test num_groups(s) == 3


### PR DESCRIPTION
Adds `make_set!` to add a new set with a single element for `DisjointSets`. Three versions are available:
- add an automatically-generated element for `IntDisjointSets`
- add a specified element for `IntDisjointSets` and `DisjointSets`
