### PR TITLE
Fix DataStructures precompile

### DIFF
--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -49,13 +49,13 @@ DefaultDictBase{K,V}(default::F) where {K,V,F} = DefaultDictBase{K,V,F,Dict{K,V}
 # Functions
 
 # most functions are simply delegated to the wrapped dictionary
-@delegate DefaultDictBase.d [ get, haskey, getkey, pop!,
+@delegate DefaultDictBase d [ get, haskey, getkey, pop!,
                               start, done, next, isempty, length ]
 
 # Some functions are delegated, but then need to return the main dictionary
 # NOTE: push! is not included below, because the fallback version just
 #       calls setindex!
-@delegate_return_parent DefaultDictBase.d [ delete!, empty!, setindex!, sizehint! ]
+@delegate_return_parent DefaultDictBase d [ delete!, empty!, setindex!, sizehint! ]
 
 similar(d::DefaultDictBase{K,V,F}) where {K,V,F} = DefaultDictBase{K,V,F}(d.default)
 in(key, v::Base.KeyIterator{T}) where {T<:DefaultDictBase} = key in keys(v.dict.d)
@@ -115,14 +115,14 @@ for _Dict in [:Dict, :OrderedDict]
         ## Functions
 
         # Most functions are simply delegated to the wrapped DefaultDictBase object
-        @delegate $DefaultDict.d [ getindex, get, get!, haskey,
+        @delegate $DefaultDict d [ getindex, get, get!, haskey,
                                    getkey, pop!, start, next,
                                    done, isempty, length ]
 
         # Some functions are delegated, but then need to return the main dictionary
         # NOTE: push! is not included below, because the fallback version just
         #       calls setindex!
-        @delegate_return_parent $DefaultDict.d [ delete!, empty!, setindex!, sizehint! ]
+        @delegate_return_parent $DefaultDict d [ delete!, empty!, setindex!, sizehint! ]
 
         # NOTE: The second and third definition of push! below are only
         # necessary for disambiguating with the fourth, fifth, and sixth

--- a/src/delegate.jl
+++ b/src/delegate.jl
@@ -1,7 +1,6 @@
 # by JMW
-macro delegate(source, targets)
-    typename = esc(source.args[1])
-    fieldname = source.args[2].args[1]
+macro delegate(source, fieldname, targets)
+    typename = esc(source)
     funcnames = targets.args
     n = length(funcnames)
     fdefs = Vector{Any}(n)
@@ -15,9 +14,8 @@ macro delegate(source, targets)
     return Expr(:block, fdefs...)
 end
 
-macro delegate_return_parent(source, targets)
-    typename = esc(source.args[1])
-    fieldname = source.args[2].args[1]
+macro delegate_return_parent(source, fieldname, targets)
+    typename = esc(source)
     funcnames = targets.args
     n = length(funcnames)
     fdefs = Vector{Any}(n)

--- a/src/multi_dict.jl
+++ b/src/multi_dict.jl
@@ -41,7 +41,7 @@ end
 
 ## Most functions are simply delegated to the wrapped Dict
 
-@delegate MultiDict.d [ haskey, get, get!, getkey,
+@delegate MultiDict d [ haskey, get, get!, getkey,
                         getindex, length, isempty, eltype,
                         start, next, done, keys, values]
 

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -17,7 +17,7 @@ OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)
 
 show(io::IO, s::OrderedSet) = (show(io, typeof(s)); print(io, "("); !isempty(s) && Base.show_comma_array(io, s,'[',']'); print(io, ")"))
 
-@delegate OrderedSet.dict [isempty, length]
+@delegate OrderedSet dict [isempty, length]
 
 sizehint!(s::OrderedSet, sz::Integer) = (sizehint!(s.dict, sz); s)
 eltype(s::OrderedSet{T}) where {T} = T


### PR DESCRIPTION
Close #327.

This is the smallest workaround I could imagine for the 0.7 macro changes, which may not be fixed ever/for a while.

The tests still break on 0.7 but at least it gets past the loading phase.