### PR TITLE
Indexer structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package implements a variety of data structures, including
 * Stack
 * Queue
 * Accumulators and Counters
+* Indexer
 * Disjoint Sets
 * Binary Heap
 * Mutable Binary Heap
@@ -104,7 +105,28 @@ pop!(a, x)       # remove a key x from a, and returns its current value
 merge(a, a2)     # return a new accumulator/counter that combines the
                  # values/counts in both a and a2
 ```
+## Indexer
 
+An `Indexer` is a simple tool to construct arrays that correspond to non-integer objects. For example, suppose we wanted to construct a permutation matrix mapping "foo" -> "bar", "bar" -> "baz", "baz" -> "foo". The `Indexer` is used simply to track the correspondence "foo" -> 1, "bar" -> 2, etc.
+
+```julia
+idx = Indexer()
+m = zeros(Float64,(3,3))
+m[get_index(idx, "foo"), get_index(idx, "bar")] = 1
+m[get_index(idx, "bar"), get_index(idx, "baz")] = 1
+m[get_index(idx, "baz"), get_index(idx, "foo")] = 1
+```
+
+After this, `m` is:
+
+```
+3x3 Array{Float64,2}:
+ 0.0  1.0  0.0
+ 0.0  0.0  1.0
+ 1.0  0.0  0.0
+```
+
+An indexer can be created with a non-zero index if desired (e.g. `Indexer(3)` will start at 3), and can be prepopulated with a collection (e.g. `Indexer(["foo", "bar", "baz"])`).
 
 ## Disjoint Sets
 

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -13,6 +13,7 @@ module DataStructures
     export capacity, num_blocks, front, back, top, sizehint
 
     export Accumulator, counter
+    export Indexer, get_index, reverse_index
     export ClassifiedCollections
     export classified_lists, classified_sets, classified_counters
 
@@ -36,6 +37,7 @@ module DataStructures
     include("stack.jl")
     include("queue.jl")
     include("accumulator.jl")
+    include("indexer.jl")
     include("classifiedcollections.jl")
     include("disjoint_set.jl")
     include("heaps.jl")

--- a/src/indexer.jl
+++ b/src/indexer.jl
@@ -1,0 +1,35 @@
+# A counter type
+
+type Indexer
+    fmap::Dict{Any, Int32}
+    rmap::Dict{Int32, Any}
+    inc::Int32
+end
+
+## constructors
+
+Indexer() = Indexer(Dict(), Dict(), 1)
+Indexer(start::Int32) = Indexer(Dict(), Dict(), start)
+function Indexer(collection)
+    idx = Indexer()
+    for x in collection
+        get_index(idx, x)
+    end
+    return idx
+end
+
+## Usage
+
+function get_index(idx::Indexer, t::Any)
+    if haskey(idx.fmap, t)
+        return get(idx.fmap, t, null)
+    else
+        result = idx.inc
+        idx.fmap[t] = idx.inc
+        idx.rmap[idx.inc] = t
+        idx.inc = idx.inc + 1
+        return result
+    end
+end
+
+reverse_index(idx::Indexer, i::Int32) = idx.rmap[i]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
-tests = ["deque", 
-		 "stack_and_queue", 
+tests = ["deque",
+		 "stack_and_queue",
 		 "accumulator",
+                 "indexer",
 		 "classifiedcollections",
-		 "disjoint_set", 
-		 "binheap", 
+		 "disjoint_set",
+		 "binheap",
 		 "mutable_binheap",
 		 "defaultdict",
 		 "ordereddict",
@@ -16,4 +17,3 @@ for t in tests
 	println("$fp ...")
 	include(fp)
 end
-

--- a/test/test_indexer.jl
+++ b/test/test_indexer.jl
@@ -1,0 +1,13 @@
+# Test of indexer
+
+using DataStructures
+using Base.Test
+
+idx = Indexer()
+@assert isa(idx, Indexer)
+
+@test get_index(idx, "foo") == 1
+@test get_index(idx, "bar") == 2
+@test get_index(idx, "foo") == 1
+
+@test reverse_index(idx, convert(Int32,2)) == "bar"


### PR DESCRIPTION
An `Indexer` is a simple tool to construct arrays that correspond to non-integer objects. For example, suppose we wanted to construct a permutation matrix mapping "foo" -> "bar", "bar" -> "baz", "baz" -> "foo". The `Indexer` is used simply to track the correspondence "foo" -> 1, "bar" -> 2, etc.

``` julia
idx = Indexer()
m = zeros(Float64,(3,3))
m[get_index(idx, "foo"), get_index(idx, "bar")] = 1
m[get_index(idx, "bar"), get_index(idx, "baz")] = 1
m[get_index(idx, "baz"), get_index(idx, "foo")] = 1
```

Not exactly difficult to build, but I find myself using it so often that I imagine others can find uses for it as well.
