### PR TITLE
Dequeuing (priority queue) with values

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.9.4
+Compat 0.17.0

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -19,7 +19,7 @@ module DataStructures
                  find, searchsortedfirst, searchsortedlast, endof, in
 
     export Deque, Stack, Queue, CircularDeque
-    export deque, enqueue!, dequeue!, update!, reverse_iter
+    export deque, enqueue!, dequeue!, dequeue_with_val!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, sizehint!
 
     export Accumulator, counter

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -53,6 +53,13 @@ push!{T,V<:Number}(ct::Accumulator{T,V}, x::T, a::V) = (ct.map[x] = ct[x] + a)
 push!{T,V<:Number,V2<:Number}(ct::Accumulator{T,V}, x::T, a::V2) = push!(ct, x, convert(V,a))
 push!{T,V<:Number}(ct::Accumulator{T,V}, x::T) = push!(ct, x, one(V))
 
+# To remove ambiguities related to Accumulator now being a subtype of Associative
+if VERSION < v"0.6.0-dev.2123"
+    push!{T,V<:Number}(ct::Accumulator{T,V}, x::Pair) = push!(ct, x, one(V))
+else
+    include_string("push!(ct::Accumulator{T,V}, x::T) where T<:Pair where V<:Number = push!(ct, x, one(V))")
+end
+
 function push!{T,V<:Number,V2<:Number}(ct::Accumulator{T,V}, r::Accumulator{T,V2})
     for (x::T, v::V2) in r
         push!(ct, x, v)

--- a/src/balanced_tree.jl
+++ b/src/balanced_tree.jl
@@ -7,9 +7,9 @@
 ## children.
 ## All the internal tree
 ## nodes are stored in an array of TreeNodes.  The bottom layer
-## of internal tree nodes, 
+## of internal tree nodes,
 ## called the "leaves" in this file, sit above one more layer
-## of data nodes, which are stored in a different array.  
+## of data nodes, which are stored in a different array.
 
 
 ## KDRec is one data node:
@@ -25,16 +25,16 @@
 ##  data nodes.
 
 
-immutable KDRec{K,D}
+@compat immutable KDRec{K,D}
     parent::Int
     k::K
     d::D
-    KDRec(p::Int, k1::K, d1::D) = new(p,k1,d1)
-    KDRec(p::Int) = new(p)
+    (::Type{KDRec{K,D}}){K,D}(p::Int, k1::K, d1::D) = new{K,D}(p,k1,d1)
+    (::Type{KDRec{K,D}}){K,D}(p::Int) = new{K,D}(p)
 end
 
 ## TreeNode is an internal node of the tree.
-## child1,child2,child3:  
+## child1,child2,child3:
 ##     These are the three children node numbers.
 ##     If the node is a 2-node (rather than 3), then child3 == 0.
 ##     If this is a leaf then child1,child2,child3 are subscripts
@@ -42,21 +42,21 @@ end
 ## splitkey1:
 ##    the minimum key of the subtree at child2.  If this is a leaf
 ##    then it is the key of child2.
-## splitkey2: 
+## splitkey2:
 ##    if child3 > 0 then splitkey2 is the minimum key of the subtree at child3.
 ##    If this is a leaf, then it is the key of child3.
 ## Again, there are two constructors for the same reason mentioned above.
 
-immutable TreeNode{K}
+@compat immutable TreeNode{K}
     child1::Int
     child2::Int
     child3::Int
     parent::Int
     splitkey1::K
     splitkey2::K
-    TreeNode(::Type{K}, c1::Int, c2::Int, c3::Int, p::Int) = new(c1, c2, c3, p)
-    TreeNode(c1::Int, c2::Int, c3::Int, p::Int, sk1::K, sk2::K) = 
-        new(c1, c2, c3, p, sk1, sk2)
+    (::Type{TreeNode{K}}){K}(::Type{K}, c1::Int, c2::Int, c3::Int, p::Int) = new{K}(c1, c2, c3, p)
+    (::Type{TreeNode{K}}){K}(c1::Int, c2::Int, c3::Int, p::Int, sk1::K, sk2::K) =
+        new{K}(c1, c2, c3, p, sk1, sk2)
 end
 
 
@@ -90,15 +90,15 @@ end
 ## ord:: The ordering object.  Often the ordering type
 ##   is a singleton type, so this field is empty, but it
 ##   is still necessary to direct the multiple dispatch.
-## data: the (key,data) pairs of the tree.  
+## data: the (key,data) pairs of the tree.
 ##   The first and second entries of the data array are dummy placeholders
 ##   for the beginning and end of the sorted order of the keys
 ## tree: the nodes of a 2-3 tree that sits above the data.
-## rootloc: the index of the entry of tree (i.e., a subscript to 
-##   treenodes) that is the tree's root    
+## rootloc: the index of the entry of tree (i.e., a subscript to
+##   treenodes) that is the tree's root
 ## depth: the depth of the tree, (number
 ##    of tree levels, not counting the level of data at the bottom)
-##    depth==1 means that there is a single root node 
+##    depth==1 means that there is a single root node
 ##      whose children are data nodes.
 ## freetreeinds: Array of indices of free locations in the
 ##    tree array (locations are freed due to deletion)
@@ -111,7 +111,7 @@ end
 ## deletionchild and deletionleftkey are two work-arrays
 ## for the delete function.
 
-type BalancedTree23{K, D, Ord <: Ordering}
+@compat type BalancedTree23{K, D, Ord <: Ordering}
     ord::Ord
     data::Array{KDRec{K,D}, 1}
     tree::Array{TreeNode{K}, 1}
@@ -124,16 +124,16 @@ type BalancedTree23{K, D, Ord <: Ordering}
     # function.
     deletionchild::Array{Int,1}
     deletionleftkey::Array{K,1}
-    function BalancedTree23(ord1::Ord)
+    function (::Type{BalancedTree23{K,D,Ord}}){K,D,Ord<:Ordering}(ord1::Ord)
         tree1 = Vector{TreeNode{K}}(1)
         initializeTree!(tree1)
         data1 = Vector{KDRec{K,D}}(2)
         initializeData!(data1)
         u1 = IntSet()
         push!(u1, 1, 2)
-        new(ord1, data1, tree1, 1, 1, Vector{Int}(0), Vector{Int}(0),
-            u1,
-            Vector{Int}(3), Vector{K}(3))
+        new{K,D,Ord}(ord1, data1, tree1, 1, 1, Vector{Int}(0), Vector{Int}(0),
+                     u1,
+                     Vector{Int}(3), Vector{K}(3))
     end
 end
 
@@ -955,7 +955,7 @@ function delete!{K,D,Ord<:Ordering}(t::BalancedTree23{K,D,Ord}, it::Int)
         t.depth -= 1
         push!(t.freetreeinds, p)
     end
-    
+
     ## If deletionleftkey1_valid, this means that the new
     ## min key of the deleted node and its right neighbors
     ## has never been stored in the tree.  It must be stored
@@ -964,8 +964,8 @@ function delete!{K,D,Ord<:Ordering}(t::BalancedTree23{K,D,Ord}, it::Int)
     ## until we find a node which has p (and therefore the
     ## deleted node) as its descendent through its second
     ## or third child.
-    ## It cannot be the case that the deleted node is 
-    ## is a descendent of the root always through 
+    ## It cannot be the case that the deleted node is
+    ## is a descendent of the root always through
     ## first children, since this would mean the deleted
     ## node is the leftmost placeholder, which
     ## cannot be deleted.
@@ -996,7 +996,6 @@ function delete!{K,D,Ord<:Ordering}(t::BalancedTree23{K,D,Ord}, it::Int)
                 # @assert(curdepth > 0)
             end
         end
-    end                                  
+    end
     nothing
 end
-

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,13 +1,12 @@
-
 """
 New items are pushed to the back of the list, overwriting values in a circular fashion.
 """
-type CircularBuffer{T} <: AbstractVector{T}
+@compat type CircularBuffer{T} <: AbstractVector{T}
     capacity::Int
     first::Int
     buffer::Vector{T}
 
-    CircularBuffer(capacity::Int) = new(capacity, 1, T[])
+    (::Type{CircularBuffer{T}}){T}(capacity::Int) = new{T}(capacity, 1, T[])
 end
 
 function _buffer_index(cb::CircularBuffer, i::Int)

--- a/src/container_loops.jl
+++ b/src/container_loops.jl
@@ -7,8 +7,8 @@ import Base.values
 ## is for all sorted containers.
 ## The following two definitions now appear in tokens2.jl
 
-#typealias SDMContainer Union{SortedDict, SortedMultiDict}
-#typealias SAContainer Union{SDMContainer, SortedSet}
+# const SDMContainer = Union{SortedDict, SortedMultiDict}
+# const SAContainer = Union{SDMContainer, SortedSet}
 
 @inline extractcontainer(s::SAContainer) = s
 
@@ -64,18 +64,18 @@ eltype(s::AbstractIncludeLast) = eltype(s.m)
 ## The basic iterations are either over the whole sorted container, an
 ## exclude-last object or include-last object.
 
-typealias SDMIterableTypesBase Union{SDMContainer,
-                                     SDMExcludeLast,
-                                     SDMIncludeLast}
+const SDMIterableTypesBase = Union{SDMContainer,
+                                   SDMExcludeLast,
+                                   SDMIncludeLast}
 
-typealias SSIterableTypesBase Union{SortedSet,
-                                    SSExcludeLast,
-                                    SSIncludeLast}
+const SSIterableTypesBase = Union{SortedSet,
+                                  SSExcludeLast,
+                                  SSIncludeLast}
 
 
-typealias SAIterableTypesBase Union{SAContainer,
-                                    AbstractExcludeLast,
-                                    AbstractIncludeLast}
+const SAIterableTypesBase = Union{SAContainer,
+                                  AbstractExcludeLast,
+                                  AbstractIncludeLast}
 
 
 ## The compound iterations are obtained by applying keys(..) or values(..)
@@ -136,18 +136,18 @@ end
 eltype(s::SDMSemiTokenValIteration) = Tuple{IntSemiToken,
                                             valtype(extractcontainer(s.base))}
 
-typealias SACompoundIterable Union{SDMKeyIteration,
-                                   SDMValIteration,
-                                   SDMSemiTokenIteration,
-                                   SSSemiTokenIteration,
-                                   SDMSemiTokenKeyIteration,
-                                   SDMSemiTokenValIteration,
-                                   SAOnlySemiTokensIteration}
+const SACompoundIterable = Union{SDMKeyIteration,
+                                 SDMValIteration,
+                                 SDMSemiTokenIteration,
+                                 SSSemiTokenIteration,
+                                 SDMSemiTokenKeyIteration,
+                                 SDMSemiTokenValIteration,
+                                 SAOnlySemiTokensIteration}
 
 @inline extractcontainer(s::SACompoundIterable) = extractcontainer(s.base)
 
 
-typealias SAIterable Union{SAIterableTypesBase, SACompoundIterable}
+const SAIterable = Union{SAIterableTypesBase, SACompoundIterable}
 
 
 ## All the loops maintain a state which is an object of the

--- a/src/container_loops.jl
+++ b/src/container_loops.jl
@@ -16,7 +16,7 @@ import Base.values
 ## iteration.
 
 
-abstract AbstractExcludeLast{ContainerType <: SAContainer}
+@compat abstract type AbstractExcludeLast{ContainerType <: SAContainer} end
 
 immutable SDMExcludeLast{ContainerType <: SDMContainer} <:
                               AbstractExcludeLast{ContainerType}
@@ -38,7 +38,7 @@ eltype(s::AbstractExcludeLast) = eltype(s.m)
 ## This holds an object describing an include-last
 ## iteration.
 
-abstract AbstractIncludeLast{ContainerType <: SAContainer}
+@compat abstract type AbstractIncludeLast{ContainerType <: SAContainer} end
 
 
 

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -14,19 +14,22 @@
 # subclassed.
 #
 
-immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
+@compat immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     default::F
     d::D
 
     check_D(D,K,V) = (D <: Associative{K,V}) ||
         throw(ArgumentError("Default dict must be <: Associative{$K,$V}"))
 
-    DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
-    DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
+    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D}(x::F, kv::AbstractArray{Tuple{K,V}}) =
+        (check_D(D,K,V); new{K,V,F,D}(x, D(kv)))
+    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D}(x::F, ps::Pair{K,V}...) =
+        (check_D(D,K,V); new{K,V,F,D}(x, D(ps...)))
 
-    @compat (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
+    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
         (check_D(D,K,V); DefaultDictBase(x, d.d))
-    DefaultDictBase(x::F, d::D = D()) = (check_D(D,K,V); new(x, d))
+    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D}(x::F, d::D = D()) =
+        (check_D(D,K,V); new{K,V,F,D}(x, d))
 end
 
 # Constructors
@@ -79,14 +82,18 @@ end
 for _Dict in [:Dict, :OrderedDict]
     DefaultDict = Symbol("Default"*string(_Dict))
     @eval begin
-        immutable $DefaultDict{K,V,F} <: Associative{K,V}
+        @compat immutable $DefaultDict{K,V,F} <: Associative{K,V}
             d::DefaultDictBase{K,V,F,$_Dict{K,V}}
 
-            $DefaultDict(x, ps::Pair{K,V}...) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, ps...))
-            $DefaultDict(x, kv::AbstractArray{Tuple{K,V}}) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, kv))
-            $DefaultDict(x, d::$DefaultDict) = $DefaultDict(x, d.d)
-            $DefaultDict(x, d::$_Dict) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, d))
-            $DefaultDict(x) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x))
+            (::Type{$DefaultDict{K,V,F}}){K,V,F}(x, ps::Pair{K,V}...) =
+                new{K,V,F}(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, ps...))
+            (::Type{$DefaultDict{K,V,F}}){K,V,F}(x, kv::AbstractArray{Tuple{K,V}}) =
+                new{K,V,F}(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, kv))
+            (::Type{$DefaultDict{K,V,F}}){K,V,F}(x, d::$DefaultDict) = $DefaultDict(x, d.d)
+            (::Type{$DefaultDict{K,V,F}}){K,V,F}(x, d::$_Dict) =
+                new{K,V,F}(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, d))
+            (::Type{$DefaultDict{K,V,F}}){K,V,F}(x) =
+                new{K,V,F}(DefaultDictBase{K,V,F,$_Dict{K,V}}(x))
         end
 
         ## Constructors

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -14,38 +14,20 @@
 # subclassed.
 #
 
-_oldDefaultDictBase = """
 immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     default::F
     d::D
 
     check_D(D,K,V) = (D <: Associative{K,V}) ||
-        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
+        throw(ArgumentError("Default dict must be <: Associative{$K,$V}"))
 
     DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
     DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
 
-    DefaultDictBase(x::F, d::DefaultDictBase) = (check_D(D,K,V); DefaultDictBase(x, d.d))
-    DefaultDictBase(x::F, d::D=D()) = (check_D(D,K,V); new(x, d))
-end
-"""
-
-_newDefaultDictBase = """
-immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
-    default::F
-    d::D
-
-    check_D(D,K,V) = (D <: Associative{K,V}) ||
-        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
-
-    DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
-    DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
-    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
+    @compat (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
         (check_D(D,K,V); DefaultDictBase(x, d.d))
     DefaultDictBase(x::F, d::D = D()) = (check_D(D,K,V); new(x, d))
 end
-"""
-eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldDefaultDictBase) : parse(_newDefaultDictBase))
 
 # Constructors
 

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -5,7 +5,7 @@
 #
 #######################################
 
-type DequeBlock{T}
+@compat type DequeBlock{T}
     data::Vector{T}  # only data[front:back] is valid
     capa::Int
     front::Int
@@ -13,9 +13,9 @@ type DequeBlock{T}
     prev::DequeBlock{T}  # ref to previous block
     next::DequeBlock{T}  # ref to next block
 
-    function DequeBlock(capa::Int, front::Int)
+    function (::Type{DequeBlock{T}}){T}(capa::Int, front::Int)
         data = Vector{T}(capa)
-        blk = new(data, capa, front, front-1)
+        blk = new{T}(data, capa, front, front-1)
         blk.prev = blk
         blk.next = blk
         blk
@@ -58,19 +58,19 @@ end
 
 const DEFAULT_DEQUEUE_BLOCKSIZE = 1024
 
-type Deque{T}
+@compat type Deque{T}
     nblocks::Int
     blksize::Int
     len::Int
     head::DequeBlock{T}
     rear::DequeBlock{T}
 
-    function Deque(blksize::Int)
+    function (::Type{Deque{T}}){T}(blksize::Int)
         head = rear = rear_deque_block(T, blksize)
-        new(1, blksize, 0, head, rear)
+        new{T}(1, blksize, 0, head, rear)
     end
 
-    Deque() = Deque{T}(DEFAULT_DEQUEUE_BLOCKSIZE)
+    (::Type{Deque{T}}){T}() = Deque{T}(DEFAULT_DEQUEUE_BLOCKSIZE)
 end
 
 """

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -105,11 +105,11 @@ end
 #
 ############################################################
 
-type DisjointSets{T}
+@compat type DisjointSets{T}
     intmap::Dict{T,Int}
     internal::IntDisjointSets
 
-    function DisjointSets(xs)    # xs must be iterable
+    function (::Type{DisjointSets{T}}){T}(xs)    # xs must be iterable
         imap = Dict{T,Int}()
         n = length(xs)
         sizehint!(imap, n)
@@ -117,7 +117,7 @@ type DisjointSets{T}
         for x in xs
             imap[x] = (id += 1)
         end
-        new(imap, IntDisjointSets(n))
+        new{T}(imap, IntDisjointSets(n))
     end
 end
 

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -42,9 +42,9 @@
 # HT: handle type
 # VT: value type
 
-abstract AbstractHeap{VT}
+@compat abstract type AbstractHeap{VT} end
 
-abstract AbstractMutableHeap{VT,HT} <: AbstractHeap{VT}
+@compat abstract type AbstractMutableHeap{VT,HT} <: AbstractHeap{VT} end
 
 # comparer
 

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -104,7 +104,7 @@ end
 
 type BinaryHeap{T,Comp} <: AbstractHeap{T}
     comparer::Comp
-    valtree::Array{T}
+    valtree::Vector{T}
 
     function BinaryHeap(comp::Comp)
         new(comp, Vector{T}(0))

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -102,17 +102,17 @@ end
 #
 #################################################
 
-type BinaryHeap{T,Comp} <: AbstractHeap{T}
+@compat type BinaryHeap{T,Comp} <: AbstractHeap{T}
     comparer::Comp
     valtree::Vector{T}
 
-    function BinaryHeap(comp::Comp)
-        new(comp, Vector{T}(0))
+    function (::Type{BinaryHeap{T,Comp}}){T,Comp}(comp::Comp)
+        new{T,Comp}(comp, Vector{T}(0))
     end
 
-    function BinaryHeap(comp::Comp, xs)  # xs is an iterable collection of values
+    function (::Type{BinaryHeap{T,Comp}}){T,Comp}(comp::Comp, xs)  # xs is an iterable collection of values
         valtree = _make_binary_heap(comp, T, xs)
-        new(comp, valtree)
+        new{T,Comp}(comp, valtree)
     end
 end
 

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -150,20 +150,20 @@ end
 #
 #################################################
 
-type MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
+@compat type MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
     comparer::Comp
     nodes::Vector{MutableBinaryHeapNode{VT}}
     node_map::Vector{Int}
 
-    function MutableBinaryHeap(comp::Comp)
+    function (::Type{MutableBinaryHeap{VT, Comp}}){VT, Comp}(comp::Comp)
         nodes = Vector{MutableBinaryHeapNode{VT}}(0)
         node_map = Vector{Int}(0)
-        new(comp, nodes, node_map)
+        new{VT, Comp}(comp, nodes, node_map)
     end
 
-    function MutableBinaryHeap(comp::Comp, xs)  # xs is an iterable collection of values
+    function (::Type{MutableBinaryHeap{VT, Comp}}){VT, Comp}(comp::Comp, xs)  # xs is an iterable collection of values
         nodes, node_map = _make_mutable_binary_heap(comp, VT, xs)
-        new(comp, nodes, node_map)
+        new{VT, Comp}(comp, nodes, node_map)
     end
 end
 

--- a/src/list.jl
+++ b/src/list.jl
@@ -1,4 +1,4 @@
-abstract LinkedList{T}
+@compat abstract type LinkedList{T} end
 
 type Nil{T} <: LinkedList{T}
 end

--- a/src/multi_dict.jl
+++ b/src/multi_dict.jl
@@ -5,14 +5,12 @@ import Base: haskey, get, get!, getkey, delete!, pop!, empty!,
              next, done, keys, values, copy, similar,  push!,
              count, size, eltype
 
-immutable MultiDict{K,V}
+@compat immutable MultiDict{K,V}
     d::Dict{K,Vector{V}}
 
-    MultiDict() = new(Dict{K,Vector{V}}())
-    MultiDict(kvs) = new(Dict{K,Vector{V}}(kvs))
-    if VERSION >= v"0.4.0-dev+980"
-        MultiDict(ps::Pair{K,Vector{V}}...) = new(Dict{K,Vector{V}}(ps...))
-    end
+    (::Type{MultiDict{K,V}}){K,V}() = new{K,V}(Dict{K,Vector{V}}())
+    (::Type{MultiDict{K,V}}){K,V}(kvs) = new{K,V}(Dict{K,Vector{V}}(kvs))
+    (::Type{MultiDict{K,V}}){K,V}(ps::Pair{K,Vector{V}}...) = new{K,V}(Dict{K,Vector{V}}(ps...))
 end
 
 MultiDict() = MultiDict{Any,Any}()
@@ -29,16 +27,14 @@ function multi_dict_with_eltype{K,V}(kvs, ::Type{Tuple{K,V}})
 end
 multi_dict_with_eltype(kvs, t) = MultiDict{Any,Any}(kvs)
 
-if VERSION >= v"0.4.0-dev+980"
-    MultiDict{K,V<:AbstractArray}(ps::Pair{K,V}...) = MultiDict{K, eltype(V)}(ps)
-    MultiDict{K,V}(kv::AbstractArray{Pair{K,V}})  = MultiDict(kv...)
-    function  MultiDict{K,V}(ps::Pair{K,V}...)
-        md = MultiDict{K,V}()
-        for (k,v) in ps
-            insert!(md, k, v)
-        end
-        return md
+MultiDict{K,V<:AbstractArray}(ps::Pair{K,V}...) = MultiDict{K, eltype(V)}(ps)
+MultiDict{K,V}(kv::AbstractArray{Pair{K,V}})  = MultiDict(kv...)
+function MultiDict{K,V}(ps::Pair{K,V}...)
+    md = MultiDict{K,V}()
+    for (k,v) in ps
+        insert!(md, k, v)
     end
+    return md
 end
 
 ## Functions

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -61,7 +61,7 @@ _oldOrderedDict1 = "OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = Ord
 _newOrderedDict1 = "OrderedDict{V}(kv::Tuple{Vararg{Pair{K,V} where K}})   = OrderedDict{Any,V}(kv)"
 OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
 OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
-eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldOrderedDict1) : parse(_newOrderedDict1))
+VERSION < v"0.6.0-dev.2123" ? include_string(_oldOrderedDict1) : include_string(_newOrderedDict1)
 OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv)
 
 OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv)
@@ -72,7 +72,7 @@ _oldOrderedDict2 = "OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{An
 _newOrderedDict2 = "OrderedDict{V}(ps::(Pair{K,V} where K)...,) = OrderedDict{Any,V}(ps)"
 OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps)
 OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps)
-eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldOrderedDict2) : parse(_newOrderedDict2))
+VERSION < v"0.6.0-dev.2123" ? include_string(_oldOrderedDict2) : include_string(_newOrderedDict2)
 OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps)
 
 function OrderedDict(kv)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -1,4 +1,3 @@
-
 # OrderedDict
 
 import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
@@ -14,25 +13,25 @@ import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
 `OrderedDict`s are  simply dictionaries  whose entries  have a  particular order.  The order
 refers to insertion order, which allows deterministic iteration over the dictionary or set.
 """
-type OrderedDict{K,V} <: Associative{K,V}
+@compat type OrderedDict{K,V} <: Associative{K,V}
     slots::Array{Int32,1}
     keys::Array{K,1}
     vals::Array{V,1}
     ndel::Int
     dirty::Bool
 
-    function OrderedDict()
-        new(zeros(Int32,16), Vector{K}(0), Vector{V}(0), 0, false)
+    function (::Type{OrderedDict{K,V}}){K,V}()
+        new{K,V}(zeros(Int32,16), Vector{K}(0), Vector{V}(0), 0, false)
     end
-    function OrderedDict(kv)
+    function (::Type{OrderedDict{K,V}}){K,V}(kv)
         h = OrderedDict{K,V}()
         for (k,v) in kv
             h[k] = v
         end
         return h
     end
-    OrderedDict(p::Pair) = setindex!(OrderedDict{K,V}(), p.second, p.first)
-    function OrderedDict(ps::Pair...)
+    (::Type{OrderedDict{K,V}}){K,V}(p::Pair) = setindex!(OrderedDict{K,V}(), p.second, p.first)
+    function (::Type{OrderedDict{K,V}}){K,V}(ps::Pair...)
         h = OrderedDict{K,V}()
         sizehint!(h, length(ps))
         for p in ps
@@ -40,12 +39,12 @@ type OrderedDict{K,V} <: Associative{K,V}
         end
         return h
     end
-    function OrderedDict(d::OrderedDict{K,V})
+    function (::Type{OrderedDict{K,V}}){K,V}(d::OrderedDict{K,V})
         if d.ndel > 0
             rehash!(d)
         end
         @assert d.ndel == 0
-        new(copy(d.slots), copy(d.keys), copy(d.vals), 0)
+        new{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0)
     end
 end
 OrderedDict() = OrderedDict{Any,Any}()

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -5,11 +5,11 @@
 # TODO: Most of these functions should be removed once AbstractSet is introduced there
 # (see https://github.com/JuliaLang/julia/issues/5533)
 
-immutable OrderedSet{T}
+@compat immutable OrderedSet{T}
     dict::OrderedDict{T,Void}
 
-    OrderedSet() = new(OrderedDict{T,Void}())
-    OrderedSet(xs) = union!(new(OrderedDict{T,Void}()), xs)
+    (::Type{OrderedSet{T}}){T}() = new{T}(OrderedDict{T,Void}())
+    (::Type{OrderedSet{T}}){T}(xs) = union!(new{T}(OrderedDict{T,Void}()), xs)
 end
 OrderedSet() = OrderedSet{Any}()
 OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -235,6 +235,46 @@ function dequeue!(pq::PriorityQueue, key)
     key
 end
 
+"""
+    dequeue_with_val!(pq)
+
+Remove and return a the lowest priority key and value from a priority queue as a tuple.
+
+```jldoctest
+julia> a = PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+
+julia> dequeue_with_val!(a)
+("c", 1)
+
+julia> a
+PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
+  "b" => 3
+  "a" => 2
+```
+"""
+function dequeue_with_val!(pq::PriorityQueue)
+    x = pq.xs[1]
+    y = pop!(pq.xs)
+    if !isempty(pq)
+        pq.xs[1] = y
+        pq.index[y.first] = 1
+        percolate_down!(pq, 1)
+    end
+    delete!(pq.index, x.first)
+    Tuple(x)
+end
+
+function dequeue_with_val!(pq::PriorityQueue, key)
+    idx = pq.index[key]
+    force_up!(pq, idx)
+    dequeue_with_val!(pq)
+end
+
+
 # Unordered iteration through key value pairs in a PriorityQueue
 start(pq::PriorityQueue) = start(pq.index)
 

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -23,7 +23,7 @@ PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
   "a" => 2
 ```
 """
-type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
+@compat type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     # Binary heap of (element, priority) pairs.
     xs::Array{Pair{K,V}, 1}
     o::O
@@ -31,14 +31,14 @@ type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     # Map elements to their index in xs
     index::Dict{K, Int}
 
-    function PriorityQueue(o::O)
-        new(Vector{Pair{K,V}}(0), o, Dict{K, Int}())
+    function (::Type{PriorityQueue{K,V,O}}){K,V,O<:Ordering}(o::O)
+        new{K,V,O}(Vector{Pair{K,V}}(0), o, Dict{K, Int}())
     end
 
-    PriorityQueue() = PriorityQueue{K,V,O}(Forward)
+    (::Type{PriorityQueue{K,V,O}}){K,V,O<:Ordering}() = PriorityQueue{K,V,O}(Forward)
 
-    function PriorityQueue(ks::AbstractArray{K}, vs::AbstractArray{V},
-                           o::O)
+    function (::Type{PriorityQueue{K,V,O}}){K,V,O<:Ordering}(ks::AbstractArray{K},
+                                                             vs::AbstractArray{V}, o::O)
         # TODO: maybe deprecate
         if length(ks) != length(vs)
             throw(ArgumentError("key and value arrays must have equal lengths"))
@@ -46,7 +46,7 @@ type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
         PriorityQueue{K,V,O}(zip(ks, vs), o)
     end
 
-    function PriorityQueue(itr, o::O)
+    function (::Type{PriorityQueue{K,V,O}}){K,V,O<:Ordering}(itr, o::O)
         xs = Vector{Pair{K,V}}(length(itr))
         index = Dict{K, Int}()
         for (i, (k, v)) in enumerate(itr)
@@ -56,7 +56,7 @@ type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
             end
             index[k] = i
         end
-        pq = new(xs, o, index)
+        pq = new{K,V,O}(xs, o, index)
 
         # heapify
         for i in heapparent(length(pq.xs)):-1:1

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -68,9 +68,9 @@ end
 
 
 
-typealias SDSemiToken IntSemiToken
+const SDSemiToken = IntSemiToken
 
-typealias SDToken Tuple{SortedDict,IntSemiToken}
+const SDToken = Tuple{SortedDict,IntSemiToken}
 
 
 

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -30,8 +30,9 @@ end
 ## Take pairs and infer argument
 ## types.  Note:  this works only for the Forward ordering.
 
-function SortedDict{K,D}(ps::Pair{K,D}...)
+function SortedDict{K,D}(p1::Pair{K,D}, ps::Pair{K,D}...)
     h = SortedDict{K,D,ForwardOrdering}()
+    h[p1.first] = p1.second
     for p in ps
         h[p.first] = p.second
     end

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -1,15 +1,14 @@
 ## A SortedDict is a wrapper around balancedTree with
 ## methods similiar to those of Julia container Dict.
 
-
-type SortedDict{K, D, Ord <: Ordering} <: Associative{K,D}
+@compat type SortedDict{K, D, Ord <: Ordering} <: Associative{K,D}
     bt::BalancedTree23{K,D,Ord}
 
 ## Zero-argument constructor, or possibly one argument to specify order.
 
-    function SortedDict(o::Ord=Forward)
+    function (::Type{SortedDict{K,D,Ord}}){K, D, Ord <: Ordering}(o::Ord=Forward)
         bt1 = BalancedTree23{K,D,Ord}(o)
-        new(bt1)
+        new{K,D,Ord}(bt1)
     end
 
 end

--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -14,9 +14,9 @@
 end
 
 
-typealias SMDSemiToken IntSemiToken
+const SMDSemiToken = IntSemiToken
 
-typealias SMDToken Tuple{SortedMultiDict, IntSemiToken}
+const SMDToken = Tuple{SortedMultiDict, IntSemiToken}
 
 ## This constructor takes two arrays an ordering object which defaults
 ## to Forward
@@ -201,7 +201,7 @@ function isequal(m1::SortedMultiDict, m2::SortedMultiDict)
     end
 end
 
-typealias SDorAssociative Union{Associative,SortedMultiDict}
+const SDorAssociative = Union{Associative,SortedMultiDict}
 
 function mergetwo!{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord},
                                         m2::SDorAssociative)

--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -39,8 +39,9 @@ end
 ## Take pairs and infer argument
 ## types.  Note:  this works only for the Forward ordering.
 
-function SortedMultiDict{K,D}(ps::Pair{K,D}...)
+function SortedMultiDict{K,D}(p1::Pair{K,D}, ps::Pair{K,D}...)
     h = SortedMultiDict{K,D,ForwardOrdering}()
+    insert!(h, p1.first, p1.second)
     for p in ps
         insert!(h, p.first, p.second)
     end

--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -2,14 +2,14 @@
 ## Unlike SortedDict, a key in SortedMultiDict can
 ## refer to multiple data entries.
 
-type SortedMultiDict{K, D, Ord <: Ordering}
+@compat type SortedMultiDict{K, D, Ord <: Ordering}
     bt::BalancedTree23{K,D,Ord}
 
 ## Zero-argument constructor, or possibly one argument to specify order.
 
-    function SortedMultiDict(o::Ord=Forward)
+    function (::Type{SortedMultiDict{K,D,Ord}}){K, D, Ord <: Ordering}(o::Ord=Forward)
         bt1 = BalancedTree23{K,D,Ord}(o)
-        new(bt1)
+        new{K,D,Ord}(bt1)
     end
 end
 

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -2,14 +2,14 @@
 ## methods similiar to those of the julia Set.
 
 
-type SortedSet{K, Ord <: Ordering}
+@compat type SortedSet{K, Ord <: Ordering}
     bt::BalancedTree23{K,Void,Ord}
 
     ## Zero-argument constructor, or possibly one argument to specify order.
 
-    function SortedSet(o::Ord=Forward)
+    function (::Type{SortedSet{K,Ord}}){K, Ord <: Ordering}(o::Ord=Forward)
         bt1 = BalancedTree23{K,Void,Ord}(o)
-        new(bt1)
+        new{K,Ord}(bt1)
     end
 end
 

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -14,10 +14,10 @@
 end
 
 
-typealias SetSemiToken IntSemiToken
+const SetSemiToken = IntSemiToken
 
 # The following definition was moved to tokens2.jl
-#typealias SetToken Tuple{SortedSet, IntSemiToken}
+# const SetToken = Tuple{SortedSet, IntSemiToken}
 
 ## This constructor takes an iterable; order defaults
 ## to Forward

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -1,19 +1,17 @@
 ## Token interface to a container.  A token is the address
 ## of an item in a container.  The token has two parts: the
 ## container and the item's address.  The address is of type
-## AbstractSemiToken.  
+## AbstractSemiToken.
 
 
 module Tokens
 
+using Compat
 
-abstract AbstractSemiToken
+@compat abstract type AbstractSemiToken end
 
 immutable IntSemiToken <: AbstractSemiToken
     address::Int
 end
 
 end
-
-
-

--- a/src/tokens2.jl
+++ b/src/tokens2.jl
@@ -3,12 +3,12 @@ import Base.isequal
 import Base.colon
 import Base.endof
 
-typealias SDMContainer Union{SortedDict, SortedMultiDict}
-typealias SAContainer Union{SDMContainer, SortedSet}
+const SDMContainer = Union{SortedDict, SortedMultiDict}
+const SAContainer = Union{SDMContainer, SortedSet}
 
-typealias Token Tuple{SAContainer, IntSemiToken}
-typealias SDMToken Tuple{SDMContainer, IntSemiToken}
-typealias SetToken Tuple{SortedSet, IntSemiToken}
+const Token = Tuple{SAContainer, IntSemiToken}
+const SDMToken = Tuple{SDMContainer, IntSemiToken}
+const SetToken = Tuple{SortedSet, IntSemiToken}
 
 
 ## Function startof returns the semitoken that points

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -1,16 +1,16 @@
-type Trie{T}
+@compat type Trie{T}
     value::T
     children::Dict{Char,Trie{T}}
     is_key::Bool
 
-    function Trie()
-        self = new()
+    function (::Type{Trie{T}}){T}()
+        self = new{T}()
         self.children = Dict{Char,Trie{T}}()
         self.is_key = false
         self
     end
 
-    function Trie(ks, vs)
+    function (::Type{Trie{T}}){T}(ks, vs)
         t = Trie{T}()
         for (k, v) in zip(ks, vs)
             t[k] = v
@@ -18,7 +18,7 @@ type Trie{T}
         return t
     end
 
-    function Trie(kv)
+    function (::Type{Trie{T}}){T}(kv)
         t = Trie{T}()
         for (k,v) in kv
             t[k] = v

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ const IntSet = DataStructures.IntSet
 import Compat: String
 using Primes
 
+if VERSION >= v"0.5.0" && VERSION < v"0.6.0-dev"
+    @test isempty(detect_ambiguities(Base, Core, DataStructures))
+end
+
 tests = ["int_set",
          "deque",
          "circ_deque",

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -61,3 +61,8 @@ ctm = merge(ct2, ct3)
 @test pop!(ctm, "b") == 22
 @test !haskey(ctm, "b")
 @test ctm["b"] == 0
+
+ct4 = counter(Pair{Int,Int})
+@test isa(ct4, Accumulator{Pair{Int,Int}})
+@test push!(ct4, 1=>2) == 1
+@test push!(ct4, 1=>2) == 2

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -93,6 +93,18 @@ while !isempty(pq)
     @test 10 != dequeue!(pq)
 end
 
+priorities2 = Dict(zip('a':'e', 5:-1:1))
+pq = PriorityQueue(priorities2)
+try
+    dequeue_with_val!(pq, 'g')
+    error("should have resulted in KeyError")
+catch ex
+    @test isa(ex, KeyError)
+end
+@test dequeue_with_val!(pq) == ('e', 1)
+@test dequeue_with_val!(pq, 'b') == ('b', 4)
+@test length(pq) == 3
+
 # low level heap operations
 xs = heapify!([v for v in values(priorities)])
 @test issorted([heappop!(xs) for _ in length(priorities)])


### PR DESCRIPTION
Closes #289. Adds `dequeue_with_val!` to PriorityQueue - returns a tuple (key, value). Implemented also for specific dequeuing of a known key.