### PR TITLE
Fixed keys() and findfirst()

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -29,7 +29,7 @@ function eltype_for_accumulator(seq::T) where {T<:Base.Generator}
     @static if VERSION < v"0.7.0-DEV.2104"
         Base._default_eltype(T)
     else
-        Base.@default_eltype(T)
+        Base.@default_eltype(seq)
     end
 end
 

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -31,8 +31,8 @@ delete!(s::OrderedSet, x) = (delete!(s.dict, x); s)
 
 getindex(x::OrderedSet,i::Int) = x.dict.keys[i]
 lastindex(x::OrderedSet) = lastindex(x.dict.keys)
-Base.keys(s::OrderedSet) = keys(s.dict)
-Base.nextind(::OrderedSet, i::Int) = i + 1 # Needed on 0.7 to mimic array indexing.
+Base.nextind(::OrderedSet, i::Int) = i + 1  # Needed on 0.7 to mimic array indexing.
+Base.keys(s::OrderedSet) = 1:length(s)
 
 union!(s::OrderedSet, xs) = (for x in xs; push!(s,x); end; s)
 setdiff!(s::OrderedSet, xs) = (for x in xs; delete!(s,x); end; s)

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -138,7 +138,11 @@
     s = OrderedSet([1,3,5,7])
     @test findfirst(isequal(1), s) == 1
     @test findfirst(isequal(7), s) == 4
-    @test findfirst(isequal(2), s) == 0
+    if VERSION >= v"0.7.0-DEV.3399"
+        @test findfirst(isequal(2), s) == nothing
+    else
+        @test findfirst(isequal(2), s) == 0    
+    end    
 
     # setdiff
     @test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet()),        OrderedSet([1,2,3]))
@@ -196,7 +200,13 @@
     # TODO: returns false!
     #       == is not properly defined for OrderedSets
     #@test symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])) == OrderedSet([1,3,5,6])
-    @test isequal(symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])), OrderedSet([1,3,5,6]))
+
+    if VERSION >= v"0.7.0-DEV.3127"
+        # in Julia 0.7 symdiff always returns an array
+        @test isequal(symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])), [1,3,5,6])
+    else
+        @test isequal(symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])), OrderedSet([1,3,5,6]))
+    end
 
     # filter
     s = OrderedSet([1,2,3,4])


### PR DESCRIPTION
Comments for fixes: 

 * unlike `_default_eltype` function, macro `@default_eltype` accepts iterator, not type
 * since `keys()` for `OrderedSet` should mimic array indexing, it's keys should be integers in range `1:length(s)`, not keys of an underlying dict, which are just elements of the set

There's still a couple of deprecation warnings, but tests pass locally. 