### PR TITLE
Add implementations of pop! and shift! to CircularBuffer

### DIFF
--- a/docs/src/circ_buffer.md
+++ b/docs/src/circ_buffer.md
@@ -15,7 +15,9 @@ capacity(a)         # return capacity
 length(a)           # get the number of elements currently in the buffer
 size(a)             # same as length(a)
 push!(a, 10)        # add an element to the back and overwrite front if full
+pop!(a)             # remove the element at the back
 unshift!(a, 10)     # add an element to the front and overwrite back if full
+shift!(a)           # remove the element at the front
 append!(a, [1, 2, 3, 4])     # push at most last `capacity` items
 convert(Vector{Float64}, a)  # convert items to type Float64
 eltype(a)           # return type of items

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -15,14 +15,14 @@ function Base.empty!(cb::CircularBuffer)
     cb
 end
 
-function _buffer_index(cb::CircularBuffer, i::Int)
+function _buffer_index_checked(cb::CircularBuffer, i::Int)
     if i < 1 || i > cb.length
         throw(BoundsError(cb, i))
     end
-    _mod_buffer_index(cb, i)
+    _buffer_index(cb, i)
 end
 
-function _mod_buffer_index(cb::CircularBuffer, i::Int)
+function _buffer_index(cb::CircularBuffer, i::Int)
     n = cb.capacity
     idx = cb.first + i - 1
     if idx > n
@@ -33,11 +33,11 @@ function _mod_buffer_index(cb::CircularBuffer, i::Int)
 end
 
 function Base.getindex(cb::CircularBuffer, i::Int)
-    cb.buffer[_buffer_index(cb, i)]
+    cb.buffer[_buffer_index_checked(cb, i)]
 end
 
 function Base.setindex!(cb::CircularBuffer, data, i::Int)
-    cb.buffer[_buffer_index(cb, i)] = data
+    cb.buffer[_buffer_index_checked(cb, i)] = data
     cb
 end
 
@@ -45,7 +45,7 @@ function Base.pop!(cb::CircularBuffer)
     if cb.length == 0
         throw(ArgumentError("array must be non-empty"))
     end
-    i = _mod_buffer_index(cb, cb.length)
+    i = _buffer_index(cb, cb.length)
     cb.length -= 1
     cb.buffer[i]
 end
@@ -57,7 +57,7 @@ function Base.push!(cb::CircularBuffer, data)
     else
         cb.length += 1
     end
-    cb.buffer[_mod_buffer_index(cb, cb.length)] = data
+    cb.buffer[_buffer_index(cb, cb.length)] = data
     cb
 end
 

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -4,21 +4,26 @@ New items are pushed to the back of the list, overwriting values in a circular f
 mutable struct CircularBuffer{T} <: AbstractVector{T}
     capacity::Int
     first::Int
+    length::Int
     buffer::Vector{T}
 
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, T[])
+    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(capacity))
 end
 
 function Base.empty!(cb::CircularBuffer)
-    cb.first = 1
-    empty!(cb.buffer)
+    cb.length = 0
+    cb
 end
 
 function _buffer_index(cb::CircularBuffer, i::Int)
-    n = length(cb)
-    if i < 1 || i > n
-        throw(BoundsError("CircularBuffer out of range. cb=$cb i=$i"))
+    if i < 1 || i > cb.length
+        throw(BoundsError(cb, i))
     end
+    _mod_buffer_index(cb, i)
+end
+
+function _mod_buffer_index(cb::CircularBuffer, i::Int)
+    n = cb.capacity
     idx = cb.first + i - 1
     if idx > n
         idx - n
@@ -36,25 +41,43 @@ function Base.setindex!(cb::CircularBuffer, data, i::Int)
     cb
 end
 
+function Base.pop!(cb::CircularBuffer)
+    if cb.length == 0
+        throw(ArgumentError("array must be non-empty"))
+    end
+    i = _mod_buffer_index(cb, cb.length)
+    cb.length -= 1
+    cb.buffer[i]
+end
+
 function Base.push!(cb::CircularBuffer, data)
     # if full, increment and overwrite, otherwise push
-    if length(cb) == cb.capacity
+    if cb.length == cb.capacity
         cb.first = (cb.first == cb.capacity ? 1 : cb.first + 1)
-        cb[length(cb)] = data
     else
-        push!(cb.buffer, data)
+        cb.length += 1
     end
+    cb.buffer[_mod_buffer_index(cb, cb.length)] = data
     cb
+end
+
+function Base.shift!(cb::CircularBuffer)
+    if cb.length == 0
+        throw(ArgumentError("array must be non-empty"))
+    end
+    i = cb.first
+    cb.first = (cb.first + 1 > cb.capacity ? 1 : cb.first + 1)
+    cb.length -= 1
+    cb.buffer[i]
 end
 
 function Base.unshift!(cb::CircularBuffer, data)
     # if full, decrement and overwrite, otherwise unshift
-    if length(cb) == cb.capacity
-        cb.first = (cb.first == 1 ? cb.capacity : cb.first - 1)
-        cb[1] = data
-    else
-        unshift!(cb.buffer, data)
+    if cb.length < cb.capacity
+        cb.length += 1
     end
+    cb.first = (cb.first == 1 ? cb.length : cb.first - 1)
+    cb.buffer[cb.first] = data
     cb
 end
 
@@ -67,10 +90,10 @@ function Base.append!(cb::CircularBuffer, datavec::AbstractVector)
     cb
 end
 
-Base.length(cb::CircularBuffer) = length(cb.buffer)
+Base.length(cb::CircularBuffer) = cb.length
 Base.size(cb::CircularBuffer) = (length(cb),)
 Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
-Base.isempty(cb::CircularBuffer) = isempty(cb.buffer)
+Base.isempty(cb::CircularBuffer) = cb.length == 0
 
 capacity(cb::CircularBuffer) = cb.capacity
 isfull(cb::CircularBuffer) = length(cb) == cb.capacity

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -43,4 +43,28 @@
 
     # test empty!(cb)
     @test length(empty!(cb)) == 0
+
+    # test pop!(cb)
+    cb = CircularBuffer{Int}(5)
+    for i in 0:5    # one extra to force wraparound
+        push!(cb, i)
+    end
+    for j in 5:-1:1
+        @test pop!(cb) == j
+        @test convert(Array, cb) == collect(1:j-1)
+    end
+    @test isempty(cb)
+    @test_throws ArgumentError pop!(cb)
+
+    # test shift!(cb)
+    cb = CircularBuffer{Int}(5)
+    for i in 0:5    # one extra to force wraparound
+        push!(cb, i)
+    end
+    for j in 1:5
+        @test shift!(cb) == j
+        @test convert(Array, cb) == collect(j+1:5)
+    end
+    @test isempty(cb)
+    @test_throws ArgumentError shift!(cb)
 end


### PR DESCRIPTION
Previously we had only `push!` and `unshift!`; this PR adds the corresponding deletion operations.  I also modified the existing code to allocate the entire underlying buffer up-front, and to introduce an explicit length field.  This ensures that `shift!` and `unshift!` run in O(1) time, rather than O(n).

I also noticed that most accesses to `cb.buffer` could safely be annotated `@inbounds`, since the `CircularBuffer` code already performs its own bounds-checking, but I'll save that for another PR.