### PR TITLE
Update hashdict.jl

### DIFF
--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -201,10 +201,10 @@ function _compact_order{K,V}(h::HashDict{K,V,Ordered})
     end
 
     i = 1
-    while h.order[i] > 0;  i += 1; end
+    while i < length(h.order) && h.order[i] > 0;  i += 1; end
 
     j = i+1
-    while h.order[j] == 0; j += 1; end
+    while j < length(h.order) && h.order[j] == 0; j += 1; end
 
     for k = j:length(h.order)
         idx = h.order[k]


### PR DESCRIPTION
Without this change, the following code example fails.  Not sure how to add a test:

using DataStructures

od = OrderedDict{Int,Int}()
od[1] = 2

ranges = [2:5,6:9,10:13]
for range in ranges
    for i = range
        od[i] = i+1
    end

```
for i = range
    delete!( od, i )
end
```

end
od[14]=15
