### PR TITLE
Change `add_singleton!` (was `make_set!`) in `disjoint_set.jl` to `push!` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Usage:
 a = IntDisjointSet(10)      # creates a forest comprised of 10 singletons
 union!(a, 3, 5)             # merges the sets that contain 3 and 5 into one
 in_same_set(a, x, y)        # determines whether x and y are in the same set
-elem = add_singleton!(a)    # adds a new set with a single element, returns that new element 
+elem = push!(a)             # adds a single element in a new set; returns the new element 
+                            # (this operation is often called MakeSet)
 ```
 
 One may also use other element types
@@ -120,7 +121,7 @@ One may also use other element types
 a = DisjointSet{String}(["a", "b", "c", "d"])
 union!(a, "a", "b")
 in_same_set(a, "c", "d")
-add_singleton!(a, "f")
+push!(a, "f")
 ```
 
 Note that the internal implementation of ``IntDisjointSet`` is based on vectors, and is very efficient. ``DisjointSet{T}`` is a wrapper of ``IntDisjointSet``, which uses a dictionary to map input elements to an internal index. 

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -16,7 +16,7 @@ module DataStructures
     export classified_lists, classified_sets, classified_counters
     
     export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set
-    export add_singleton!
+    export push!
 
     export AbstractHeap, compare, extract_all!
     export BinaryHeap, binary_minheap, binary_maxheap

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -63,7 +63,7 @@ end
 
 # make a new subset with a given new element x
 #
-function add_singleton!(s::IntDisjointSets, x::Integer)
+function push!(s::IntDisjointSets, x::Integer)
     push!(s.parents, x)
     push!(s.ranks, 0)
     s.ngroups += 1
@@ -72,9 +72,9 @@ end
 # make a new subset with an automatically chosen new element x
 # returns the new element
 #
-function add_singleton!(s::IntDisjointSets)
+function push!(s::IntDisjointSets)
     x = length(s) + 1
-    add_singleton!(s, x)
+    push!(s, x)
     return x
 end
 
@@ -115,8 +115,8 @@ function union!{T}(s::DisjointSets{T}, x::T, y::T)
     union!(s.internal, s.intmap[x], s.intmap[y])
 end
 
-function add_singleton!{T}(s::DisjointSets{T}, x::T)
-    id = add_singleton!(s.internal)
+function push!{T}(s::DisjointSets{T}, x::T)
+    id = push!(s.internal)
     s.intmap[x] = id
 end
 

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -38,7 +38,7 @@ r = [find_root(s, i) for i in 1 : 10]
 @test isa(r, Vector{Int})
 @test isequal(r, r0)
 
-add_singleton!(s, 17)
+push!(s, 17)
 
 @test length(s) == 11
 @test num_groups(s) == 3


### PR DESCRIPTION
Changes the name `add_singleton!` to `push!` in `disjoint_set.jl` for consistency with other data structures, following the suggestion of @kmsquire in #22. Incorporates the change in README.md from #22.
