### PR TITLE
Update README badges for repo move

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,16 @@
 
-.. image:: https://travis-ci.org/JuliaLang/DataStructures.jl.svg?branch=master
-   :target: https://travis-ci.org/JuliaLang/DataStructures.jl
+.. image:: https://travis-ci.org/JuliaCollections/DataStructures.jl.svg?branch=master
+   :target: https://travis-ci.org/JuliaCollections/DataStructures.jl
    :alt: Travis Build Status
 .. image:: https://ci.appveyor.com/api/projects/status/5gw9xok4e58aixsv?svg=true
    :target: https://ci.appveyor.com/project/kmsquire/datastructures-jl
    :alt: Appveyor Build Status
-.. image:: https://coveralls.io/repos/JuliaLang/DataStructures.jl/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/JuliaLang/DataStructures.jl?branch=master
+.. image:: https://coveralls.io/repos/github/JuliaCollections/DataStructures.jl/badge.svg?branch=master
+   :target: https://coveralls.io/github/JuliaCollections/DataStructures.jl?branch=master
    :alt: Test Coverage
-.. image:: https://codecov.io/github/JuliaLang/DataStructures.jl/coverage.svg?branch=master
-   :target: https://codecov.io/github/JuliaLang/DataStructures.jl?branch=master
+.. image:: https://codecov.io/github/JuliaCollections/DataStructures.jl/coverage.svg?branch=master
+   :target: https://codecov.io/github/JuliaCollections/DataStructures.jl?branch=master
    :alt: Test Coverage
-.. image:: http://pkg.julialang.org/badges/DataStructures_0.5.svg
-   :target: http://pkg.julialang.org/?pkg=DataStructures&ver=0.5
-   :alt: PkgEval.jl Status on Julia 0.5
 .. image:: http://pkg.julialang.org/badges/DataStructures_0.6.svg
    :target: http://pkg.julialang.org/?pkg=DataStructures&ver=0.6
    :alt: PkgEval.jl Status on Julia 0.6


### PR DESCRIPTION
I had to reenable Coveralls; it was enabled for JuliaLang/DataStructures.jl but not for JuliaCollections/DataStructures.jl. This also removes the 0.5 badge since we've dropped support for it.