### PR TITLE
`@inline` binary heap `top` call

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -147,6 +147,6 @@ end
 
 Returns the element at the top of the heap `h`.
 """
-top(h::BinaryHeap) = h.valtree[1]
+@inline top(h::BinaryHeap) = h.valtree[1]
 
 pop!{T}(h::BinaryHeap{T}) = _binary_heap_pop!(h.comparer, h.valtree)

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -208,7 +208,7 @@ function push!{T}(h::MutableBinaryHeap{T}, v::T)
     i
 end
 
-top(h::MutableBinaryHeap) = h.nodes[1].value
+@inline top(h::MutableBinaryHeap) = h.nodes[1].value
 
 """
     top_with_handle(h::MutableBinaryHeap)


### PR DESCRIPTION
This will allow `@inbounds` to propagate into this call.