### PR TITLE
[RFC] Fixes #38, error in `empty!` for Deque.

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -180,7 +180,8 @@ function empty!{T}(q::Deque{T})
     # reset queue fields
     q.nblocks = 1
     q.len = 0
-    q.rear = h
+    q.rear = q.head
+    q
 end
 
 

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -137,4 +137,11 @@ for k = 1 : m
     @test collect(q) == r
 end
 
+# issue #38
+
+q = Deque{Int}(1)
+push!(q,1)
+@test !isempty(q)
+empty!(q)
+@test isempty(q)
 


### PR DESCRIPTION
I've followed what I believe is the behaviour of `empty!` for vectors by returning the empty container. Have also added a simple test. @kmsquire is this sufficient?
