### PR TITLE
WIP: Memory packed arrays

### DIFF
--- a/src/memory_packed_array.jl
+++ b/src/memory_packed_array.jl
@@ -278,8 +278,6 @@ function delete!{D}(A::MemoryPackedArray{D},index::Int)
 	local number_of_elements = scan(A,left,right);
 	local leaf_depth = log2(A.number_of_segments);
 	local seg_size = A.segment_size;
-
-	println(seg_size," ",right-left);
 	
 	local k = 0;
 

--- a/src/memory_packed_array.jl
+++ b/src/memory_packed_array.jl
@@ -85,20 +85,17 @@ function scan{D}(A::MemoryPackedArray{D},from::Int,to::Int)
 end
 
 function in_threashold{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elements::Int, k::Int)
-	println("left:", left," right: ", right, " number_of_elemnts:", number_of_elements, " k:", k);
 	local d = log2(A.number_of_segments);
 	local l = d-k;
 	local t = A.t0+((A.td-A.t0)/d)*l;
 	local p = A.p0-((A.p0-A.pd)/d)*l;
 	density = number_of_elements/(right-left);
 	## return	
-	println(p," ",t," ",density)
 	p<=density && density<=t
 end
 
 function ancestor{D}(A::MemoryPackedArray{D},left::Int,right::Int,seg_pos::Int, seg_size::Int)
 	local nr::Int;
-	println("seg_pos: ", seg_pos)
 	if (seg_pos & 1)==1 ## we are in left child;
 		nr = scan(A,right,right+seg_size+1);
 		right = right+seg_size;
@@ -127,14 +124,10 @@ function rebalance{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_ele
 		end
 		if i==index
 			k = j-1;
-			## k - the j where the elemnt should go. 
 		end
 		A.exists[i] = false;
 		i = i+1;
 	end
-
-	println(A.exists);
-	println(A.store);
 
 	i = right-1
 	
@@ -164,9 +157,6 @@ function rebalance{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_ele
 			i = ceil(Int,i-gap);
 		end
 	end
-	println(A.store);
-	println(A.exists);
-	
 	nothing
 end
 
@@ -178,7 +168,6 @@ function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
 
 	local left =  index - index%(A.segment_size)+1;
 	local right = left+A.segment_size;
-
 
 
 ##	scan couting the elemnts;
@@ -201,11 +190,7 @@ function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
 	end
 
 ##	rebalance with inserting the element. 
-	println("GERE")
-	println(A, left, right, number_of_elements, index, element);
-	rebalance(A,left,right,number_of_elements,index,element);
-	println(A);
-		
+	
 	nothing 	
 end
 

--- a/src/memory_packed_array.jl
+++ b/src/memory_packed_array.jl
@@ -234,10 +234,9 @@ function rebalance!{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_el
 	
 	
 	if j==right-1 
-##	No elements in this segemnt, place at index
+##	No elements in this segment, place at index
 		A.store[index] = element;
 		A.exists[index] = true;
-		println("HERE1");
 	else
 		j = j+1; 
 		while i<right && j<k
@@ -316,10 +315,7 @@ function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
 ##	Right - right border of the segement conatining element at "index", exclusive
 
 
-	local segment_position = ceil(Int,index/A.segment_size);
-
-	segment_position = max(segment_position,1);
-	
+	local segment_position = max(ceil(Int,index/A.segment_size),1);
 	local right = segment_position*A.segment_size+1;
 	local left = right-A.segment_size;
 	local number_of_elements = scan(A,left,right);
@@ -331,7 +327,6 @@ function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
 	if (index<A.size && in_threshold(A,left,right,number_of_elements,k) && A.exists[index+1]==false)
 		A.exists[index+1] = true;
 		A.store[index+1] = element;
-		println("HERE2");
 		return	
 	end
 

--- a/src/memory_packed_array.jl
+++ b/src/memory_packed_array.jl
@@ -1,0 +1,186 @@
+
+
+## --------------------------- WARNING:: WORK IN PROGRESS --------------------------- ##
+
+
+## This file implements memory-packed arrays
+## The array is used to implement cache-oblivious trees
+
+
+## Functions simplifing notation: 
+
+## Function returning the closest power of 2 >= x 
+#@inline hyperceil(x::Float64) = 1 << (ceil(log2(x)));
+## Function returning the closest power of 2 <= x
+#@inline hyperfloor(x::Float64) = 1 << (floor(log2(x))); 
+
+## TODO: make the constructor idiotensicher ??
+
+
+## Note:  
+##	size - is equal c*N where 
+## 		N - number of elemnts stored
+##		c - some desired constant 
+##	segment_size - the size of a segment, this is ceil(lg(size))
+##	number_of_segments - the number of segments 
+##	p0 - density lower threshold for root
+##	t0 - density upper threshold for root
+##	pd - density lower threshold for leaves
+## 	td - density upper threashold for leaves
+##		thresholds should satisfy:
+##		0 < pd < p0 < to < td = 1 
+##
+
+##	exists - flags indicating whether a coresponding 
+##		cell in store is occupied  
+##	store  - the array storing the actual elemnts	
+## TODO: search for alternatives for exists
+
+type MemoryPackedArray{D}
+	size::Int
+	segment_size::Int
+	number_of_segments::Int
+	p0::Float64
+	pd::Float64 
+	t0::Float64
+	td::Float64
+	store::Array{D,1} 
+	exists::Array{Bool,1}
+	function MemoryPackedArray(size::Int, p0::Float64, pd::Float64, t0::Float64, td::Float64)
+			seg_size = ceil(log2(size));
+			no_seg = hyperceil(size/seg_size);
+			sizeP = number_of_segments*segment_size;
+			store = Array(D,sizeP);
+			exists = zeros(sizeP);
+			new(sizeP,seg_size,no_seg,p0,pd,t0,td,store,exists)
+	end
+end
+
+## Function that scans the entire segment,
+##	from - start of the segment (inclusive) 
+##	to - end of the segment (exclusive).
+##	returns: number of elemnts in the segment
+	 
+function scan{D}(A::MemoryPackedArray{D},from::Int,to::Int)
+	local nr = 0;
+	local i = from;
+	local j = to-1;
+	while(i<j)
+		if(A.exists[i])
+			nr = nr+1;
+		end
+		if(A.exists[j])
+			nr = nr+1;
+		end
+		i = i+1;
+		j = j-1;	
+	end
+
+## 	If segemnt_size is odd we haven't checked the element in the middle.
+s
+	if ((A.segment_size & 1) == 1) && (A.exists[i])
+		nr = nr+1;
+	end
+##	return	
+	nr
+end
+
+function in_threashold{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elements::Int, k::Int)
+	local d = log2(A.number_of_segments);
+	local l = d-k;
+	local t = A.t0+((A.td-A.t0)/d)*l;
+	local p = A.p0-((A.p0-A.pd)/d)*l;
+	density = number_of_elemnts/(right-left);
+	## return	
+	p<=density && density<=t
+end
+
+function ancestor{D}(A::MemoryPackedArray{D},left::Int,right::Int,seg_pos::Int, seg_size::Int)
+	local nr::Int;
+	if (seg_pos & 1)==1 ## we are in left child;
+		nr = scan(A,right,right+seg_size+1);
+		right = right+seg_size;
+	else 
+		nr = scan(A,left-seg_size,left);
+		left = left-seg_size;
+	end
+##	return 
+	left,right,nr
+end
+
+
+##	TODO:make this wiser
+function rebalance{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elemnts::Int,index::Int,elemnt::D)
+	local gap = ceil((right-left)/number_of_elemnts);
+	local j = left;
+	local i = left;
+	local k::Int;
+	## move everthing to the left
+	while i<right
+		if A.exists[i]
+			A.store[j] = A.store[i];
+			j = j+1;
+		end
+		if i==index
+			k = j-1;
+		end
+		A.exists[i] = false;
+		i = i+1;
+	end
+	
+	i = right-1
+	while i>=left && j-1>k
+		A.store[i] = A.store[j-1];
+		A.exists[i] = true;
+		j = j-1;
+		i = i-gap;
+	end
+	if i>=left
+		A.store[i] = elemnt;
+		A.exists[i] = true;
+		i = i-gap;
+	end
+
+	while i>=left && j-1>=left
+		A.store[i] = A.store[j-1];
+		A.exists[i] = true;
+		j = j-1;
+		i = i-gap;
+	end
+	
+	nothing
+end
+
+function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
+
+##	left - left border of the segemnt containing elemnt at "index", inclusive
+##		this is the same as div(index/seg_size)*seg_size
+##	right - right border of the segement conatining elemnt at "index", exclusive
+
+	local left =  index - index%(A.segment_size)+1;
+	local right = left+A.segment_size+1;
+
+
+##	scan couting the elemnts;
+	local number_of_elements = scan(A,left,right);
+	local leaf_depth = log2(A.number_of_segments);
+	local seg_size = A.segment_size;
+	local k = 0;
+
+	while !(in_threashold(A,left,right,number_of_elemnts,k)) && k <= leaf_depth 
+		seg_pos = ceil(index/seg_size);
+		left, right, number_of_elemnts = ancestor(A,left,right,seg_pos,seg_size);
+		seg_size << 1;
+		k=k+1;
+	end
+
+	if (k>leaf_depth)
+		##TODO: handle the situation  
+	end
+
+##	rebalnace with inserting the element. 
+	rebalnace(A,left,right,number_of_elements,index,element);
+		
+	nothing 	
+end
+

--- a/src/memory_packed_array.jl
+++ b/src/memory_packed_array.jl
@@ -9,10 +9,10 @@
 @inline hyperfloor(x::Float64) = 1 << (floor(Int,log2(x))); 
 
 ## Note:  
-##	size - is equal to some c*N where 
+##	capacity - is equal to some c*N where 
 ## 		N - number of elements stored
 ##		c - some desired constant 
-##	segment_size - the size of a segment, this is ceil(lg(size))
+##	segment_capacity - the capacity of a segment, this is ceil(lg(capacity))
 ##	number_of_segments - the number of segments 
 ##	p0 - density lower threshold for root
 ##	t0 - density upper threshold for root
@@ -27,8 +27,8 @@
 ##	store  - the array storing the actual elements	
 
 type MemoryPackedArray{D}
-	size::Int
-	segment_size::Int
+	capacity::Int
+	segment_capacity::Int
 	number_of_segments::Int
 	p0::Float64
 	pd::Float64 
@@ -36,13 +36,13 @@ type MemoryPackedArray{D}
 	td::Float64
 	store::Array{D,1} 
 	exists::Array{Bool,1}
-	function MemoryPackedArray(size::Int, pd::Float64, p0::Float64, t0::Float64, td::Float64)
-			seg_size = ceil(Int,log2(size));
-			no_seg = hyperceil(size/seg_size);
-			sizeP = no_seg*seg_size;
-			store = Array(D,sizeP);
-			exists = zeros(sizeP);
-			new(sizeP,seg_size,no_seg,p0,pd,t0,td,store,exists)
+	function MemoryPackedArray(capacity::Int, pd::Float64, p0::Float64, t0::Float64, td::Float64)
+			seg_capacity = ceil(Int,log2(capacity));
+			no_seg = hyperceil(capacity/seg_capacity);
+			capacityP = no_seg*seg_capacity;
+			store = Array(D,capacityP);
+			exists = zeros(capacityP);
+			new(capacityP,seg_capacity,no_seg,p0,pd,t0,td,store,exists)
 	end
 end
 
@@ -52,7 +52,26 @@ end
 ##	returns: number of elements in the segment
 	 
 function scan{D}(A::MemoryPackedArray{D},from::Int,to::Int)
-	sum(A.exists[from:(to-1)]);	
+	nr = 0
+	i = from
+	j = to-1
+	while i<j
+		if(A.exists[i])
+			nr+=1
+		end
+		if(A.exists[j])
+			nr+=1
+		end
+		i+=1
+		j-=1	
+	end
+
+## 	If segemnt_capacity is odd we haven't checked the element in the middle.
+	if ((A.segment_capacity & 1) == 1) && (A.exists[i])
+		nr += 1
+	end
+##	return	
+	nr
 end
 
 ## Checks if a segment is within a threshold
@@ -64,11 +83,11 @@ end
 function in_threshold{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elements::Int, k::Int)
 ##	d - depth of leaf nodes
 ##	l - depth of node correspodning to given segment
-	local d = log2(A.number_of_segments);
-	local l = d-k;
-	local t = A.t0+((A.td-A.t0)/d)*l;
-	local p = A.p0-((A.p0-A.pd)/d)*l;
-	density = number_of_elements/(right-left);	
+	d = log2(A.number_of_segments)
+	l = d-k
+	t = A.t0+((A.td-A.t0)/d)*l
+	p = A.p0-((A.p0-A.pd)/d)*l
+	density = number_of_elements/(right-left)	
 	p<=density && density<=t
 end
 
@@ -79,81 +98,81 @@ end
 ##	seg_pos - the position of a segemnt in current tree level
 ##	returns: the bounds of ancestor segment and newly scaned elements 
 function ancestor{D}(A::MemoryPackedArray{D},left::Int,right::Int,seg_pos::Int)
-	local nr::Int;
-	local seg_size = right-left;
+	local nr::Int
+	seg_capacity = right-left
 	if (seg_pos & 1)==1 ## we are in left child;
-		nr = scan(A,right,right+seg_size);
-		right = right+seg_size;
+		nr = scan(A,right,right+seg_capacity)
+		right+=seg_capacity
 	else 
-		nr = scan(A,left-seg_size,left);
-		left = left-seg_size;
+		nr = scan(A,left-seg_capacity,left)
+		left-=seg_capacity
 	end
 	left,right,nr
 end
 
 ## Extends the array by factor 2
 function extend!{D}(A::MemoryPackedArray{D})
-	local taken=0;
-	local size = A.size*2;
-	local store = Array(D,size);
-	local exists::Array{Bool,1} = zeros(size);
-	for i in 1:A.size
+	taken=0
+	capacity = (A.capacity << 1)
+	store = Array(D,capacity)
+	exists::Array{Bool,1} = zeros(capacity)
+	for i in 1:A.capacity
 		if A.exists[i]
-			taken = taken+1;
-			exists[i] = true;
-			store[i] = A.store[i];
+			taken += 1
+			exists[i] = true
+			store[i] = A.store[i]
 		end
 	end
-	A.number_of_segments = 2*A.number_of_segments;
-	A.size = size;
-	A.store = store;
-	A.exists = exists;
-	rebalance!(A,1,A.size,taken);
+	A.number_of_segments <<= 1 
+	A.capacity = capacity
+	A.store = store
+	A.exists = exists
+	rebalance!(A,1,A.capacity,taken)
 	nothing
 end
 
 
 ## Extends the array by factor 2 and inserts an element
 function extend!{D}(A::MemoryPackedArray{D},index::Int,element::D)
-	local taken=0;
-	local size = A.size*2;
-	local store = Array(D,size);
-	local exists::Array{Bool,1} = zeros(size);
-	for i in 1:A.size
+	taken=0
+	capacity = (A.capacity << 1)
+	store = Array(D,capacity)
+	exists::Array{Bool,1} = zeros(capacity)
+	for i in 1:A.capacity
 		if A.exists[i]
-			taken = taken+1;
-			exists[i] = true;
-			store[i] = A.store[i];
+			taken+=1
+			exists[i] = true
+			store[i] = A.store[i]
 		end
 	end
-	A.number_of_segments = 2*A.number_of_segments;
-	A.size = size;
-	A.store = store;
-	A.exists = exists;
-	rebalance!(A,1,A.size,taken,index,element);
+	A.number_of_segments <<= 1
+	A.capacity = capacity
+	A.store = store
+	A.exists = exists
+	rebalance!(A,1,A.capacity,taken,index,element)
 	nothing
 end
 
 ## Decreases the array by factor 2 
 function decrease!{D}(A::MemoryPackedArray{D})
-	local taken = 0;
-	local size = A.size/2;
-	store = Array(D,size);
-	exists = Array(Bool,size);
-	local j=1;
-	for i in 1:A.size
+	taken = 0
+	capacity = (A.capacity >> 1)
+	store = Array(D,capacity)
+	exists = Array(Bool,capacity)
+	local j=1
+	for i in 1:A.capacity
 		if A.exists[i]
-			taken = taken+1;
-			exists[j] = true;
-			store[j] = A.store[i];
-			j = j+1;
+			taken+=1
+			exists[j] = true
+			store[j] = A.store[i]
+			j+=1 
 		end
 	end
-	A.number_of_segments = 2*A.number_of_segments;
-	A.size = size;
-	A.store = store;
-	A.exists = exists;
-	rebalance!(A,1,A.size,taken);
+	A.number_of_segments >>= 1
+	A.capacity = capacity
+	A.store = store
+	A.exists = exists
+	rebalance!(A,1,A.capacity,taken)
 	nothing
 end
 
@@ -163,40 +182,40 @@ end
 ##	right - left of the segment (exlusive)
 ##	number_of_elements - number of elements in the segment
 function rebalance!{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elements::Int)
-	local gap = (right-left)/(number_of_elements+1);
-	local j = right-1;
-	local i = right-1;
-	local p = 1;
+	gap = (right-left)/(number_of_elements+1)
+	j = right-1
+	i = right-1
+	p = 1
 
 ##	Move everthing to the right
 	while i>=left
 		if A.exists[i]
-			A.store[j] = A.store[i];
-			j = j-1;
+			A.store[j] = A.store[i]
+			j -= 1
 		end
-		A.exists[i] = false;
-		i = i-1;
+		A.exists[i] = false
+		i -= 1
 	end
 
 	
-	i = left+floor(Int,p*gap)-1;
-	p = p+1;
+	i = left+floor(Int,p*gap)-1
+	p += 1
 	
 	
 	if j==right-1
 ## 	No place taken - just insert and move on
-		A.store[index] = element;
-		A.exists[index] = true;
+		A.store[index] = element
+		A.exists[index] = true
 	else
-		j = j+1; 
+		j += 1 
 ##	j = Last taken place
 ##	Move the elements to right positions 
 		while i<right && j<right
-			A.store[i] = A.store[j];
+			A.store[i] = A.store[j]
 			A.exists[i] = true;
-			j = j+1;
-			i = left+floor(Int,p*gap)-1;
-			p = p+1;
+			j += 1
+			i = left+floor(Int,p*gap)-1
+			p += 1
 		end
 		
 	end
@@ -210,56 +229,56 @@ end
 ##	index - the index after which insert the element
 ##	element - the element to be inserted 
 function rebalance!{D}(A::MemoryPackedArray{D},left::Int,right::Int,number_of_elements::Int,index::Int,element::D)
-	local gap = (right-left)/(number_of_elements+1);
-	local j = right-1;
-	local i = right-1;
-	local k = 0;
-	local p = 1;
+	local gap = (right-left)/(number_of_elements+1)
+	local j = right-1
+	local i = right-1
+	local k = 0
+	local p = 1
 	
 	while i>=left
 		if i==index
-			k = j+1;
+			k = j+1
 		end
 		if A.exists[i]
-			A.store[j] = A.store[i];
-			j = j-1;
+			A.store[j] = A.store[i]
+			j -= 1
 		end
-		A.exists[i] = false;
-		i = i-1;
+		A.exists[i] = false
+		i -= 1
 	end
 
-	k = max(1,k);
-	i = left+floor(Int,p*gap)-1;
-	p = p+1;
+	k = max(1,k)
+	i = left+floor(Int,p*gap)-1
+	p += 1
 	
 	
 	if j==right-1 
 ##	No elements in this segment, place at index
-		A.store[index] = element;
-		A.exists[index] = true;
+		A.store[index] = element
+		A.exists[index] = true
 	else
-		j = j+1; 
+		j +=1 
 		while i<right && j<k
-			A.store[i] = A.store[j];
-			A.exists[i] = true;
-			j = j+1;
-			i = left+floor(Int,p*gap)-1;
-			p = p+1;
+			A.store[i] = A.store[j]
+			A.exists[i] = true
+			j += 1
+			i = left+floor(Int,p*gap)-1
+			p += 1
 		end
 		if i<right 
 ## 	Then j==k, so insert the new element here
-			A.store[i] = element;
-			A.exists[i] = true;
-			i = left+floor(Int,p*gap)-1;
-			p = p+1;
+			A.store[i] = element
+			A.exists[i] = true
+			i = left+floor(Int,p*gap)-1
+			p += 1
 		
 		end
 		while i<right && j<right
-			A.store[i] = A.store[j];
-			A.exists[i] = true;
-			j = j+1;
-			i =left+floor(Int,p*gap)-1;
-				p = p+1;
+			A.store[i] = A.store[j]
+			A.exists[i] = true
+			j += 1
+			i =left+floor(Int,p*gap)-1
+				p += 1
 		end
 	end
 	nothing
@@ -270,33 +289,32 @@ end
 ##	index - the position of the element to be deleted
 function delete!{D}(A::MemoryPackedArray{D},index::Int)
 
-	A.exists[index] = false;
+	A.exists[index] = false
 	
-	local segment_position = ceil(Int,index/A.segment_size);
-	local right = segment_position*A.segment_size+1;
-	local left = right-A.segment_size;
-	local number_of_elements = scan(A,left,right);
-	local leaf_depth = log2(A.number_of_segments);
-	local seg_size = A.segment_size;
+	segment_position = ceil(Int,index/A.segment_capacity)
+	right = segment_position*A.segment_capacity+1
+	left = right-A.segment_capacity
+	number_of_elements = scan(A,left,right)
+	leaf_depth = log2(A.number_of_segments)
+	seg_capacity = A.segment_capacity
 	
-	local k = 0;
-
+	k = 0
 	while !(in_threshold(A,left,right,number_of_elements,k)) && k <= leaf_depth 
 		k += 1 
-		if k>leaf_depth break end;
+		if k>leaf_depth break end
 
-		seg_pos = ceil(Int,index/seg_size);
-		left, right, nr = ancestor(A,left,right,seg_pos);
-		number_of_elements = nr+number_of_elements;
-		seg_size = seg_size << 1;
+		seg_pos = ceil(Int,index/seg_capacity)
+		left, right, nr = ancestor(A,left,right,seg_pos)
+		number_of_elements = nr+number_of_elements
+		seg_capacity = seg_capacity << 1
 	end
 
 	if k>leaf_depth
-		extend(A);
+		extend!(A)
 		return  
 	end
 
-	rebalance!(A,left,right,number_of_elements);
+	rebalance!(A,left,right,number_of_elements)
 	nothing
 end	
 
@@ -313,37 +331,36 @@ function insert!{D}(A::MemoryPackedArray{D},index::Int,element::D)
 ##	Right - right border of the segement conatining element at "index", exclusive
 
 
-	local segment_position = max(ceil(Int,index/A.segment_size),1);
-	local right = segment_position*A.segment_size+1;
-	local left = right-A.segment_size;
-	local number_of_elements = scan(A,left,right);
-	local leaf_depth = log2(A.number_of_segments);
-	local seg_size = A.segment_size;
-	local k = 0;
-
-
-	if (index<A.size && in_threshold(A,left,right,number_of_elements,k) && A.exists[index+1]==false)
-		A.exists[index+1] = true;
-		A.store[index+1] = element;
+	segment_position = max(ceil(Int,index/A.segment_capacity),1)
+	right = segment_position*A.segment_capacity+1
+	left = right-A.segment_capacity
+	number_of_elements = scan(A,left,right)
+	leaf_depth = log2(A.number_of_segments)
+	seg_capacity = A.segment_capacity
+	
+	k = 0
+	if (index<A.capacity && in_threshold(A,left,right,number_of_elements,k) && A.exists[index+1]==false)
+		A.exists[index+1] = true
+		A.store[index+1] = element
 		return	
 	end
 
 	while !(in_threshold(A,left,right,number_of_elements,k)) && k <= leaf_depth 
 		k += 1 
-		if k>leaf_depth break end;
-		seg_pos = ceil(Int,index/seg_size);
-		left, right, nr = ancestor(A,left,right,seg_pos);
-		number_of_elements = nr+number_of_elements;
-		seg_size = seg_size << 1;
+		if k>leaf_depth break end
+		seg_pos = max(ceil(Int,index/seg_capacity),1)
+		left, right, nr = ancestor(A,left,right,seg_pos)
+		number_of_elements = nr+number_of_elements
+		seg_capacity = seg_capacity << 1
 	end
 
 	if k>leaf_depth
-		extend!(A,index,element); 
-		return;
+		extend!(A,index,element)
+		return
 	end
 
 ##	Rebalance with inserting the element. 
-	rebalance!(A,left,right,number_of_elements,index,element);
+	rebalance!(A,left,right,number_of_elements,index,element)
 	
 	nothing 	
 end

--- a/src/vEB_binary_tree.jl
+++ b/src/vEB_binary_tree.jl
@@ -61,54 +61,54 @@ function find_rec{K}(vEBTree::vEBBinaryTree{K},n::Int,key::K)
 		end
 end
 
-	function delete!(key::K)
-		delete_p(key)
+	function delete!(vEBTree::vEBBinaryTree{K},key::K)
+		delete_p(vEBTree, key)
 	end
 
-	function insert!(key::K)
-		insert_p(key)
+	function insert!(vEBTree::vEBBinaryTree{K},key::K)
+		insert_p(vEBTree, key)
 	end
 
-	function insert_p(key::K)
-		MPAidx = find(key)
+	function insert_p(vEBTree::vEBBinaryTree{K},key::K)
+		MPAidx = find(vEBTree, key)
 		updates, capacity_changed = this.MPA.insert!(MPAidx,key)
-		perform_update(updates,capacity_changed)
+		perform_update(vEBTree, updates,capacity_changed)
 		this.n_elements+=1
 	end
 
-	function delete_p(key::K)
-		MPAidx = find(key)
+	function delete_p(vEBTree::vEBBinaryTree{K}, key::K)
+		MPAidx = find(vEBTree, key)
 		if MPA.store[MPAidx].value==key:
 			updates, capacity_changed = this.MPA.delete!(MPAidx)
-			perform_update(updates,capacity_changed)
+			perform_update(vEBTree, updates,capacity_changed)
 			this.n_elements-=1
 		end
 	end
 
-	function perform_update(updates::Array{UpdateInfo{K},1},capacity_changed)
+	function perform_update(vEBTree::vEBBinaryTree{K}, updates::Array{UpdateInfo{K},1},capacity_changed)
 		if capacity_changed:
-			build_tree(updates)
+			build_tree(vEBTree, updates)
 			return
 		end
 		parents = []
 		for u in updates:
-				idx = vEB_index(u.n,this.height)
+				idx = vEB_index(vEBTree, u.n,this.height)
 				if store[idx].isblank != u.blank || store[idx].value != u.value:
 					store[idx].isblank = u.blank
 					store[idx].value = u.value
 					parents.append!(div(u.n,2))
 				end
 		end
-		update_path(parents)
+		update_path(vEBTree, parents)
 	end
 
 
-	function update_path(updates::Array{Int,1})
+	function update_path(vEBTree::vEBBinaryTree{K}, updates::Array{Int,1})
 		parent_update = []
 		for u in updates:
-			idx = vEB_index(u,this.height)
-			left_child = vEB_index(u*2.this.height)
-			right_child = vEB_index(u*2+1,this.height)
+			idx = vEB_index(vEBTree,u,this.height)
+			left_child = vEB_index(vEBTree, u*2.this.height)
+			right_child = vEB_index(vEBTree, u*2+1,this.height)
 
 			node = store[idx]
 
@@ -137,27 +137,27 @@ end
 
 		end
 		if size(parent_update)>0:
-			update_path(parent_update)
+			update_path(vEBTree, parent_update)
 		end
 	end
 
-	function build_tree{K}(updates):
+	function build_tree{K}(vEBTree::vEBBinaryTree{K}, updates):
 			this.height = ceil(Int.log2(this.MPA.capacity))
 			this.tree_size = 1<<(height+1)
 			new_store = Array(vEBEntry{K},this.tree_size)
 			parents = []
 			for u in updates:
-					idx = vEB_index(u.n,this.height)
+					idx = vEB_index(vEBTree, u.n,this.height)
 					new_store[idx].isblank = u.blank
 					new_store[idx].value = u.value
 					parents.append!(div(u.n,2))
 			end
 			this.store = new_store
-			update_path(parents)
+			update_path(vEBTree, parents)
 	end
 
 
-	function vEB_index(n::Int, height::Int)
+	function vEB_index(vEBTree::vEBBinaryTree{K}, n::Int, height::Int)
 		if height<3
 			return n
 		end
@@ -168,8 +168,7 @@ end
 		top_h = h - bottom_h
 
 		if depth<top_h:
-			cal_new_depth
-			return vEB_index(n,cal_new_depth,top_h)
+			return vEB_index(vEBTree,n,top_h)
 		end
 
 		sub_d = depth - top_h
@@ -184,6 +183,6 @@ end
 
 		x = top_size+(sub_root & (num_sub-1))*sub_size
 
-		return x + vEB_index(n,bottom_h)
+		return x + vEB_index(vEBTree,n,bottom_h)
 	end
 end

--- a/src/vEB_binary_tree.jl
+++ b/src/vEB_binary_tree.jl
@@ -1,0 +1,165 @@
+@inline hyperceil(x::Float64) = 1 << (ceil(Int,log2(x)));
+@inline hyperfloor(x::Float64) = 1 << (floor(Int,log2(x)));
+
+
+type vEBEntry{K}
+	value::K
+	isblank::boolean
+	isleaf::boolean
+	MPAidx::Int
+	function vEBEntry(value::K)
+		this.value = value
+		this.isblank = false
+		this.isleaf = false
+	end
+	function vEBEntry()
+		this.isblank = true
+		this.isleaf = false
+	end
+	function vEBEntry(value::K,MPAidx::Int)
+		this.value = value
+		this.isblank = false
+		this.isleaf = true
+		this.MPAidx = MPAidx
+	end
+end
+
+type UpdateInfo{K}
+	value::K
+	isblank::boolean
+	n::Int
+end
+
+type vEBBinaryTree{K}
+	store::Array{vEBEntry{K},1}
+	tree_size::Int
+	n_elements::Int
+	MPA::MemoryPackedArray{K}
+	function vEBBinaryTree(tree_size::Int)
+		this.tree_size = tree_size
+		n_elements = 0
+		this.MPA = MemoryPackedArray{K}(tree_size,0.0,0.1,0.5,0.9)
+	end
+	function isEmpty()
+		return n_elemnts==0
+	end
+
+	function find(key::K)
+		root = 1
+		find_rec(root,key)
+	end
+
+	function find_rec(n::Int,key::K)
+		idx = vEB_index(n)
+		if store[idx].isleaf
+			return store[idx].MPAidx
+		elseif store[idx].isblank || store[idx].value<=key
+			return find_rec((2*n),key)
+		else
+			return find_rec((2*n)+1,key)
+		end
+	end
+
+	function delete!(key::K)
+		delete_p(key)
+	end
+
+	function insert!(key::K)
+		insert_p(key)
+	end
+
+	function insert_p(key::K)
+		MPAidx = find(key)
+		updates = this.MPA.insert!(MPAidx,key)
+		perform_update(updates)
+	end
+
+	function delete_p(key::K)
+		MPAidx, found = find(key)
+		if found:
+			updates = this.MPA.delete!(MPAidx)
+			update_leafs(updates)
+		end
+	end
+
+
+	function perform_update(updates::Array{UpdateInfo{K},1})
+		parents = []
+		for u in updates:
+				idx = vEB_index(u.n)
+				if store[idx].isblank != u.blank || store[idx].value != u.value:
+					store[idx].isblank = u.blank
+					store[idx].value = u.value
+					parents.append!(u/2)
+				end
+		end
+		update_path(parents)
+	end
+
+
+	function update_path(updates::Array{Int,1})
+		parent_update = []
+		for u in updates:
+			idx = vEB_index(u)
+			left_child = vEB_index(u*2)
+			right_child = vEB_index(u*2+1)
+
+			node = store[idx]
+
+			old_blank = node.isblank
+			old_vaule::K
+			if !node.isblank:
+				old_value = node.value
+			end
+
+			if left_child.isblank && right_child.isblank:
+				node.isblank = true
+			elseif left_child.isblank:
+				node.value = right_child.value
+				node.isblank = false
+			elseif right_child.isblank:
+				node.value = left_child.value
+				node.isblank = false
+			else
+				node.value = max(left_child.value,right_child.value)
+				node.isblank = false
+			end
+
+			if old_blank != node.isblank || old_value != node.value
+				parent_update.append!(u/2)
+			end
+		end
+		if size(parent_update)>0:
+			update_path(parent_update)
+		end
+	end
+
+
+	function vEB_index(n::Int, depth::Int, height::Int)
+		if height<3
+			return n
+		end
+
+		bottom_h = hyperceil(h*1.0/2)
+		top_h = h - bottom_h
+
+		if depth<top_h:
+			cal_new_depth
+			return vEB_index(n,cal_new_depth,top_h)
+		end
+
+		sub_d = depth - top_h
+		sub_root = n >> sub_d
+
+		num_sub = 1 <<top_h
+		n &= (1<<sub_d)-1
+		n |= 1 << sub_d
+
+		sub_size = (1 << bottom_h)-1
+		top_size = (1 <<top_h) -1
+
+		x = top_size+(sub_root & (num_sub-1))*sub_size
+
+		return x + vEB_index(n,bottom_h)
+	end
+end


### PR DESCRIPTION
  I am working on the implementation of oblivious B-trees, as proposed in issue  #219, based on the paper _Cache-Oblivious B-Trees, Bender, Demaine and Farach-Colton, SIAM J. Comput. 35 (2006) 341-358_ 

  The structure is quite complicated, but on the bottom of everything lies a memory packed array (description of it can be found in the above paper, as well as in: _An adaptive packed-memory array, Bender, Hu, ACM Transactions on Database Systems v.32 i.4, (2007)_ ). For use in the B-trees the structure must offer an "insert after" method and a "delete" method. Presented implementation is still a subject to change. One of the problems is that the array must be always within lower and upper threshold. I tested the current implementation only with the lower threshold set to 0, as otherwise an empty array wouldn't  be within the threshold, preventing from inserting any element. I will try to add some test by the end of this or future week. As the array is a basis for future work on the cache-oblivious b-trees, I would really appreciate if someone could look at it and share his opinion.   

  I was also wondering if the memory packed array would be useful not only for the cache oblivious B-trees. I am not sure, what is right now the best way of inserting an element after a given index (I tried only insert!(collection, index, item)). I was thinking about making some tests and checking if memory packed array is a faster solution for this issue. 
