### PR TITLE
Remove unnecessary `global` declaration in IntSet test

### DIFF
--- a/test/test_int_set.jl
+++ b/test/test_int_set.jl
@@ -121,8 +121,8 @@ s = IntSet(1:2:10)
 @test s === delete!(s, 1)
 for i in s; pop!(s, i); end
 @test isempty(s)
-global x = 0
-@test 1 == pop!(()->(global x; x+=1), s, 100)
+x = 0
+@test 1 == pop!(()->(x+=1), s, 100)
 @test x == 1
 push!(s, 100)
 @test pop!(()->throw(ErrorException()), s, 100) == 100


### PR DESCRIPTION
Fixes the
```
WARNING: deprecated syntax "implicit assignment to global variable `x`".
Use "global x" instead.
```
when running the tests.