### PR TITLE
Fix an ambiguity

### DIFF
--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -45,8 +45,9 @@ end
 ## Take pairs and infer argument
 ## types.  Note:  this works only for the Forward ordering.
 
-function SortedMultiDict{K,D}(ps::Pair{K,D}...)
+function SortedMultiDict{K,D}(p1::Pair{K,D}, ps::Pair{K,D}...)
     h = SortedMultiDict{K,D,ForwardOrdering}()
+    insert!(h, p1.first, p1.second)
     for p in ps
         insert!(h, p.first, p.second)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ const IntSet = DataStructures.IntSet
 import Compat: String
 using Primes
 
+if VERSION >= v"0.5.0" && VERSION < v"0.6.0-dev"
+    @test isempty(detect_ambiguities(Base, Core, DataStructures))
+end
+
 tests = ["int_set",
          "deque",
          "circ_deque",


### PR DESCRIPTION
This fixes the following:
```julia
julia> using Base.Test, DataStructures
INFO: Recompiling stale cache file /home/tim/.julia/lib/v0.5/DataStructures.ji for module DataStructures.

julia> detect_ambiguities(Base,Core,DataStructures)
Skipping Base.<|
Skipping Base.>:
Skipping Base.cluster_manager
1-element Array{Tuple{Method,Method},1}:
 ((::Type{DataStructures.SortedMultiDict}){K,D}(ps::Pair{K,D}...) at /home/tim/.julia/v0.5/DataStructures/src/sorted_multi_dict.jl:49,(::Type{DataStructures.SortedMultiDict})(kv) at /home/tim/.julia/v0.5/DataStructures/src/sorted_multi_dict.jl:72)
```

Noticed in https://github.com/JuliaImages/ImageMetadata.jl/issues/13. Will need a new tag for ImageMetadata to pass its tests.