### PR TITLE
Move not_iterator_of_pairs function from sorted_dict.jl to dict_support.jl

### DIFF
--- a/src/dict_support.jl
+++ b/src/dict_support.jl
@@ -1,6 +1,12 @@
 # support functions
 
-# These functions are defined in Base, but are not exported,
+# _tablesz and hashindex are defined in Base, but are not exported,
 # so they are redefined here.
 _tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
 hashindex(key, sz) = (reinterpret(Int,(hash(key))) & (sz-1)) + 1
+
+function not_iterator_of_pairs(kv)
+    return any(x->isempty(methodswith(typeof(kv), x, true)),
+               [start, next, done]) ||
+           any(x->!isa(x, Union{Tuple,Pair}), kv)
+end

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -62,12 +62,6 @@ end
 # Construction inferring Key/Value types from input
 # e.g. SortedDict{}
 
-function not_iterator_of_pairs(kv)
-    return any(x->isempty(methodswith(typeof(kv), x, true)),
-               [start, next, done]) ||
-           any(x->!isa(x, Union{Tuple,Pair}), kv)
-end
-
 SortedDict(o1::Ordering, o2::Ordering) = throw(ArgumentError("SortedDict with two parameters must be called with an Ordering and an interable of pairs"))
 SortedDict(kv, o::Ordering=Forward) = SortedDict(o, kv)
 function SortedDict(o::Ordering, kv)


### PR DESCRIPTION
~~This function was moved to dict_support.jl, but wasn't removed from its original location.~~