### PR TITLE
RFC: SortedMultiDict constructor updates

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -118,4 +118,14 @@ module DataStructures
 
     @deprecate DefaultOrderedDict(default, ks, vs) DefaultOrderedDict(default, zip(ks, vs))
     @deprecate DefaultOrderedDict{K,V}(::Type{K}, ::Type{V}, default) DefaultOrderedDict{K,V}(default)
+
+    function SortedMultiDict{K,V}(ks::AbstractVector{K},
+                                  vs::AbstractVector{V},
+                                  o::Ordering=Forward)
+        Base.depwarn("SortedMultiDict(ks, vs, o::Ordering=Forward) is deprecated.\n" * "Use SortedMultiDict(o, zip(ks,vs)) or SortedMultiDict(zip(ks, vs))", :SortedMultiDict)
+        if length(ks) != length(vs)
+            throw(ArgumentError("SortedMultiDict(ks,vs,o): ks and vs arrays must be the same length"))
+        end
+        SortedMultiDict(o, zip(ks,vs))
+    end
 end

--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -5,81 +5,91 @@
 @compat type SortedMultiDict{K, D, Ord <: Ordering}
     bt::BalancedTree23{K,D,Ord}
 
-## Zero-argument constructor, or possibly one argument to specify order.
+    ## Base constructors
 
-    function (::Type{SortedMultiDict{K,D,Ord}}){K, D, Ord <: Ordering}(o::Ord=Forward)
-        bt1 = BalancedTree23{K,D,Ord}(o)
-        new{K,D,Ord}(bt1)
+    SortedMultiDict(o::Ord) = new(BalancedTree23{K,D,Ord}(o))
+
+    function SortedMultiDict(o::Ord, kv)
+        smd = new(BalancedTree23{K,D,Ord}(o))
+
+        if eltype(kv) <: Pair
+            # It's (possibly?) more efficient to access the first and second
+            # elements of Pairs directly, rather than destructure
+            for p in kv
+                insert!(smd, p.first, p.second)
+            end
+        else
+            for (k,v) in kv
+                insert!(smd, k, v)
+            end
+        end
+        return smd
+
     end
 end
 
-@compat (::Type{SortedMultiDict})() = SortedMultiDict{Any,Any,ForwardOrdering}(Forward)
-@compat (::Type{SortedMultiDict{K,D}}){K,D}() = SortedMultiDict{K,D,ForwardOrdering}(Forward)
-@compat (::Type{SortedMultiDict}){O<:Ordering}(o::O) = SortedMultiDict{Any,Any,O}(o)
-@compat (::Type{SortedMultiDict{K,D}}){K,D,O<:Ordering}(o::O) = SortedMultiDict{K,D,O}(o)
-# @compat (::Type{SortedMultiDict{K,D}}){K,D,O<:Ordering}(o::O, ps::Pair...) = SortedMultiDict{K,D,O}(o, ps...)
-# @compat (::Type{SortedMultiDict{K,D}}){K,D}(ps::Pair...) = SortedMultiDict{K,D}(Base.Forward, ps...)
+SortedMultiDict() = SortedMultiDict{Any,Any,ForwardOrdering}(Forward)
+SortedMultiDict{O<:Ordering}(o::O) = SortedMultiDict{Any,Any,O}(o)
+
+# Construction from Pairs
+SortedMultiDict(ps::Pair...) = SortedMultiDict(Forward, ps)
+SortedMultiDict(o::Ordering, ps::Pair...) = SortedMultiDict(o, ps)
+@compat (::Type{SortedMultiDict{K,D}}){K,D}(ps::Pair...) = SortedMultiDict{K,D,ForwardOrdering}(Forward, ps)
+@compat (::Type{SortedMultiDict{K,D}}){K,D,Ord<:Ordering}(o::Ord, ps::Pair...) = SortedMultiDict{K,D,Ord}(o, ps)
+
+# Construction from Associatives
+SortedMultiDict{K,D,Ord<:Ordering}(o::Ord, d::Associative{K,D}) = SortedMultiDict{K,D,Ord}(o, d)
+
+## Construction from iteratables of Pairs/Tuples
+
+# Construction specifying Key/Value types
+# e.g., SortedMultiDict{Int,Float64}([1=>1, 2=>2.0])
+@compat (::Type{SortedMultiDict{K,D}}){K,D}(kv) = SortedMultiDict{K,D}(Forward, kv)
+@compat function (::Type{SortedMultiDict{K,D}}){K,D,Ord<:Ordering}(o::Ord, kv)
+    try
+        SortedMultiDict{K,D,Ord}(o, kv)
+    catch e
+        if not_iterator_of_pairs(kv)
+            throw(ArgumentError("SortedMultiDict(kv): kv needs to be an iterator of tuples or pairs"))
+        else
+            rethrow(e)
+        end
+    end
+end
+
+# Construction inferring Key/Value types from input
+# e.g. SortedMultiDict{}
+
+SortedMultiDict(o1::Ordering, o2::Ordering) = throw(ArgumentError("SortedMultiDict with two parameters must be called with an Ordering and an interable of pairs"))
+SortedMultiDict(kv, o::Ordering=Forward) = SortedMultiDict(o, kv)
+function SortedMultiDict(o::Ordering, kv)
+    try
+        _sorted_multidict_with_eltype(o, kv, eltype(kv))
+    catch e
+        if not_iterator_of_pairs(kv)
+            throw(ArgumentError("SortedMultiDict(kv): kv needs to be an iterator of tuples or pairs"))
+        else
+            rethrow(e)
+        end
+    end
+end
+
+_sorted_multidict_with_eltype{K,D,Ord}(o::Ord, ps, ::Type{Pair{K,D}}) = SortedMultiDict{  K,  D,Ord}(o, ps)
+_sorted_multidict_with_eltype{K,D,Ord}(o::Ord, kv, ::Type{Tuple{K,D}}) = SortedMultiDict{  K,  D,Ord}(o, kv)
+_sorted_multidict_with_eltype{K,  Ord}(o::Ord, ps, ::Type{Pair{K}}  ) = SortedMultiDict{  K,Any,Ord}(o, ps)
+_sorted_multidict_with_eltype{    Ord}(o::Ord, kv, ::Type            ) = SortedMultiDict{Any,Any,Ord}(o, kv)
+
+## TODO: It seems impossible (or at least very challenging) to create the eltype below.
+##       If deemed possible, please create a test and uncomment this definition.
+# if VERSION < v"0.6.0-dev.2123"
+#     _sorted_multi_dict_with_eltype{  D,Ord}(o::Ord, ps, ::Type{Pair{TypeVar(:K),D}}) = SortedMultiDict{Any,  D,Ord}(o, ps)
+# else
+#     include_string("_sorted_multi_dict_with_eltype{  D,Ord}(o::Ord, ps, ::Type{Pair{K,D} where K}) = SortedMultiDict{Any,  D,Ord}(o, ps)")
+# end
 
 const SMDSemiToken = IntSemiToken
 
 const SMDToken = Tuple{SortedMultiDict, IntSemiToken}
-
-## This constructor takes two arrays an ordering object which defaults
-## to Forward
-
-function SortedMultiDict{K,D, Ord <: Ordering}(kk::AbstractArray{K,1},
-                                               dd::AbstractArray{D,1},
-                                               o::Ord=Forward)
-    if length(kk) != length(dd)
-        throw(ArgumentError("SortedMultiDict K and D constructor array arguments must be the same length"))
-    end
-    h = SortedMultiDict{K,D,Ord}(o)
-    for i = 1 : length(kk)
-        insert!(h, kk[i], dd[i])
-    end
-    h
-end
-
-
-
-## Take pairs and infer argument
-## types.  Note:  this works only for the Forward ordering.
-
-function SortedMultiDict{K,D}(p1::Pair{K,D}, ps::Pair{K,D}...)
-    h = SortedMultiDict{K,D,ForwardOrdering}()
-    insert!(h, p1.first, p1.second)
-    for p in ps
-        insert!(h, p.first, p.second)
-    end
-    h
-end
-
-
-## Take pairs and infer argument
-## types.  Ordering parameter must be explicit first argument.
-
-
-function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
-    h = SortedMultiDict{K,D,Ord}(o)
-    for p in ps
-        insert!(h, p.first, p.second)
-    end
-    h
-end
-
-
-## This one takes an iterable; ordering type is optional.
-
-SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) =
-sortedmultidict_with_eltype(kv, eltype(kv), o)
-
-function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
-    h = SortedMultiDict{K,D,Ord}(o)
-    for (k,v) in kv
-        insert!(h, k, v)
-    end
-    h
-end
 
 
 ## This function inserts an item into the tree.
@@ -218,13 +228,13 @@ function mergetwo!{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord},
 end
 
 function packcopy{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord})
-    w = SortedMultiDict((K)[], (D)[], orderobject(m))
+    w = SortedMultiDict{K,D}(orderobject(m))
     mergetwo!(w,m)
     w
 end
 
 function packdeepcopy{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord})
-    w = SortedMultiDict((K)[], (D)[], orderobject(m))
+    w = SortedMultiDict{K,D}(orderobject(m))
     for (k,v) in m
         insert!(w.bt, deepcopy(k), deepcopy(v), true)
     end
@@ -260,6 +270,6 @@ function Base.show{K,D,Ord <: Ordering}(io::IO, m::SortedMultiDict{K,D,Ord})
 end
 
 similar{K,D,Ord<:Ordering}(m::SortedMultiDict{K,D,Ord}) =
-   SortedMultiDict(K[], D[], orderobject(m))
+   SortedMultiDict{K,D}(orderobject(m))
 
 isordered{T<:SortedMultiDict}(::Type{T}) = true


### PR DESCRIPTION
Update SortedMultiDict constructors to accept type parameters
* Mirrors recent updates to SortedDict constructors

@StephenVavasis, can you please review?

One change, mirrored in all of the other `Dict`s, is that I deprecated `SortedMultiDict(ks,vs)` (constructor from arrays).  However, `SortedMultiDicts` are different enough that I would like feedback on that change (and anything else.)