### PR TITLE
Make counters use inc!, dec!, reset! and merge!, also adds setindex!

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module DataStructures
 
-    import Base: <, <=, ==, length, isempty, start, next, done,
+    import Base: <, <=, ==, length, isempty, start, next, done, delete!,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,
                  push!, pop!, shift!, unshift!, insert!,
@@ -20,12 +20,12 @@ module DataStructures
     export deque, enqueue!, dequeue!, dequeue_pair!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, top_with_handle, sizehint!
 
-    export Accumulator, counter
+    export Accumulator, counter, reset!, inc!, dec!
+
     export ClassifiedCollections
     export classified_lists, classified_sets, classified_counters
 
     export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set, root_union!
-    export push!
 
     export AbstractHeap, compare, extract_all!
     export BinaryHeap, binary_minheap, binary_maxheap, nlargest, nsmallest

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -26,7 +26,7 @@ end
 
 eltype_for_accumulator(seq::T) where T = eltype(T)
 function eltype_for_accumulator(seq::T) where {T<:Base.Generator}
-    @static if VERSION < v"0.7.0-DEV.2096"
+    @static if VERSION < v"0.7.0-DEV.2104"
         Base._default_eltype(T)
     else
         Base.@default_eltype(T)

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -24,7 +24,7 @@ function counter(seq)
     return ct
 end
 
-eltype_for_accumulator(seq::T) = eltype(T)
+eltype_for_accumulator(seq::T) where T = eltype(T)
 function eltype_for_accumulator(seq::T) where {T<:Base.Generator}
     @static if VERSION < v"0.7.0-DEV.2096"
         Base._default_eltype(T)

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -17,12 +17,23 @@ counter(dct::Dict{T,V}) where {T,V<:Integer} = Accumulator{T,V}(copy(dct))
 Returns an `Accumulator` object containing the elements from `seq`.
 """
 function counter(seq)
-    ct = counter(eltype(seq))
+    ct = counter(eltype_for_accumulator(seq))
     for x in seq
         inc!(ct, x)
     end
     return ct
 end
+
+eltype_for_accumulator(seq::T) = eltype(T)
+function eltype_for_accumulator(seq::T) where {T<:Base.Generator}
+    @static if VERSION < v"0.7.0-DEV.2096"
+        Base._default_eltype(T)
+    else
+        Base.@default_eltype(T)
+    end
+end
+
+
 
 copy(ct::Accumulator) = Accumulator(copy(ct.map))
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -114,7 +114,17 @@
 
     s = ["y", "el", "sol", "se", "fue"]
     @test counter(length(x) for x in s) == counter(map(length, s))
-  
+
+
+    # non-integer uses
+    acc = Accumulator(Symbol, Float16)
+    acc[:a] = 1.5
+    @test acc[:a] ≈ 1.5
+    push!(acc, :a, 2.5)
+    @test acc[:a] ≈ 4.0
+    dec!(acc, :a)
+    @test acc[:a] ≈ 3.0
+
     # ambiguity resolution
     ct7 = counter(Int)
     @test_throws MethodError push!(ct7, 1=>2)
@@ -123,7 +133,10 @@
     #deprecations
     ctd = counter([1,2,3])
     @test ctd[3]==1
+
+    println("\nThe following warning is expected:")
     @test pop!(ctd, 3)==1
+    println("\nThe following warning is expected:")
     @test push!(counter([1,2,3]),counter([1,2,3])) == merge!(counter([1,2,3]), counter([1,2,3]))
 
 end # @testset Accumulators

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -9,16 +9,31 @@
     @test !haskey(ct, "abc")
     @test isempty(collect(keys(ct)))
 
-    push!(ct, "a")
+    # Test setindex!
+    ct["b"] = 2
+    @test ct["b"] == 2
+    ct["b"] = 0
+    @test ct["b"] == 0
+
+
+
+    inc!(ct, "a")
     @test haskey(ct, "a")
     @test ct["a"] == 1
 
-    push!(ct, "b", 2)
+    inc!(ct, "b", 2)
     @test haskey(ct, "b")
     @test ct["b"] == 2
 
+    # Test dec!
+    dec!(ct, "b")
+    @test ct["b"] == 1
+    dec!(ct, "b", 16)
+    @test ct["b"] == -15
+    ct["b"] = 2     
+
     # Test convert
-    push!(ct, "b", 0x3)
+    inc!(ct, "b", 0x3)
     @test ct["b"] == 5
 
     @test !haskey(ct, "abc")
@@ -39,7 +54,7 @@
     @test ct2["b"] == 2
     @test ct2["c"] == 2
 
-    push!(ct, ct2)
+    merge!(ct, ct2)
     @test ct["a"] == 4
     @test ct["b"] == 7
     @test ct["c"] == 2
@@ -85,7 +100,7 @@
 
     ct6 = counter(["a", "b" , "b", "c", "c", "c"])
     for ii in split("a b c")
-        push!(ct6, ii)
+        inc!(ct6, ii)
     end
     @test ct6["a"] == 2
     @test ct6["b"] == 3

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -60,7 +60,7 @@
     @test ctm["b"] == 22
     @test ctm["c"] == 2
 
-    @test pop!(ctm, "b") == 22
+    @test reset!(ctm, "b") == 22
     @test !haskey(ctm, "b")
     @test ctm["b"] == 0
 
@@ -70,7 +70,7 @@
     @test push!(ct4, 1=>2) == 2
 
     ct5 = counter(Dict([("a",10), ("b",20)]))
-    @test merge(ct5)===ct5
+    @test merge(ct5)==ct5
     @test merge!(ct5)===ct5
     @test merge(ct5,ct5,ct5)==counter(Dict([("a",30), ("b",60)]))
 
@@ -91,7 +91,7 @@
     @test ct6["b"] == 3
     @test ct6["c"] == 4
     for ii in split("a b")
-        pop!(ct6, ii)
+        reset!(ct6, ii)
     end
     @test ct6["a"] == 0
     @test ct6["b"] == 0
@@ -104,5 +104,14 @@
     ct7 = counter(Int)
     @test_throws MethodError push!(ct7, 1=>2)
 
+
+    #deprecations
+    ctd = counter([1,2,3])
+    @test ctd[3]==1
+    @test pop!(ctd, 3)==1
+    @test push!(counter([1,2,3]),counter([1,2,3])) == merge!(counter([1,2,3]), counter([1,2,3]))
+
 end # @testset Accumulators
+
+
 


### PR DESCRIPTION
This resolves https://github.com/JuliaCollections/DataStructures.jl/issues/303
and https://github.com/JuliaCollections/DataStructures.jl/issues/285

In particular it gets rid of `pop!` entirely for `dec!`, with a deprecation warning.
After the deprecation period is over, we can add `pop!` back for the Bag/multiset interpretation of an accumulator.
And then maybe add it as thing that all ClassifiedCollections have too,
(since then all of them will have that)


Possibly `reset!` should be named `delete!` and should have the normal `delete!` return value of the whole collection. Right now it returns the count of the deleted item. Like `pop!`

It added new exports for `inc!`, `dec!` and `reset!`.
Technically if wanted to reduce exports `inc` could stay as `push!`, and `reset!` could be come `delete!`.
But need `dec!` as otherwise can't deprecate `pop!`.