### PR TITLE
Fix SortedSet ambiguities on julia v0.5, v0.6

### DIFF
--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -19,22 +19,18 @@ end
 SortedSet() = SortedSet{Any,ForwardOrdering}(Forward)
 SortedSet{O<:Ordering}(o::O) = SortedSet{Any,O}(o)
 
-if VERSION < v"0.5"
-    # To address ambiguity warnings on Julia v0.4
-    SortedSet(o1::Ordering,o2::Ordering) =
-        throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
-end
+# To address ambiguity warnings on Julia v0.4
+SortedSet(o1::Ordering,o2::Ordering) =
+    throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
 SortedSet(o::Ordering, iter) = sortedset_with_eltype(o, iter, eltype(iter))
 SortedSet(iter, o::Ordering=Forward) = sortedset_with_eltype(o, iter, eltype(iter))
 
 @compat (::Type{SortedSet{K}}){K}() = SortedSet{K,ForwardOrdering}(Forward)
 @compat (::Type{SortedSet{K}}){K,O<:Ordering}(o::O) = SortedSet{K,O}(o)
 
-if VERSION < v"0.5"
-    # To address ambiguity warnings on Julia v0.4
-    @compat (::Type{SortedSet{K}}){K}(o1::Ordering,o2::Ordering) =
-        throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
-end
+# To address ambiguity warnings on Julia v0.4
+@compat (::Type{SortedSet{K}}){K}(o1::Ordering,o2::Ordering) =
+    throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
 @compat (::Type{SortedSet{K}}){K}(o::Ordering, iter) = sortedset_with_eltype(o, iter, K)
 @compat (::Type{SortedSet{K}}){K}(iter, o::Ordering=Forward) = sortedset_with_eltype(o, iter, K)
 

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1477,10 +1477,8 @@ end
     @test typeof(SortedSet([1,2,3], Reverse)) == SortedSet{Int, ReverseOrdering{ForwardOrdering}}
     @test typeof(SortedSet{Float32}([1,2,3], Reverse)) == SortedSet{Float32, ReverseOrdering{ForwardOrdering}}
 
-    if VERSION < v"0.5"
-        @test_throws ArgumentError SortedSet(Reverse, Reverse)
-        @test_throws ArgumentError SortedSet{Int}(Reverse, Reverse)
-    end
+    @test_throws ArgumentError SortedSet(Reverse, Reverse)
+    @test_throws ArgumentError SortedSet{Int}(Reverse, Reverse)
 
     smallest = 10.0
     largest = -10.0


### PR DESCRIPTION
SortedSet has a couple of constructors which look like
```julia
SortedSet(o::Ordering, iter) = sortedset_with_eltype(o, iter, eltype(iter))
SortedSet(iter, o::Ordering=Forward) = sortedset_with_eltype(o, iter, eltype(iter))
```

Because this causes an ambiguity to be shown on Julia v0.4, the following constructor was added for that version only:
```julia
SortedSet(o1::Ordering,o2::Ordering) =
    throw(ArgumentError("SortedSet with two parameters must be called with an Ordering and an interable"))
```

However, DataStructure tests recently started testing for ambiguities, and the lack of this definition on v0.5 and v0.6 causes problems.  So this PR just defines it for all julia versions.