### PR TITLE
Remove Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.6
-Compat 0.17.0

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -2,8 +2,6 @@ __precompile__()
 
 module DataStructures
 
-    using Compat
-
     import Base: <, <=, ==, length, isempty, start, next, done,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -6,8 +6,6 @@
 
 module Tokens
 
-using Compat
-
 abstract type AbstractSemiToken end
 
 struct IntSemiToken <: AbstractSemiToken


### PR DESCRIPTION
* Will likely need to be reintroduced in the future, but for now, all is up to date with v0.6/v0.7

Probably good to add this before tagging.