### PR TITLE
Update Dict construction to use new syntax

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -6,7 +6,7 @@ end
 
 ## constructors
 
-Accumulator{T,V<:Number}(::Type{T}, ::Type{V}) = Accumulator{T,V}((T=>V)[])
+Accumulator{T,V<:Number}(::Type{T}, ::Type{V}) = Accumulator{T,V}(Dict{T,V}())
 counter(T::Type) = Accumulator(T,Int)
 
 Accumulator{T,V<:Number}(dct::Dict{T,V}) = Accumulator{T,V}(copy(dct))

--- a/src/classifiedcollections.jl
+++ b/src/classifiedcollections.jl
@@ -10,7 +10,7 @@ end
 
 ## constructors
 
-ClassifiedCollections(K::Type, C::Type) = ClassifiedCollections{K, C}((K=>C)[])
+ClassifiedCollections(K::Type, C::Type) = ClassifiedCollections{K, C}(Dict{K,C}())
 
 classified_lists(K::Type, V::Type) = ClassifiedCollections(K, Vector{V})
 classified_sets(K::Type, V::Type) = ClassifiedCollections(K, Set{V})

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -5,7 +5,7 @@ type Trie{T}
 
     function Trie()
         self = new()
-        self.children = (Char=>Trie{T})[]
+        self.children = Dict{Char,Trie{T}}()
         self.is_key = false
         self
     end

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -42,7 +42,7 @@ push!(ct, ct2)
 @test ct["b"] == 7
 @test ct["c"] == 2
 
-ct3 = counter((ASCIIString=>Int)["a"=>10, "b"=>20])
+ct3 = counter(Dict([("a",10), ("b",20)]))
 @test isa(ct3, Accumulator{ASCIIString,Int})
 @test haskey(ct3, "a")
 @test haskey(ct3, "b")

--- a/test/test_defaultdict.jl
+++ b/test/test_defaultdict.jl
@@ -47,7 +47,7 @@ end
 
 # Starting from an existing dictionary
 # Note: dictionary is copied upon construction
-e = ['a'=>1, 'b'=>3, 'c'=>5]
+e = Dict([('a',1), ('b',3), ('c',5)])
 f = DefaultDict(0, e)
 @test f['d'] == 0
 @test_throws KeyError e['d']


### PR DESCRIPTION
Julia 0.4 changes the syntax for constructing Dicts; this commit
updates the package to use the new syntax.
