### PR TITLE
Optimize DisjointSets

### DIFF
--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -13,17 +13,19 @@
 #
 ############################################################
 
-type IntDisjointSets
+type IntWrapper val::Int end
+
+immutable IntDisjointSets
     parents::Vector{Int}
     ranks::Vector{Int}
-    ngroups::Int
+    ngroups::IntWrapper
 
     # creates a disjoint set comprised of n singletons
-    IntDisjointSets(n::Integer) = new([1:n], zeros(Int, n), n)
+    IntDisjointSets(n::Integer) = new([1:n], zeros(Int, n), IntWrapper(n))
 end
 
 length(s::IntDisjointSets) = length(s.parents)
-num_groups(s::IntDisjointSets) = s.ngroups
+num_groups(s::IntDisjointSets) = s.ngroups.val
 
 
 # find the root element of the subset that contains x
@@ -57,7 +59,7 @@ function union!(s::IntDisjointSets, x::Integer, y::Integer)
                 s.ranks[xroot] += 1
             end
         end
-        s.ngroups -= 1
+        @inbounds s.ngroups.val -= 1
     end
 end
 
@@ -66,7 +68,7 @@ end
 function push!(s::IntDisjointSets, x::Integer)
     push!(s.parents, x)
     push!(s.ranks, 0)
-    s.ngroups += 1
+    @inbounds s.ngroups.val += 1
 end
 
 # make a new subset with an automatically chosen new element x
@@ -88,7 +90,7 @@ end
 #
 ############################################################
 
-type DisjointSets{T}
+immutable DisjointSets{T}
     intmap::Dict{T,Int}
     internal::IntDisjointSets
 


### PR DESCRIPTION
The disjoint-set data structure seemed a bit slow, over 3x the speed of a C++ reference:

```
~/disjoint > ./disjoint
0.061481
~/disjoint > ./disjoint
0.061004
~/disjoint > ./disjoint
0.061247
```

```
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                       master=
elapsed time: 0.193454033 seconds (16006792 bytes allocated)
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                       master=
elapsed time: 0.192407743 seconds (16006856 bytes allocated)
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                       master=
elapsed time: 0.195339228 seconds (16006824 bytes allocated)
```

Making the type immutable results in an almost 2x speed increase, as well as eliminating essentially all of the memory allocation. This is within 1.7x C++ speed.

```
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                     disjoint=
elapsed time: 0.103117607 seconds (6888 bytes allocated)
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                     disjoint=
elapsed time: 0.109216987 seconds (6888 bytes allocated)
~/.julia/v0.3/DataStructures/test > julia bench_disjoint_set.jl                     disjoint=
elapsed time: 0.103264055 seconds (6888 bytes allocated)
```
