### PR TITLE
Fix an overflow in testing SortedDicts on 32-bit systems

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,6 @@ environment:
     - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
     - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
-matrix:
-  allow_failures:
-    # Sorted Containers tests fail on 32-bit
-    - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-    # We don't yet support the new type system
-    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
 branches:
   only:
     - master

--- a/test/test_classified_collections.jl
+++ b/test/test_classified_collections.jl
@@ -26,7 +26,7 @@ push!(c, "high", 5)
 @test c["high"] == [4, 5]
 
 @test length(c) == 2
-@test collect(keys(c)) == Compat.ASCIIString["high","low"]
+@test sort(collect(keys(c))) == Compat.ASCIIString["high","low"]
 
 pop!(c,"low")
 @test !haskey(c,"low")

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -457,7 +457,7 @@ end
         u += pr[2]
     end
     numprimes = length(m1)
-    pn = primes(N)
+    pn = convert(Array{Int64}, primes(N))
     @test t == sum(pn)
     @test u == sum(pn.^2)
     ij = endof(m1)


### PR DESCRIPTION
The sum of the first 5000 primes overflows an `Int32`.  The easy fix was to force it to be an `Int64`.