### PR TITLE
Reduce type strictness for accumulator

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -30,13 +30,13 @@ length(a::Accumulator) = length(a.map)
 
 ## retrieval
 
-get{T,V}(ct::Accumulator{T,V}, x::T, default) = get(ct.map, x, default)
+get(ct::Accumulator, x, default) = get(ct.map, x, default)
 # need to allow user specified default in order to
 # correctly implement "informal" Associative interface
 
-getindex{T,V}(ct::Accumulator{T,V}, x::T) = get(ct.map, x, zero(V))
+getindex{T,V}(ct::Accumulator{T,V}, x) = get(ct.map, x, zero(V))
 
-haskey{T,V}(ct::Accumulator{T,V}, x::T) = haskey(ct.map, x)
+haskey(ct::Accumulator, x) = haskey(ct.map, x)
 
 keys(ct::Accumulator) = keys(ct.map)
 
@@ -53,24 +53,23 @@ done(ct::Accumulator, state) = done(ct.map, state)
 
 # manipulation
 
-push!{T,V<:Number}(ct::Accumulator{T,V}, x::T, a::V) = (ct.map[x] = ct[x] + a)
-push!{T,V<:Number,V2<:Number}(ct::Accumulator{T,V}, x::T, a::V2) = push!(ct, x, convert(V,a))
-push!{T,V<:Number}(ct::Accumulator{T,V}, x::T) = push!(ct, x, one(V))
+push!(ct::Accumulator, x, a::Number) = (ct.map[x] = ct[x] + a)
+push!{T,V}(ct::Accumulator{T,V}, x) = push!(ct, x, one(V))
 
 # To remove ambiguities related to Accumulator now being a subtype of Associative
 if VERSION < v"0.6.0-dev.2123"
-    push!{T,V<:Number}(ct::Accumulator{T,V}, x::Pair) = push!(ct, x, one(V))
+    push!{T,V}(ct::Accumulator{T,V}, x::Pair) = push!(ct, x, one(V))
 else
-    include_string("push!(ct::Accumulator{T,V}, x::T) where T<:Pair where V<:Number = push!(ct, x, one(V))")
+    include_string("push!(ct::Accumulator{T,V}, x::T) where T<:Pair where V = push!(ct, x, one(V))")
 end
 
-function push!{T,V<:Number,V2<:Number}(ct::Accumulator{T,V}, r::Accumulator{T,V2})
-    for (x::T, v::V2) in r
+function push!(ct::Accumulator, r::Accumulator)
+    for (x, v) in r
         push!(ct, x, v)
     end
     ct
 end
 
-pop!{T,V<:Number}(ct::Accumulator{T,V}, x::T) = pop!(ct.map, x)
+pop!(ct::Accumulator, x) = pop!(ct.map, x)
 
-merge{T,V<:Number}(ct1::Accumulator{T,V}, ct2::Accumulator{T,V}) = push!(copy(ct1), ct2)
+merge(ct1::Accumulator, ct2::Accumulator) = push!(copy(ct1), ct2)

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -70,3 +70,24 @@ ct4 = counter(Pair{Int,Int})
 
 @test counter([2,3,4,4]) == counter([4,2,3,4])
 @test counter([2,3,4,4]) != counter([4,2,3,4,4])
+
+
+ct5 = counter(split("a b b c c c"))
+@test ct5["a"] == 1
+@test ct5["b"] == 2
+@test ct5["c"] == 3
+
+ct6 = counter(["a", "b" , "b", "c", "c", "c"])
+for ii in split("a b c")
+    push!(ct6, ii)
+end
+@show ct6
+@test ct6["a"] == 2
+@test ct6["b"] == 3
+@test ct6["c"] == 4
+for ii in split("a b")
+    pop!(ct6, ii)
+end
+@test ct6["a"] == 0
+@test ct6["b"] == 0
+@test ct6["c"] == 4


### PR DESCRIPTION
Accumulator was overly strictly typed.
This was breaking the ability to use it for `SubString`s and `String`s interchangeably.


There is no need to type-things any stricter than the backing dictionary does.
