### PR TITLE
RFC: Update `SortedSet` constructors

### DIFF
--- a/doc/source/sorted_containers.rst
+++ b/doc/source/sorted_containers.rst
@@ -206,20 +206,18 @@ Constructors for Sorted Containers
   may also be constructed via ``SortedMultiDict(K[], V[], o)`` where
   the ``o`` argument is optional.
 
-``SortedSet(iter,o)``
+``SortedSet()``
+``SortedSet{K}()``
+  Construct a SortedSet{Any} with ``Forward`` ordering.
+
+``SortedSet(iter,o=Forward)``
+``SortedSet{K}(iter,o=Forward)``
+``SortedSet(o, iter)``
+``SortedSet{K}(o, iter)``
   Construct a SortedSet using keys given by iterable ``iter`` (e.g.,
   an array)
   and ordering object ``o``.  The ordering object
   defaults to ``Forward`` if not specified.
-
-``SortedSet{K,Ord}(o)``
-  Construct an empty sorted set in which type parameter
-  is explicitly listed; ordering object is explicitly specified.
-  (See below for discussion of ordering.)  An alternate way
-  to create an empty set of type ``K`` is ``SortedSet(K[], o)``;
-  again, the order argument defaults to ``Forward`` if not
-  specified.
-
 
 Complexity of Sorted Containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -5,44 +5,45 @@
 @compat type SortedSet{K, Ord <: Ordering}
     bt::BalancedTree23{K,Void,Ord}
 
-    ## Zero-argument constructor, or possibly one argument to specify order.
+    function (::Type{SortedSet{K,Ord}}){K,Ord<:Ordering}(o::Ord=Forward, iter=[])
+        sorted_set = new{K,Ord}(BalancedTree23{K,Void,Ord}(o))
 
-    function (::Type{SortedSet{K,Ord}}){K, Ord <: Ordering}(o::Ord=Forward)
-        bt1 = BalancedTree23{K,Void,Ord}(o)
-        new{K,Ord}(bt1)
+        for item in iter
+            push!(sorted_set, item)
+        end
+
+        sorted_set
     end
 end
 
-@compat (::Type{SortedSet})() = SortedSet{Any,ForwardOrdering}(Forward)
-@compat (::Type{SortedSet{K}}){K}() = SortedSet{K,ForwardOrdering}(Forward)
-@compat (::Type{SortedSet}){O<:Ordering}(o::O) = SortedSet{Any,O}(o)
-@compat (::Type{SortedSet{K}}){K,O<:Ordering}(o::O) = SortedSet{K,O}(o)
-# @compat (::Type{SortedSet{K}}){K,O<:Ordering}(o::O, ps...) = SortedSet{K,O}(o, ps...)
-# @compat (::Type{SortedSet{K}}){K}(ps...) = SortedSet{K}(Base.Forward, ps...)
+SortedSet() = SortedSet{Any,ForwardOrdering}(Forward)
+SortedSet{O<:Ordering}(o::O) = SortedSet{Any,O}(o)
 
+if VERSION < v"0.5"
+    # To address ambiguity warnings on Julia v0.4
+    SortedSet(o1::Ordering,o2::Ordering) =
+        throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
+end
+SortedSet(o::Ordering, iter) = sortedset_with_eltype(o, iter, eltype(iter))
+SortedSet(iter, o::Ordering=Forward) = sortedset_with_eltype(o, iter, eltype(iter))
+
+@compat (::Type{SortedSet{K}}){K}() = SortedSet{K,ForwardOrdering}(Forward)
+@compat (::Type{SortedSet{K}}){K,O<:Ordering}(o::O) = SortedSet{K,O}(o)
+
+if VERSION < v"0.5"
+    # To address ambiguity warnings on Julia v0.4
+    @compat (::Type{SortedSet{K}}){K}(o1::Ordering,o2::Ordering) =
+        throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
+end
+@compat (::Type{SortedSet{K}}){K}(o::Ordering, iter) = sortedset_with_eltype(o, iter, K)
+@compat (::Type{SortedSet{K}}){K}(iter, o::Ordering=Forward) = sortedset_with_eltype(o, iter, K)
+
+sortedset_with_eltype{K,Ord}(o::Ord, iter, ::Type{K}) = SortedSet{K,Ord}(o, iter)
 
 const SetSemiToken = IntSemiToken
 
 # The following definition was moved to tokens2.jl
 # const SetToken = Tuple{SortedSet, IntSemiToken}
-
-## This constructor takes an iterable; order defaults
-## to Forward
-
-## This one takes an iterable; ordering type is optional.
-
-SortedSet{Ord <: Ordering}(iter, o::Ord=Forward) =
-    sortedset_with_eltype(iter, eltype(iter), o)
-
-function sortedset_with_eltype{K,Ord}(iter, ::Type{K}, o::Ord)
-    h = SortedSet{K,Ord}(o)
-    for k in iter
-        insert!(h, k)
-    end
-    h
-end
-
-
 
 ## This function looks up a key in the tree;
 ## if not found, then it returns a marker for the

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1468,7 +1468,19 @@ end
     @test typeof(SortedSet{Float64}()) == SortedSet{Float64, ForwardOrdering}
     @test typeof(SortedSet(Reverse)) == SortedSet{Any, ReverseOrdering{ForwardOrdering}}
     @test typeof(SortedSet{Float64}(Reverse)) == SortedSet{Float64, ReverseOrdering{ForwardOrdering}}
+    @test typeof(SortedSet([1,2,3])) == SortedSet{Int, ForwardOrdering}
+    @test typeof(SortedSet{Float32}([1,2,3])) == SortedSet{Float32, ForwardOrdering}
+    if VERSION >= v"0.5"
+        @test typeof(SortedSet(Reverse, [1,2,3])) == SortedSet{Int, ReverseOrdering{ForwardOrdering}}
+        @test typeof(SortedSet{Float32}(Reverse, [1,2,3])) == SortedSet{Float32, ReverseOrdering{ForwardOrdering}}
+    end
+    @test typeof(SortedSet([1,2,3], Reverse)) == SortedSet{Int, ReverseOrdering{ForwardOrdering}}
+    @test typeof(SortedSet{Float32}([1,2,3], Reverse)) == SortedSet{Float32, ReverseOrdering{ForwardOrdering}}
 
+    if VERSION < v"0.5"
+        @test_throws ArgumentError SortedSet(Reverse, Reverse)
+        @test_throws ArgumentError SortedSet{Int}(Reverse, Reverse)
+    end
 
     smallest = 10.0
     largest = -10.0


### PR DESCRIPTION
* `SortedSet` constructors can now take nothing, an ordering, an iterable,
  or an ordering and an interable, with or without specifying the set
  element type