### PR TITLE
Fix warnings in tests

### DIFF
--- a/test/test_defaultdict.jl
+++ b/test/test_defaultdict.jl
@@ -6,8 +6,8 @@ using Base.Test
 ##############
 
 # construction
-@test_throws DefaultDict()
-@test_throws DefaultDict(String, Int)
+@test_throws ErrorException DefaultDict()
+@test_throws ErrorException DefaultDict(String, Int)
 
 # empty dictionary
 d = DefaultDict(Char, Int, 1)
@@ -50,7 +50,7 @@ end
 e = ['a'=>1, 'b'=>3, 'c'=>5]
 f = DefaultDict(0, e)
 @test f['d'] == 0
-@test_throws e['d']
+@test_throws KeyError e['d']
 e['e'] = 9
 @test e['e'] == 9
 @test f['e'] == 0
@@ -61,8 +61,8 @@ e['e'] = 9
 #####################
 
 # construction
-@test_throws DefaultOrderedDict()
-@test_throws DefaultOrderedDict(String, Int)
+@test_throws ErrorException DefaultOrderedDict()
+@test_throws ErrorException DefaultOrderedDict(String, Int)
 
 # empty dictionary
 d = DefaultOrderedDict(Char, Int, 1)

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -8,16 +8,16 @@ q = Deque{Int}()
 @test length(q) == 0
 @test isempty(q)
 @test q.blksize == DataStructures.DEFAULT_DEQUEUE_BLOCKSIZE
-@test_throws front(q)
-@test_throws back(q)
+@test_throws ArgumentError front(q)
+@test_throws ArgumentError back(q)
 
 q = Deque{Int}(3)
 @test length(q) == 0
 @test isempty(q)
 @test q.blksize == 3
 @test num_blocks(q) == 1
-@test_throws front(q)
-@test_throws back(q)
+@test_throws ArgumentError front(q)
+@test_throws ArgumentError back(q)
 @test isa(collect(q), Vector{Int})
 @test collect(q) == Int[]
 
@@ -52,8 +52,8 @@ for i = 1 : n
         @test front(q) == 1
         @test back(q) == n - i
     else
-        @test_throws front(q)
-        @test_throws back(q)
+        @test_throws ArgumentError front(q)
+        @test_throws ArgumentError back(q)
     end
 
     cq = collect(q)
@@ -91,8 +91,8 @@ for i = 1 : n
         @test front(q) == n - i
         @test back(q) == 1
     else
-        @test_throws front(q)
-        @test_throws back(q)
+        @test_throws ArgumentError front(q)
+        @test_throws ArgumentError back(q)
     end
 
     cq = collect(q)

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -11,7 +11,7 @@ using Base.Test
 d = OrderedDict(Char, Int)
 @test length(d) == 0
 @test isempty(d)
-@test_throws d['c'] == 1
+@test_throws KeyError d['c'] == 1
 d['c'] = 1
 @test !isempty(d)
 empty!(d)

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -10,8 +10,8 @@ n = 100
 
 @test length(s) == 0
 @test isempty(s)
-@test_throws top(s)
-@test_throws pop!(s)
+@test_throws ArgumentError top(s)
+@test_throws ArgumentError pop!(s)
 
 for i = 1 : n
     push!(s, i)
@@ -26,7 +26,7 @@ for i = 1 : n
     if i < n
         @test top(s) == n - i
     else
-        @test_throws top(s)
+        @test_throws ArgumentError top(s)
     end
     @test isempty(s) == (i == n)
     @test length(s) == n - i
@@ -39,9 +39,9 @@ n = 100
 
 @test length(s) == 0
 @test isempty(s)
-@test_throws front(s)
-@test_throws back(s)
-@test_throws dequeue!(s)
+@test_throws ArgumentError front(s)
+@test_throws ArgumentError back(s)
+@test_throws ArgumentError dequeue!(s)
 
 for i = 1 : n
     enqueue!(s, i)
@@ -58,8 +58,8 @@ for i = 1 : n
         @test front(s) == i + 1
         @test back(s) == n
     else
-        @test_throws front(s)
-        @test_throws back(s)
+        @test_throws ArgumentError front(s)
+        @test_throws ArgumentError back(s)
     end
     @test isempty(s) == (i == n)
     @test length(s) == n - i


### PR DESCRIPTION
Calling test_throws without specifying a single exception type is now deprecated (see https://github.com/JuliaLang/julia/pull/6475).
