### PR TITLE
dequeue_with_val! - closes #289

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -19,7 +19,7 @@ module DataStructures
                  find, searchsortedfirst, searchsortedlast, endof, in
 
     export Deque, Stack, Queue, CircularDeque
-    export deque, enqueue!, dequeue!, update!, reverse_iter
+    export deque, enqueue!, dequeue!, dequeue_with_val!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, top_with_handle, sizehint!
 
     export Accumulator, counter

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -19,7 +19,7 @@ module DataStructures
                  find, searchsortedfirst, searchsortedlast, endof, in
 
     export Deque, Stack, Queue, CircularDeque
-    export deque, enqueue!, dequeue!, dequeue_with_val!, update!, reverse_iter
+    export deque, enqueue!, dequeue!, dequeue_pair!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, top_with_handle, sizehint!
 
     export Accumulator, counter

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -235,6 +235,46 @@ function dequeue!(pq::PriorityQueue, key)
     key
 end
 
+"""
+    dequeue_with_val!(pq)
+
+Remove and return a the lowest priority key and value from a priority queue as a tuple.
+
+```jldoctest
+julia> a = PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
+PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
+  "c" => 1
+  "b" => 3
+  "a" => 2
+
+julia> dequeue_with_val!(a)
+("c", 1)
+
+julia> a
+PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
+  "b" => 3
+  "a" => 2
+```
+"""
+function dequeue_with_val!(pq::PriorityQueue)
+    x = pq.xs[1]
+    y = pop!(pq.xs)
+    if !isempty(pq)
+        pq.xs[1] = y
+        pq.index[y.first] = 1
+        percolate_down!(pq, 1)
+    end
+    delete!(pq.index, x.first)
+    Tuple(x)
+end
+
+function dequeue_with_val!(pq::PriorityQueue, key)
+    idx = pq.index[key]
+    force_up!(pq, idx)
+    dequeue_with_val!(pq)
+end
+
+
 # Unordered iteration through key value pairs in a PriorityQueue
 start(pq::PriorityQueue) = start(pq.index)
 

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -265,7 +265,7 @@ function dequeue_with_val!(pq::PriorityQueue)
         percolate_down!(pq, 1)
     end
     delete!(pq.index, x.first)
-    Tuple(x)
+    (x.first, x.second)
 end
 
 function dequeue_with_val!(pq::PriorityQueue, key)

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -236,9 +236,9 @@ function dequeue!(pq::PriorityQueue, key)
 end
 
 """
-    dequeue_with_val!(pq)
+    dequeue_pair!(pq)
 
-Remove and return a the lowest priority key and value from a priority queue as a tuple.
+Remove and return a the lowest priority key and value from a priority queue as a pair.
 
 ```jldoctest
 julia> a = PriorityQueue(["a","b","c"],[2,3,1],Base.Order.Forward)
@@ -247,8 +247,8 @@ PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
   "b" => 3
   "a" => 2
 
-julia> dequeue_with_val!(a)
-("c", 1)
+julia> dequeue_pair!(a)
+"c" => 1
 
 julia> a
 PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
@@ -256,7 +256,7 @@ PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 2 entries:
   "a" => 2
 ```
 """
-function dequeue_with_val!(pq::PriorityQueue)
+function dequeue_pair!(pq::PriorityQueue)
     x = pq.xs[1]
     y = pop!(pq.xs)
     if !isempty(pq)
@@ -265,13 +265,13 @@ function dequeue_with_val!(pq::PriorityQueue)
         percolate_down!(pq, 1)
     end
     delete!(pq.index, x.first)
-    (x.first, x.second)
+    x
 end
 
-function dequeue_with_val!(pq::PriorityQueue, key)
+function dequeue_pair!(pq::PriorityQueue, key)
     idx = pq.index[key]
     force_up!(pq, idx)
-    dequeue_with_val!(pq)
+    dequeue_pair!(pq)
 end
 
 

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -96,13 +96,13 @@ end
 priorities2 = Dict(zip('a':'e', 5:-1:1))
 pq = PriorityQueue(priorities2)
 try
-    dequeue_with_val!(pq, 'g')
+    dequeue_pair!(pq, 'g')
     error("should have resulted in KeyError")
 catch ex
     @test isa(ex, KeyError)
 end
-@test dequeue_with_val!(pq) == ('e', 1)
-@test dequeue_with_val!(pq, 'b') == ('b', 4)
+@test dequeue_pair!(pq) == Pair('e', 1)
+@test dequeue_pair!(pq, 'b') == Pair('b', 4)
 @test length(pq) == 3
 
 # low level heap operations

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -95,12 +95,7 @@ end
 
 priorities2 = Dict(zip('a':'e', 5:-1:1))
 pq = PriorityQueue(priorities2)
-try
-    dequeue_pair!(pq, 'g')
-    error("should have resulted in KeyError")
-catch ex
-    @test isa(ex, KeyError)
-end
+@test_throws KeyError dequeue_pair!(pq, 'g')
 @test dequeue_pair!(pq) == Pair('e', 1)
 @test dequeue_pair!(pq, 'b') == Pair('b', 4)
 @test length(pq) == 3

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -93,6 +93,18 @@ while !isempty(pq)
     @test 10 != dequeue!(pq)
 end
 
+priorities2 = Dict(zip('a':'e', 5:-1:1))
+pq = PriorityQueue(priorities2)
+try
+    dequeue_with_val!(pq, 'g')
+    error("should have resulted in KeyError")
+catch ex
+    @test isa(ex, KeyError)
+end
+@test dequeue_with_val!(pq) == ('e', 1)
+@test dequeue_with_val!(pq, 'b') == ('b', 4)
+@test length(pq) == 3
+
 # low level heap operations
 xs = heapify!([v for v in values(priorities)])
 @test issorted([heappop!(xs) for _ in length(priorities)])


### PR DESCRIPTION
Closes #289. Adds dequeue_with_val! to PriorityQueue - returns a tuple (key, value). Implemented also for specific dequeuing of a known key.