### PR TITLE
RFC: Remove v0.6 deprecations

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -105,10 +105,6 @@ module DataStructures
 
     # Deprecations
 
-    # Remove when Julia 0.6 is released
-    @deprecate iter(s::Stack) s
-    @deprecate iter(q::Queue) q
-
     # Remove when Julia 0.7 (or whatever version is after v0.6) is released
     @deprecate DefaultDictBase(default, ks::AbstractArray, vs::AbstractArray) DefaultDictBase(default, zip(ks, vs))
     @deprecate DefaultDictBase(default, ks, vs) DefaultDictBase(default, zip(ks, vs))


### PR DESCRIPTION
* For a short while, a seprate `iter` function was defined for
  Stacks and Queues.  This was deprecated in favor of iterating
  over Stacks and Queues directly (which is more standard in Julia)