### PR TITLE
add most_common for accumulator

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -24,7 +24,7 @@ module DataStructures
     export deque, enqueue!, dequeue!, dequeue_pair!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, top_with_handle, sizehint!
 
-    export Accumulator, counter, reset!, inc!, dec!, most_common
+    export Accumulator, counter, reset!, inc!, dec!
 
     export ClassifiedCollections
     export classified_lists, classified_sets, classified_counters

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -24,7 +24,7 @@ module DataStructures
     export deque, enqueue!, dequeue!, dequeue_pair!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, top_with_handle, sizehint!
 
-    export Accumulator, counter, reset!, inc!, dec!
+    export Accumulator, counter, reset!, inc!, dec!, most_common
 
     export ClassifiedCollections
     export classified_lists, classified_sets, classified_counters

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -165,7 +165,7 @@ julia> nlargest(counter("abbbccddddda"),2)
 ```
 """
 nlargest(acc::Accumulator) = sort!(collect(acc), by=last, rev=true)
-nlargest(acc::Accumulator, n) = select!(collect(acc), 1:n, by=last, rev=true)
+nlargest(acc::Accumulator, n) = @compat partialsort!(collect(acc), 1:n, by=last, rev=true)
 
 
 """
@@ -179,7 +179,7 @@ For obvious reasons this will not include zero counts for items not encountered.
 (unless those elements are added to he accumulator directly, eg via `acc[foo]=0)
 """
 nsmallest(acc::Accumulator) = sort!(collect(acc), by=last, rev=false)
-nsmallest(acc::Accumulator, n) = select!(collect(acc), 1:n, by=last, rev=false)
+nsmallest(acc::Accumulator, n) = @compat partialsort!(collect(acc), 1:n, by=last, rev=false)
 
 
 

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -1,4 +1,4 @@
-# A counter type
+#A counter type
 
 struct Accumulator{T, V<:Number} <: AbstractDict{T,V}
     map::Dict{T,V}
@@ -138,14 +138,16 @@ Returns its former count.
 reset!(ct::Accumulator, x) = pop!(ct.map, x)
 
 """
-     most_common(acc::Accumulator, [k])
+     nlargest(acc::Accumulator, [n])
 
-Returns a sorted vector of the `k` most common elements, with their counts.
-If `k` is ommitted, the full sorted collection is returned.
+Returns a sorted vector of the `n` most common elements, with their counts.
+If `n` is omitted, the full sorted collection is returned.
+
+This corresponds to Python's `Counter.most_common` function.
 
 Example
 ```
-julia> most_common(counter("abbbccddddda"))
+julia> nlargest(counter("abbbccddddda"))
 
 4-element Array{Pair{Char,Int64},1}:
  'd'=>5
@@ -154,7 +156,7 @@ julia> most_common(counter("abbbccddddda"))
  'a'=>2
 
 
-julia> most_common(counter("abbbccddddda"),2)
+julia> nlargest(counter("abbbccddddda"),2)
 
 2-element Array{Pair{Char,Int64},1}:
  'd'=>5
@@ -162,8 +164,22 @@ julia> most_common(counter("abbbccddddda"),2)
 
 ```
 """
-most_common(acc::Accumulator) = sort(collect(acc), by=last, rev=true)
-most_common(acc::Accumulator, k) = select(collect(acc), 1:k, by=last, rev=true)
+nlargest(acc::Accumulator) = sort!(collect(acc), by=last, rev=true)
+nlargest(acc::Accumulator, n) = select!(collect(acc), 1:n, by=last, rev=true)
+
+
+"""
+     nsmallest(acc::Accumulator, [n])
+
+Returns a sorted vector of the `n` least common elements, with their counts.
+If `n` is omitted, the full sorted collection is returned.
+
+This is the opposite of the `nlargest` function.
+For obvious reasons this will not include zero counts for items not encountered.
+(unless those elements are added to he accumulator directly, eg via `acc[foo]=0)
+"""
+nsmallest(acc::Accumulator) = sort!(collect(acc), by=last, rev=false)
+nsmallest(acc::Accumulator, n) = select!(collect(acc), 1:n, by=last, rev=false)
 
 
 

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -137,6 +137,34 @@ Returns its former count.
 """
 reset!(ct::Accumulator, x) = pop!(ct.map, x)
 
+"""
+     most_common(acc::Accumulator, [k])
+
+Returns a sorted vector of the `k` most common elements, with their counts.
+If `k` is ommitted, the full sorted collection is returned.
+
+Example
+```
+julia> most_common(counter("abbbccddddda"))
+
+4-element Array{Pair{Char,Int64},1}:
+ 'd'=>5
+ 'b'=>3
+ 'c'=>2
+ 'a'=>2
+
+
+julia> most_common(counter("abbbccddddda"),2)
+
+2-element Array{Pair{Char,Int64},1}:
+ 'd'=>5
+ 'b'=>3
+
+```
+"""
+most_common(acc::Accumulator) = sort(collect(acc), by=last, rev=true)
+most_common(acc::Accumulator, k) = select(collect(acc), 1:k, by=last, rev=true)
+
 
 
 ## Deprecations

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -165,7 +165,7 @@ julia> nlargest(counter("abbbccddddda"),2)
 ```
 """
 nlargest(acc::Accumulator) = sort!(collect(acc), by=last, rev=true)
-nlargest(acc::Accumulator, n) = @compat partialsort!(collect(acc), 1:n, by=last, rev=true)
+nlargest(acc::Accumulator, n) = partialsort!(collect(acc), 1:n, by=last, rev=true)
 
 
 """
@@ -179,7 +179,7 @@ For obvious reasons this will not include zero counts for items not encountered.
 (unless those elements are added to he accumulator directly, eg via `acc[foo]=0)
 """
 nsmallest(acc::Accumulator) = sort!(collect(acc), by=last, rev=false)
-nsmallest(acc::Accumulator, n) = @compat partialsort!(collect(acc), 1:n, by=last, rev=false)
+nsmallest(acc::Accumulator, n) = partialsort!(collect(acc), 1:n, by=last, rev=false)
 
 
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -112,33 +112,44 @@
     @test ct6["b"] == 0
     @test ct6["c"] == 4
 
-    s = ["y", "el", "sol", "se", "fue"]
-    @test counter(length(x) for x in s) == counter(map(length, s))
 
+    @testset "Generators" begin
+        s = ["y", "el", "sol", "se", "fue"]
+        @test counter(length(x) for x in s) == counter(map(length, s))
+    end
 
-    # non-integer uses
-    acc = Accumulator(Symbol, Float16)
-    acc[:a] = 1.5
-    @test acc[:a] ≈ 1.5
-    push!(acc, :a, 2.5)
-    @test acc[:a] ≈ 4.0
-    dec!(acc, :a)
-    @test acc[:a] ≈ 3.0
+    @testset "non-integer uses" begin
+        acc = Accumulator(Symbol, Float16)
+        acc[:a] = 1.5
+        @test acc[:a] ≈ 1.5
+        push!(acc, :a, 2.5)
+        @test acc[:a] ≈ 4.0
+        dec!(acc, :a)
+        @test acc[:a] ≈ 3.0
+    end
 
-    # ambiguity resolution
-    ct7 = counter(Int)
-    @test_throws MethodError push!(ct7, 1=>2)
+    @testset "ambiguity resolution" begin
+        ct7 = counter(Int)
+        @test_throws MethodError push!(ct7, 1=>2)
+    end
 
+	@testset "most common" begin
+		@test most_common(counter("abbbccddddda")) == ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>2]
+		@test most_common(counter("abbbccddddda"),2) == ['d'=>5, 'b'=>3]
+		@test most_common(counter("a")) == ['a'=>1]
 
-    #deprecations
-    ctd = counter([1,2,3])
-    @test ctd[3]==1
+		@test_throws BoundsError most_common(counter("a"),2)
+	end
 
-    println("\nThe following warning is expected:")
-    @test pop!(ctd, 3)==1
-    println("\nThe following warning is expected:")
-    @test push!(counter([1,2,3]),counter([1,2,3])) == merge!(counter([1,2,3]), counter([1,2,3]))
+    @testset "deprecations" begin
+        ctd = counter([1,2,3])
+        @test ctd[3]==1
 
+        println("\nThe following warning is expected:")
+        @test pop!(ctd, 3)==1
+        println("\nThe following warning is expected:")
+        @test push!(counter([1,2,3]),counter([1,2,3])) == merge!(counter([1,2,3]), counter([1,2,3]))
+    end
 end # @testset Accumulators
 
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -30,7 +30,7 @@
     @test ct["b"] == 1
     dec!(ct, "b", 16)
     @test ct["b"] == -15
-    ct["b"] = 2     
+    ct["b"] = 2
 
     # Test convert
     inc!(ct, "b", 0x3)
@@ -134,9 +134,12 @@
     end
 
     @testset "nlargest" begin
-        @test nlargest(counter("abbbccddddda")) == ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>2]
+        @test nlargest(counter("abbbcddddda")) == ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>1]
         @test nlargest(counter("abbbccddddda"),2) == ['d'=>5, 'b'=>3]
         @test nlargest(counter("a")) == ['a'=>1]
+
+        @test nlargest(counter("aaabbcc")) ∈ (['a'=>3,'b'=>2, 'c'=>2], ['a'=>3,'c'=>2, 'b'=>2])
+
 
         @test_throws BoundsError nlargest(counter("a"),2)
     end
@@ -147,6 +150,8 @@
         @test nsmallest(acc,2) == ['a'=>2, 'b'=>3]
         acc['d']=0
         @test nsmallest(acc,2) == ['d'=>0, 'a'=>2]
+
+        @test nsmallest(counter("aaabbcc")) ∈ (['b'=>2, 'c'=>2, 'a'=>3], ['c'=>2, 'b'=>2, 'a'=>3])
 
         @test_throws BoundsError nsmallest(counter("a"),2)
     end

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -133,13 +133,23 @@
         @test_throws MethodError push!(ct7, 1=>2)
     end
 
-	@testset "most common" begin
-		@test most_common(counter("abbbccddddda")) == ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>2]
-		@test most_common(counter("abbbccddddda"),2) == ['d'=>5, 'b'=>3]
-		@test most_common(counter("a")) == ['a'=>1]
+    @testset "nlargest" begin
+        @test nlargest(counter("abbbccddddda")) == ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>2]
+        @test nlargest(counter("abbbccddddda"),2) == ['d'=>5, 'b'=>3]
+        @test nlargest(counter("a")) == ['a'=>1]
 
-		@test_throws BoundsError most_common(counter("a"),2)
-	end
+        @test_throws BoundsError nlargest(counter("a"),2)
+    end
+
+    @testset "nsmallest" begin
+        acc = counter("aabbbcccc")
+        @test nsmallest(acc) == ['a'=>2, 'b'=>3, 'c'=>4]
+        @test nsmallest(acc,2) == ['a'=>2, 'b'=>3]
+        acc['d']=0
+        @test nsmallest(acc,2) == ['d'=>0, 'a'=>2]
+
+        @test_throws BoundsError nsmallest(counter("a"),2)
+    end
 
     @testset "deprecations" begin
         ctd = counter([1,2,3])


### PR DESCRIPTION
This is basically #198 but with select and sort.
And up to date and without conflicts.

I left off optimising the `most_common(A, 1)` case, because that optimization should be done to
 `select` in Base.
I think
