### PR TITLE
EqualityForAccumulators

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -30,6 +30,10 @@ length(a::Accumulator) = length(a.map)
 
 ## retrieval
 
+get{T,V}(ct::Accumulator{T,V}, x::T, default) = get(ct.map, x, default)
+# need to allow user specified default in order to
+# correctly implement "informal" Associative interface
+
 getindex{T,V}(ct::Accumulator{T,V}, x::T) = get(ct.map, x, zero(V))
 
 haskey{T,V}(ct::Accumulator{T,V}, x::T) = haskey(ct.map, x)

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -66,3 +66,7 @@ ct4 = counter(Pair{Int,Int})
 @test isa(ct4, Accumulator{Pair{Int,Int}})
 @test push!(ct4, 1=>2) == 1
 @test push!(ct4, 1=>2) == 2
+
+
+@test counter([2,3,4,4]) == counter([4,2,3,4])
+@test counter([2,3,4,4]) != counter([4,2,3,4,4])


### PR DESCRIPTION
Before:

```julia
julia> using DataStructures

julia> counter([2,3,4]) == counter([2,4,3]) 
ERROR: MethodError: no method matching get(::DataStructures.Accumulator{Int64,Int64}, ::Int64, ::Symbol)
Closest candidates are:
  get(::ObjectIdDict, ::ANY, ::ANY) at dict.jl:284
  get(::AbstractArray{T,N}, ::Integer, ::Any) at abstractarray.jl:912
  get{K,V}(::Dict{K,V}, ::Any, ::Any) at dict.jl:692
  ...
 in in(::Pair{Int64,Int64}, ::DataStructures.Accumulator{Int64,Int64}, ::Base.#==) at ./dict.jl:10
 in ==(::DataStructures.Accumulator{Int64,Int64}, ::DataStructures.Accumulator{Int64,Int64}) at ./dict.jl:209
```

Now:
``julia
julia> using DataStructures

julia> counter([2,3,4]) == counter([2,4,3]) 
ERROR: MethodError: no method matching get(::DataStructures.Accumulator{Int64,Int64}, ::Int64, ::Symbol)
Closest candidates are:
  get(::ObjectIdDict, ::ANY, ::ANY) at dict.jl:284
  get(::AbstractArray{T,N}, ::Integer, ::Any) at abstractarray.jl:912
  get{K,V}(::Dict{K,V}, ::Any, ::Any) at dict.jl:692
  ...
 in in(::Pair{Int64,Int64}, ::DataStructures.Accumulator{Int64,Int64}, ::Base.#==) at ./dict.jl:10
 in ==(::DataStructures.Accumulator{Int64,Int64}, ::DataStructures.Accumulator{Int64,Int64}) at ./dict.jl:209
```

Turns out, that all subclasses of Associative,
should implement `get(store, key, default)`
or otherwise several things break