### PR TITLE
Sorted containers -> new iteration protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 doc/build
 docs/build/
 docs/site/
+.gitignore
+*~
+

--- a/docs/src/sorted_containers.md
+++ b/docs/src/sorted_containers.md
@@ -71,7 +71,7 @@ then there may be a loss of performance compared to:
 k,v = deref((sc,st))
 ```
 
-because the former needs an extra heap allocation step for `tok`.
+because the former may need an extra heap allocation step for `tok`.
 
 The notion of token is similar to the concept of iterators used by C++
 standard containers. Tokens can be explicitly advanced or regressed
@@ -406,8 +406,8 @@ past-end token. Time: O(1)
 ## Iteration Over Sorted Containers
 
 As is standard in Julia, iteration over the containers is implemented
-via calls to three functions, `start`, `next` and `done`. It is usual
-practice, however, to call these functions implicitly with a for-loop
+via calls to the function `Base.iterate`. It is usual
+practice, however, to call this function implicitly with a for-loop
 rather than explicitly, so they are presented here in for-loop notation.
 Internally, all of these iterations are implemented with semitokens that
 are advanced via the `advance` operation. Each iteration of these loops
@@ -454,11 +454,13 @@ end
 ```
 
 Here, `st1` and `st2` are semitokens that refer to the container `sc`.
+Token `(sc,st1)` may not be the before-start token and
+token `(sc,st2)` may not be the past-end token.  
 It is acceptable for `(sc,st1)` to be the past-end token or `(sc,st2)`
-to be the before-start token (in these cases, the body is not executed).
+to be the before-start token or both (in these cases, the body is not executed).
 If `compare(sc,st1,st2)==1` then the body is not executed. A second
-calling format for `inclusive` is `inclusive(sc,(st1,st2))`. One purpose
-for second format is so that the return value of `searchequalrange` may
+calling format for `inclusive` is `inclusive(sc,(st1,st2))`. With
+the second format, the return value of `searchequalrange` may
 be used directly as the second argument to `inclusive`.
 
 One can also define a loop that excludes the final item:
@@ -771,10 +773,10 @@ Lt((x,y) -> isless(lowercase(x),lowercase(y)))
 The ordering object is indicated in the above list of constructors in
 the `o` position (see above for constructor syntax).
 
-This approach suffers from a performance hit (10%-50% depending on the
-container) because the compiler cannot inline or compute the correct
-dispatch for the function in parentheses, so the dispatch takes place at
-run-time. A more complicated but higher-performance method to implement
+This approach suffers may suffer from a performance hit because
+higher performance may be possibility if equality is available
+as well as less-than.
+A more complicated but higher-performance method to implement
 a custom ordering is as follows. First, the user creates a singleton
 type that is a subtype of `Ordering` as follows:
 
@@ -798,7 +800,7 @@ container also needs an equal-to function; the default is:
 eq(o::Ordering, a, b) = !lt(o, a, b) && !lt(o, b, a)
 ```
 
-For a further slight performance boost, the user can also customize this
+The user can also customize this
 function with a more efficient implementation. In the above example, an
 appropriate customization would be:
 

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -16,6 +16,12 @@ module DataStructures
                  union, intersect, symdiff, setdiff, issubset,
                  searchsortedfirst, searchsortedlast, in
 
+    if VERSION >= v"0.7.0-DEV.5126"
+        import Base: iterate, IteratorSize, HasLength, SizeUnknown,
+                   IteratorEltype, HasEltype
+    end
+    
+
     using Compat
     using Compat.InteractiveUtils # for methodswith
     import Compat: lastindex, pushfirst!, popfirst!

--- a/src/balanced_tree.jl
+++ b/src/balanced_tree.jl
@@ -17,7 +17,7 @@
 ##  d: the data of the node
 ##  parent: the tree leaf that is the parent of this
 ##    node.  Parent pointers are needed in order
-##    to implement indices.
+##    to implement tokens.
 ##  There are two constructors, the standard one (first)
 ##  and the incomplete one (second).  The incomplete constructor
 ##  is needed because when the data structure is first created,
@@ -80,14 +80,14 @@ end
 
 
 ## Type BalancedTree23{K,D,Ord} is 'base class' for
-## SortedDict.
+## SortedDict, SortedMultiDict and SortedSet.
 ## K = key type, D = data type
 ## Key type must support an ordering operation defined by Ordering
 ## object Ord.
 ## The default is Forward which implies that the ordering function
 ## is isless (see ordering.jl)
 ## The fields are as follows.
-## ord:: The ordering object.  Often the ordering type
+## ord: The ordering object.  Often the ordering type
 ##   is a singleton type, so this field is empty, but it
 ##   is still necessary to direct the multiple dispatch.
 ## data: the (key,data) pairs of the tree.
@@ -104,10 +104,10 @@ end
 ##    tree array (locations are freed due to deletion)
 ## freedatainds: Array of indices of free locations in the
 ##    data array (locations are freed due to deletion)
-## useddatacells: IntSet (i.e., bit vector) showing which
+## useddatacells: BitSet (i.e., bit vector) showing which
 ##    data cells are taken.  The complementary positions are
 ##    exactly those stored in freedatainds.  This array is
-##    used only for error checking (only present at debug level 1 and 2)
+##    used only for error checking.
 ## deletionchild and deletionleftkey are two work-arrays
 ## for the delete function.
 
@@ -119,7 +119,7 @@ mutable struct BalancedTree23{K, D, Ord <: Ordering}
     depth::Int
     freetreeinds::Array{Int,1}
     freedatainds::Array{Int,1}
-    useddatacells::IntSet
+    useddatacells::BitSet
     # The next two arrays are used as a workspace by the delete!
     # function.
     deletionchild::Array{Int,1}
@@ -129,7 +129,7 @@ mutable struct BalancedTree23{K, D, Ord <: Ordering}
         initializeTree!(tree1)
         data1 = Vector{KDRec{K,D}}(undef, 2)
         initializeData!(data1)
-        u1 = IntSet()
+        u1 = BitSet()
         push!(u1, 1, 2)
         new{K,D,Ord}(ord1, data1, tree1, 1, 1, Vector{Int}(), Vector{Int}(),
                      u1,
@@ -631,30 +631,30 @@ function compareInd(t::BalancedTree23, i1::Int, i2::Int)
     i2a = i2
     p1 = t.data[i1].parent
     p2 = t.data[i2].parent
-    curdepth = t.depth
+    # curdepth = t.depth
     while true
-        @assert(curdepth > 0)
+        # @assert(curdepth > 0)
         if p1 == p2
             if i1a == t.tree[p1].child1
-                @assert(t.tree[p1].child2 == i2a || t.tree[p1].child3 == i2a)
+                # @assert(t.tree[p1].child2 == i2a || t.tree[p1].child3 == i2a)
                 return -1
             end
             if i1a == t.tree[p1].child2
                 if (t.tree[p1].child1 == i2a)
                     return 1
                 end
-                @assert(t.tree[p1].child3 == i2a)
+                # @assert(t.tree[p1].child3 == i2a)
                 return -1
             end
-            @assert(i1a == t.tree[p1].child3)
-            @assert(t.tree[p1].child1 == i2a || t.tree[p1].child2 == i2a)
+            # @assert(i1a == t.tree[p1].child3)
+            # @assert(t.tree[p1].child1 == i2a || t.tree[p1].child2 == i2a)
             return 1
         end
         i1a = p1
         i2a = p2
         p1 = t.tree[i1a].parent
         p2 = t.tree[i2a].parent
-        curdepth -= 1
+        # curdepth -= 1
     end
 end
 

--- a/src/container_loops.jl
+++ b/src/container_loops.jl
@@ -1,7 +1,5 @@
-import Base.keys
-import Base.values
-
-## These are the containers that can be looped over
+## These functions define the possible iterations for the
+## sorted containers.
 ## The prefix SDM is for SortedDict and SortedMultiDict
 ## The prefix SS is for SortedSet.  The prefix SA
 ## is for all sorted containers.
@@ -10,7 +8,9 @@ import Base.values
 # const SDMContainer = Union{SortedDict, SortedMultiDict}
 # const SAContainer = Union{SDMContainer, SortedSet}
 
-@inline extractcontainer(s::SAContainer) = s
+extractcontainer(s::SAContainer) = s
+getrangeobj(s::SAContainer) = s
+
 
 ## This holds an object describing an exclude-last
 ## iteration.
@@ -25,6 +25,14 @@ struct SDMExcludeLast{ContainerType <: SDMContainer} <:
     pastlast::Int
 end
 
+keytype(::SDMExcludeLast{T}) where {T <: SAContainer} = keytype(T)
+keytype(::Type{SDMExcludeLast{T}}) where {T <: SAContainer} = keytype(T)
+valtype(::SDMExcludeLast{T}) where {T <: SAContainer} = valtype(T)
+valtype(::Type{SDMExcludeLast{T}}) where {T <: SAContainer} = valtype(T)
+eltype(::SDMExcludeLast{T}) where {T <: SAContainer} = eltype(T)
+eltype(::Type{SDMExcludeLast{T}}) where {T <: SAContainer} = eltype(T)
+
+
 struct SSExcludeLast{ContainerType <: SortedSet} <:
                               AbstractExcludeLast{ContainerType}
     m::ContainerType
@@ -32,14 +40,17 @@ struct SSExcludeLast{ContainerType <: SortedSet} <:
     pastlast::Int
 end
 
-@inline extractcontainer(s::AbstractExcludeLast) = s.m
-eltype(s::AbstractExcludeLast) = eltype(s.m)
+eltype(::SSExcludeLast{T}) where {T <: SortedSet} = eltype(T)
+eltype(::Type{SSExcludeLast{T}}) where {T <: SortedSet} = eltype(T)
+
+
+extractcontainer(s::AbstractExcludeLast) = s.m
+getrangeobj(s::AbstractExcludeLast) = s
 
 ## This holds an object describing an include-last
 ## iteration.
 
 abstract type AbstractIncludeLast{ContainerType <: SAContainer} end
-
 
 
 struct SDMIncludeLast{ContainerType <: SDMContainer} <:
@@ -49,6 +60,14 @@ struct SDMIncludeLast{ContainerType <: SDMContainer} <:
     last::Int
 end
 
+keytype(::SDMIncludeLast{T}) where {T <: SAContainer} = keytype(T)
+keytype(::Type{SDMIncludeLast{T}}) where {T <: SAContainer} = keytype(T)
+valtype(::SDMIncludeLast{T}) where {T <: SAContainer} = valtype(T)
+valtype(::Type{SDMIncludeLast{T}}) where {T <: SAContainer} = valtype(T)
+eltype(::SDMIncludeLast{T}) where {T <: SAContainer} = eltype(T)
+eltype(::Type{SDMIncludeLast{T}}) where {T <: SAContainer} = eltype(T)
+
+
 
 struct SSIncludeLast{ContainerType <: SortedSet} <:
                                AbstractIncludeLast{ContainerType}
@@ -57,8 +76,21 @@ struct SSIncludeLast{ContainerType <: SortedSet} <:
     last::Int
 end
 
-@inline extractcontainer(s::AbstractIncludeLast) = s.m
-eltype(s::AbstractIncludeLast) = eltype(s.m)
+eltype(::SSIncludeLast{T}) where {T <: SortedSet} = eltype(T)
+eltype(::Type{SSIncludeLast{T}}) where {T <: SortedSet} = eltype(T)
+
+
+
+
+extractcontainer(s::AbstractIncludeLast) = s.m
+getrangeobj(s::AbstractIncludeLast) = s
+
+if VERSION >= v"0.7.0-DEV.5126"
+    IteratorSize(::Type{T} where {T <: SAContainer}) = HasLength()
+    IteratorSize(::Type{T} where {T <: AbstractExcludeLast}) = SizeUnknown()
+    IteratorSize(::Type{T} where {T <: AbstractIncludeLast}) = SizeUnknown()
+end
+
 
 
 ## The basic iterations are either over the whole sorted container, an
@@ -87,54 +119,72 @@ struct SDMKeyIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SDMKeyIteration{T}}) where {T} = keytype(T)
 eltype(s::SDMKeyIteration) = keytype(extractcontainer(s.base))
-length(s::SDMKeyIteration) = length(extractcontainer(s.base))
+length(s::SDMKeyIteration{T} where T <: SDMContainer) = length(extractcontainer(s.base))
 
 
 struct SDMValIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SDMValIteration{T}}) where {T} = valtype(T)
 eltype(s::SDMValIteration) = valtype(extractcontainer(s.base))
-length(s::SDMValIteration) = length(extractcontainer(s.base))
+length(s::SDMValIteration{T} where T <: SDMContainer) = length(extractcontainer(s.base))
+
 
 
 struct SDMSemiTokenIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SDMSemiTokenIteration{T}}) where {T} =
+    Tuple{IntSemiToken, keytype(T), valtype(T)}
 eltype(s::SDMSemiTokenIteration) = Tuple{IntSemiToken,
                                          keytype(extractcontainer(s.base)),
                                          valtype(extractcontainer(s.base))}
+length(s::SDMSemiTokenIteration{T} where T <: SDMContainer) = length(s.base)
+
 
 struct SSSemiTokenIteration{T <: SSIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SSSemiTokenIteration{T}}) where {T} =
+    Tuple{IntSemiToken, eltype(T)}
 eltype(s::SSSemiTokenIteration) = Tuple{IntSemiToken,
                                         eltype(extractcontainer(s.base))}
+length(s::SSSemiTokenIteration{T} where T <: SortedSet) = length(s.base)
 
 
 struct SDMSemiTokenKeyIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SDMSemiTokenKeyIteration{T}}) where {T} =
+    Tuple{IntSemiToken,
+          keytype(T)}
 eltype(s::SDMSemiTokenKeyIteration) = Tuple{IntSemiToken,
                                             keytype(extractcontainer(s.base))}
+length(s::SDMSemiTokenKeyIteration{T} where T <: SDMContainer) = length(s.base)
 
 struct SAOnlySemiTokensIteration{T <: SAIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SAOnlySemiTokensIteration{T}} where {T}) = IntSemiToken
 eltype(::SAOnlySemiTokensIteration) = IntSemiToken
-
+length(s::SAOnlySemiTokensIteration{T} where T <: SAContainer) = length(s.base)
 
 struct SDMSemiTokenValIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
+eltype(::Type{SDMSemiTokenValIteration{T}}) where {T} =
+    Tuple{IntSemiToken, valtype(T)}
 eltype(s::SDMSemiTokenValIteration) = Tuple{IntSemiToken,
                                             valtype(extractcontainer(s.base))}
+length(s::SDMSemiTokenValIteration{T} where T <: SDMContainer) = length(s.base)
 
 const SACompoundIterable = Union{SDMKeyIteration,
                                  SDMValIteration,
@@ -144,10 +194,22 @@ const SACompoundIterable = Union{SDMKeyIteration,
                                  SDMSemiTokenValIteration,
                                  SAOnlySemiTokensIteration}
 
-@inline extractcontainer(s::SACompoundIterable) = extractcontainer(s.base)
-
+extractcontainer(s::SACompoundIterable) = extractcontainer(s.base)
+getrangeobj(s::SACompoundIterable) = getrangeobj(s.base)
 
 const SAIterable = Union{SAIterableTypesBase, SACompoundIterable}
+
+
+if VERSION >= v"0.7.0-DEV.5126"
+    IteratorEltype(::Type{T} where {T <: SAIterable}) = HasEltype()
+    IteratorSize(::Type{SDMKeyIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SDMValIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SDMSemiTokenIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SSSemiTokenIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SDMSemiTokenKeyIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SDMSemiTokenValIteration{T}}) where {T} = IteratorSize(T)
+    IteratorSize(::Type{SAOnlySemiTokensIteration{T}}) where {T} = IteratorSize(T)
+end
 
 
 ## All the loops maintain a state which is an object of the
@@ -159,167 +221,217 @@ struct SAIterationState
 end
 
 
-## All the loops have the same method for 'done'
-
-@inline done(::SAIterable, state::SAIterationState) = state.next == state.final
-
-
-@inline exclusive(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) where {T <: SDMContainer} =
+exclusive(m::SDMContainer, ii::Tuple{IntSemiToken,IntSemiToken}) =
     SDMExcludeLast(m, ii[1].address, ii[2].address)
-
-@inline exclusive(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) where {T <: SortedSet} =
+exclusive(m::SortedSet, ii::Tuple{IntSemiToken,IntSemiToken}) =
     SSExcludeLast(m, ii[1].address, ii[2].address)
+exclusive(m::SAContainer, i1::IntSemiToken, i2::IntSemiToken) =
+    exclusive(m, (i1, i2))
 
-@inline exclusive(m::T, i1::IntSemiToken, i2::IntSemiToken) where {T <: SAContainer} =
-    exclusive(m, (i1,i2))
-
-@inline inclusive(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) where {T <: SDMContainer} =
+inclusive(m::SDMContainer, ii::Tuple{IntSemiToken,IntSemiToken}) =
     SDMIncludeLast(m, ii[1].address, ii[2].address)
-
-@inline inclusive(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) where {T <: SortedSet} =
+inclusive(m::SortedSet, ii::Tuple{IntSemiToken,IntSemiToken}) =
     SSIncludeLast(m, ii[1].address, ii[2].address)
-
-@inline inclusive(m::T, i1::IntSemiToken, i2::IntSemiToken) where {T <: SAContainer} =
-    inclusive(m, (i1,i2))
-
+inclusive(m::SAContainer, i1::IntSemiToken, i2::IntSemiToken) =
+    inclusive(m, (i1, i2))
 
 
 # Next definition needed to break ambiguity with keys(AbstractDict) from Dict.jl
 
-@inline keys(ba::SortedDict{K,D,Ord}) where {K, D, Ord <: Ordering} = SDMKeyIteration(ba)
-@inline keys(ba::T) where {T <: SDMIterableTypesBase} = SDMKeyIteration(ba)
+keys(ba::SortedDict) = SDMKeyIteration(ba)
+keys(ba::SDMIterableTypesBase) = SDMKeyIteration(ba)
 
 
-in(k, keyit::SDMKeyIteration{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} =
+in(k, keyit::SDMKeyIteration{SortedDict{K,D,Ord}} where {K,D,Ord}) =
     haskey(extractcontainer(keyit.base), k)
 
-in(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) where {K,D,Ord <: Ordering} =
+in(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}} where {K,D,Ord}) =
     haskey(extractcontainer(keyit.base), k)
-
 
 
 # Next definition needed to break ambiguity with values(AbstractDict) from Dict.jl
-@inline values(ba::SortedDict{K,D,Ord}) where {K, D, Ord <: Ordering} = SDMValIteration(ba)
-@inline values(ba::T) where {T <: SDMIterableTypesBase} = SDMValIteration(ba)
-@inline semitokens(ba::T) where {T <: SDMIterableTypesBase} = SDMSemiTokenIteration(ba)
-@inline semitokens(ba::T) where {T <: SSIterableTypesBase} = SSSemiTokenIteration(ba)
-@inline semitokens(ki::SDMKeyIteration{T}) where {T <: SDMIterableTypesBase} =
-                   SDMSemiTokenKeyIteration(ki.base)
-@inline semitokens(vi::SDMValIteration{T}) where {T <: SDMIterableTypesBase} =
-                   SDMSemiTokenValIteration(vi.base)
-@inline onlysemitokens(ba::T) where {T <: SAIterableTypesBase} = SAOnlySemiTokensIteration(ba)
+values(ba::SortedDict) = SDMValIteration(ba)
+values(ba::SDMIterableTypesBase) = SDMValIteration(ba)
+semitokens(ba::SDMIterableTypesBase) = SDMSemiTokenIteration(ba)
+semitokens(ba::SSIterableTypesBase) = SSSemiTokenIteration(ba)
+semitokens(ki::SDMKeyIteration) = SDMSemiTokenKeyIteration(ki.base)
+semitokens(vi::SDMValIteration) = SDMSemiTokenValIteration(vi.base)
+onlysemitokens(ba::SAIterableTypesBase) = SAOnlySemiTokensIteration(ba)
 
 
 
-@inline start(m::SAContainer) = SAIterationState(nextloc0(m.bt,1), 2)
-@inline start(e::SACompoundIterable) = start(e.base)
+if VERSION >= v"0.7.0-DEV.5126"
+    
+    function nexthelper(c::SAContainer, state::SAIterationState)
+        sn = state.next
+        (sn < 3 || !(sn in c.bt.useddatacells)) && throw(BoundsError())
+        SAIterationState(nextloc0(c.bt, sn), state.final)
+    end
 
-function start(e::AbstractExcludeLast)
-    (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
-        !(e.pastlast in e.m.bt.useddatacells)) &&
-        throw(BoundsError())
-    if compareInd(e.m.bt, e.first, e.pastlast) < 0
-        return SAIterationState(e.first, e.pastlast)
-    else
-        return SAIterationState(2, 2)
+
+    
+    getitem(::SDMIterableTypesBase, dt, sn) = dt.k => dt.d
+    getitem(::SSIterableTypesBase, dt, sn) = dt.k
+    getitem(::SDMKeyIteration, dt, sn) = dt.k
+    getitem(::SDMValIteration, dt, sn) = dt.d
+    getitem(::SDMSemiTokenIteration, dt, sn) = (IntSemiToken(sn), dt.k, dt.d) 
+    getitem(::SSSemiTokenIteration, dt, sn) = (IntSemiToken(sn), dt.k)
+    getitem(::SDMSemiTokenKeyIteration, dt, sn) = (IntSemiToken(sn), dt.k)
+    getitem(::SDMSemiTokenValIteration, dt, sn) = (IntSemiToken(sn), dt.d)
+    getitem(::SAOnlySemiTokensIteration, dt, sn) = IntSemiToken(sn)
+
+
+    function get_init_state(e::AbstractExcludeLast)
+        (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
+         !(e.pastlast in e.m.bt.useddatacells)) &&
+         throw(BoundsError())
+        if compareInd(e.m.bt, e.first, e.pastlast) < 0
+            return SAIterationState(e.first, e.pastlast)
+        else
+            return SAIterationState(2, 2)
+        end
+    end
+
+    function get_init_state(e::AbstractIncludeLast)
+        (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
+         !(e.last in e.m.bt.useddatacells) || e.last == 2) &&
+         throw(BoundsError())
+        if compareInd(e.m.bt, e.first, e.last) <= 0
+            return SAIterationState(e.first, nextloc0(e.m.bt, e.last))
+        else
+            return SAIterationState(2, 2)
+        end
+    end
+
+    get_init_state(m::SAContainer) = SAIterationState(beginloc(m.bt), 2)
+
+    function iterate(s::SAIterable, state = get_init_state(getrangeobj(s)))
+        if state.next == state.final
+            return nothing
+        else
+            c = extractcontainer(s)
+            dt = isa(s, SAOnlySemiTokensIteration) ? nothing : c.bt.data[state.next]
+            return (getitem(s, dt, state.next),
+                    nexthelper(c, state))
+        end
+    end
+
+
+else  # Julia version 0.6.x and early versions of 0.7.0-DEV
+
+    done(::SAIterable, state::SAIterationState) = state.next == state.final
+    
+    start(m::SAContainer) = SAIterationState(nextloc0(m.bt,1), 2)
+    start(e::SACompoundIterable) = start(e.base)
+
+
+    function start(e::AbstractExcludeLast)
+        (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
+         !(e.pastlast in e.m.bt.useddatacells)) &&
+         throw(BoundsError())
+        if compareInd(e.m.bt, e.first, e.pastlast) < 0
+            return SAIterationState(e.first, e.pastlast)
+        else
+            return SAIterationState(2, 2)
+        end
+    end
+
+    
+    function start(e::AbstractIncludeLast)
+        (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
+         !(e.last in e.m.bt.useddatacells) || e.last == 2) &&
+         throw(BoundsError())
+        if compareInd(e.m.bt, e.first, e.last) <= 0
+            return SAIterationState(e.first, nextloc0(e.m.bt, e.last))
+        else
+            return SAIterationState(2, 2)
+        end
+    end
+    
+    
+    ## The 'next' function returns different objects depending on whether
+    ## it is a basic iteration, a key iteration, a values iterations,
+    ## a semitokens/basic iteration, a semitokens/key iteration, or semitokens/values
+    ## iteration.
+    
+    function next(u::SAOnlySemiTokensIteration, state::SAIterationState)
+        sn = state.next
+        (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
+        IntSemiToken(sn),
+        SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
+    end
+    
+    
+    function nexthelper(u, state::SAIterationState)
+        sn = state.next
+        (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
+        extractcontainer(u).bt.data[sn], sn,
+        SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
+    end
+    
+    
+    function next(u::SDMIterableTypesBase, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        (dt.k => dt.d), ni
+    end
+    
+    
+    function next(u::SSIterableTypesBase, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        dt.k, ni
+    end
+    
+    
+    function next(u::SDMKeyIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        dt.k, ni
+    end
+    
+    function next(u::SDMValIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        dt.d, ni
+    end
+    
+    
+    function next(u::SDMSemiTokenIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        (IntSemiToken(t), dt.k, dt.d), ni
+    end
+    
+    
+    function next(u::SSSemiTokenIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        (IntSemiToken(t), dt.k), ni
+    end
+    
+    function next(u::SDMSemiTokenKeyIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        (IntSemiToken(t), dt.k), ni
+    end
+    
+    
+    function next(u::SDMSemiTokenValIteration, state::SAIterationState)
+        dt, t, ni = nexthelper(u, state)
+        (IntSemiToken(t), dt.d), ni
     end
 end
 
-function start(e::AbstractIncludeLast)
-    (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
-        !(e.last in e.m.bt.useddatacells) || e.last == 2) &&
-        throw(BoundsError())
-    if compareInd(e.m.bt, e.first, e.last) <= 0
-        return SAIterationState(e.first, nextloc0(e.m.bt, e.last))
-    else
-        return SAIterationState(2, 2)
-    end
-end
 
-
-## The 'next' function returns different objects depending on whether
-## it is a basic iteration, a key iteration, a values iterations,
-## a semitokens/basic iteration, a semitokens/key iteration, or semitokens/values
-## iteration.
-
-@inline function next(u::SAOnlySemiTokensIteration, state::SAIterationState)
-    sn = state.next
-    (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    IntSemiToken(sn),
-    SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
-end
-
-
-@inline function nexthelper(u, state::SAIterationState)
-    sn = state.next
-    (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    extractcontainer(u).bt.data[sn], sn,
-    SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
-end
-
-
-
-
-
-@inline function next(u::SDMIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (dt.k => dt.d), ni
-end
-
-
-@inline function next(u::SSIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.k, ni
-end
-
-
-@inline function next(u::SDMKeyIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.k, ni
-end
-
-@inline function next(u::SDMValIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.d, ni
-end
-
-
-@inline function next(u::SDMSemiTokenIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k, dt.d), ni
-end
-
-
-@inline function next(u::SSSemiTokenIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k), ni
-end
-
-@inline function next(u::SDMSemiTokenKeyIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k), ni
-end
-
-
-@inline function next(u::SDMSemiTokenValIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.d), ni
-end
 
 
 eachindex(sd::SortedDict) = keys(sd)
 eachindex(sdm::SortedMultiDict) = onlysemitokens(sdm)
 eachindex(ss::SortedSet) = onlysemitokens(ss)
-eachindex(sd::SDMExcludeLast{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} = keys(sd)
-eachindex(smd::SDMExcludeLast{SortedMultiDict{K,D,Ord}}) where {K,D,Ord <: Ordering} =
+eachindex(sd::SDMExcludeLast{SortedDict{K,D,Ord}} where {K,D,Ord <: Ordering}) = keys(sd)
+eachindex(smd::SDMExcludeLast{SortedMultiDict{K,D,Ord}} where {K,D,Ord <: Ordering}) =
      onlysemitokens(smd)
 eachindex(ss::SSExcludeLast) = onlysemitokens(ss)
-eachindex(sd::SDMIncludeLast{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} = keys(sd)
-eachindex(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) where {K,D,Ord <: Ordering} =
+eachindex(sd::SDMIncludeLast{SortedDict{K,D,Ord}} where {K,D,Ord <: Ordering}) = keys(sd)
+eachindex(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}} where {K,D,Ord <: Ordering}) =
      onlysemitokens(smd)
 eachindex(ss::SSIncludeLast) = onlysemitokens(ss)
 
 
 empty!(m::SAContainer) =  empty!(m.bt)
-@inline length(m::SAContainer) = length(m.bt.data) - length(m.bt.freedatainds) - 2
-@inline isempty(m::SAContainer) = length(m) == 0
+length(m::SAContainer) = length(m.bt.data) - length(m.bt.freedatainds) - 2
+isempty(m::SAContainer) = length(m) == 0

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -14,6 +14,7 @@ lt(::CaseInsensitive, a, b) = isless(lowercase(a), lowercase(b))
 eq(::CaseInsensitive, a, b) = isequal(lowercase(a), lowercase(b))
 
 
+
 @testset "SortedContainers" begin
 
 ## Function fulldump dumps the entire tree; helpful for debugging.
@@ -98,7 +99,7 @@ function checkcorrectness(t::DataStructures.BalancedTree23{K,D,Ord},
     r = t.rootloc
     bfstreenodes = Vector{Int}()
     tdpth = t.depth
-    intree = IntSet()
+    intree = BitSet()
     levstart = Vector{Int}(undef, tdpth)
     push!(bfstreenodes, r)
     levstart[1] = 1
@@ -131,7 +132,7 @@ function checkcorrectness(t::DataStructures.BalancedTree23{K,D,Ord},
         end
     end
     bfstreesize = size(bfstreenodes, 1)
-    dataused = IntSet()
+    dataused = BitSet()
     minkeys = Vector{K}(undef, bfstreesize)
     maxkeys = Vector{K}(undef, bfstreesize)
     for s = levstart[tdpth] : bfstreesize
@@ -230,7 +231,7 @@ function checkcorrectness(t::DataStructures.BalancedTree23{K,D,Ord},
             end
         end
     end
-    freedata = IntSet()
+    freedata = BitSet()
     for i = 1 : size(t.freedatainds,1)
         fdi = t.freedatainds[i]
         if in(fdi, freedata)
@@ -254,7 +255,7 @@ function checkcorrectness(t::DataStructures.BalancedTree23{K,D,Ord},
             throw(ErrorException("Mismatch between t.freedatainds and t.useddatacells"))
         end
     end
-    freetree = IntSet()
+    freetree = BitSet()
     for i = 1 : size(t.freetreeinds,1)
         tfi = t.freetreeinds[i]
         if in(tfi, freetree)
@@ -636,7 +637,9 @@ end
         end
     end
     @test eltype(semitokens(exclusive(m1, startof(m1), pastendsemitoken(m1)))) ==
-    Tuple{IntSemiToken, T, T}
+        Tuple{IntSemiToken, T, T}
+    @test eltype(typeof(semitokens(exclusive(m1, startof(m1), pastendsemitoken(m1))))) ==
+        Tuple{IntSemiToken, T, T}
     @test count == N^2
     N = 10000
     sk = zero1
@@ -666,10 +669,12 @@ end
     @test sk2 == sk
     @test sv == sv2
     sk2 = zero1
+    @test length(keys(m1)) == length(m1)
     for k in keys(m1)
         sk2 += k
     end
     @test eltype(keys(m1)) == T
+    @test eltype(typeof(keys(m1))) == T
     @test sk2 == sk
 
     sk2a = zero1
@@ -679,11 +684,16 @@ end
         sk2a += k
     end
     @test eltype(eachindex(m1)) == T
+    @test eltype(typeof(eachindex(m1))) == T
+    @test length(eachindex(m1)) == length(m1)
     @test sk2a == sk
 
 
 
     sk2b = zero1
+    @test length(onlysemitokens(m1)) == length(m1)
+    @test eltype(onlysemitokens(m1)) == IntSemiToken
+    @test eltype(typeof(onlysemitokens(m1))) == IntSemiToken
     for st in onlysemitokens(m1)
         sk2b += deref_key((m1,st))
     end
@@ -694,6 +704,8 @@ end
         sv2 += v
     end
     @test eltype(values(m1)) == T
+    @test eltype(typeof(values(m1))) == T
+    @test length(values(m1)) == length(m1)
 
     @test sv == sv2
     count = 0
@@ -702,6 +714,8 @@ end
         count += 1
     end
     @test eltype(semitokens(keys(m1))) == Tuple{IntSemiToken, T}
+    @test eltype(typeof(semitokens(keys(m1)))) == Tuple{IntSemiToken, T}
+    @test length(semitokens(keys(m1))) == length(m1)
 
     @test count == N
     count = 0
@@ -711,6 +725,8 @@ end
     end
     @test count == N
     @test eltype(semitokens(values(m1))) == Tuple{IntSemiToken, T}
+    @test eltype(typeof(semitokens(values(m1)))) == Tuple{IntSemiToken, T}
+    @test length(semitokens(values(m1))) == length(m1)
 
     pos1 = searchsortedfirst(m1, div(N,2))
     sk2 = zero1
@@ -719,6 +735,7 @@ end
     end
     @test sk2 == skhalf
     @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
+    @test eltype(typeof(keys(exclusive(m1, startof(m1), pos1)))) == T
 
 
 
@@ -728,6 +745,7 @@ end
     end
     @test sk2a == skhalf
     @test eltype(eachindex(exclusive(m1, startof(m1), pos1))) == T
+    @test eltype(typeof(eachindex(exclusive(m1, startof(m1), pos1)))) == T
 
 
 
@@ -741,6 +759,7 @@ end
         count += 1
     end
     @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
+    @test eltype(typeof(keys(exclusive(m1, startof(m1), pos1)))) == T
     @test count == 0
 
 
@@ -750,6 +769,8 @@ end
     end
     @test count == 0
     @test eltype(keys(inclusive(m1, startof(m1), beforestartsemitoken(m1)))) ==
+       T
+    @test eltype(typeof(keys(inclusive(m1, startof(m1), beforestartsemitoken(m1))))) ==
        T
 
 
@@ -761,6 +782,7 @@ end
     end
     @test count == 1 && sk5 == deref_key((m1,startof(m1)))
     @test eltype(eachindex(inclusive(m1, startof(m1), startof(m1)))) == T
+    @test eltype(typeof(eachindex(inclusive(m1, startof(m1), startof(m1))))) == T
 
     factors = SortedMultiDict{Int,Int}()
     N = 1000
@@ -786,9 +808,6 @@ end
     @test sum1a == sum1 && sum2a == sum2
 
 
-
-
-
     sum1a = 0
     sum2a = 0
     for st in eachindex(factors)
@@ -797,6 +816,9 @@ end
         sum2a += v
     end
     @test sum1a == sum1 && sum2a == sum2
+    @test length(eachindex(factors)) == length(factors)
+    @test eltype(eachindex(factors)) == IntSemiToken
+    @test eltype(typeof(eachindex(factors))) == IntSemiToken
 
     sum1a = 0
     sum2a = 0
@@ -806,7 +828,9 @@ end
         sum2a += v
     end
     @test sum1a == sum1 && sum2a == sum2
+    @test length(onlysemitokens(factors)) == length(factors)
     @test eltype(onlysemitokens(factors)) == IntSemiToken
+    @test eltype(typeof(onlysemitokens(factors))) == IntSemiToken
 
     sum2 = 0
     for (k,v) in inclusive(factors,
@@ -819,6 +843,9 @@ end
     @test eltype(inclusive(factors,
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == Pair{Int,Int}
+    @test eltype(typeof(inclusive(factors,
+                                  searchsortedfirst(factors,70),
+                                  searchsortedlast(factors,70)))) == Pair{Int,Int}
 
 
     sum2 = 0
@@ -833,6 +860,9 @@ end
     @test eltype(eachindex(inclusive(factors,
                                      searchsortedfirst(factors,70),
                                      searchsortedlast(factors,70)))) == IntSemiToken
+    @test eltype(typeof(eachindex(inclusive(factors,
+                                            searchsortedfirst(factors,70),
+                                            searchsortedlast(factors,70))))) == IntSemiToken
 
 
 
@@ -846,6 +876,9 @@ end
     @test eltype(exclusive(factors,
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == Pair{Int,Int}
+    @test eltype(typeof(exclusive(factors,
+                                  searchsortedfirst(factors,70),
+                                  searchsortedlast(factors,70)))) == Pair{Int,Int}
 
 
     sum3 = 0
@@ -859,6 +892,9 @@ end
     @test eltype(eachindex(exclusive(factors,
                                      searchsortedfirst(factors,70),
                                      searchsortedlast(factors,70)))) == IntSemiToken
+    @test eltype(typeof(eachindex(exclusive(factors,
+                                            searchsortedfirst(factors,70),
+                                            searchsortedlast(factors,70))))) == IntSemiToken
 
 
     sum4 = 0
@@ -878,6 +914,7 @@ end
 
     @test sum5 == sum2a
     @test eltype(values(factors)) == Int
+    @test eltype(typeof(values(factors))) == Int
 
     sum2 = 0
     for k in keys(inclusive(factors,
@@ -889,6 +926,9 @@ end
     @test eltype(keys(inclusive(factors,
                                 searchsortedfirst(factors,70),
                                 searchsortedlast(factors,70)))) ==  Int
+    @test eltype(typeof(keys(inclusive(factors,
+                                       searchsortedfirst(factors,70),
+                                       searchsortedlast(factors,70))))) ==  Int
 
 
     sum3 = 0
@@ -902,6 +942,10 @@ end
                                 searchsortedfirst(factors,60),
                                 searchsortedfirst(factors,61)))) == Int
 
+    @test eltype(typeof(keys(exclusive(factors,
+                                       searchsortedfirst(factors,60),
+                                       searchsortedfirst(factors,61))))) == Int
+
 
 
     sum2 = 0
@@ -914,6 +958,9 @@ end
     @test eltype(values(inclusive(factors,
                                   searchsortedfirst(factors,60),
                                   searchsortedfirst(factors,61)))) == Int
+    @test eltype(typeof(values(inclusive(factors,
+                                         searchsortedfirst(factors,60),
+                                         searchsortedfirst(factors,61))))) == Int
 
     sum3 = 0
     for v in values(exclusive(factors,
@@ -925,6 +972,9 @@ end
     @test eltype(values(exclusive(factors,
                                   searchsortedfirst(factors,60),
                                   searchsortedfirst(factors,61)))) == Int
+    @test eltype(typeof(values(exclusive(factors,
+                                         searchsortedfirst(factors,60),
+                                         searchsortedfirst(factors,61))))) == Int
 
     sum1b = 0
     sum2b = 0
@@ -935,6 +985,7 @@ end
     end
     @test sum1b == sum1a && sum2b == sum2a
     @test eltype(semitokens(factors)) == Tuple{IntSemiToken, Int, Int}
+    @test eltype(typeof(semitokens(factors))) == Tuple{IntSemiToken, Int, Int}
 
     sum2 = 0
     for (st,k,v) in semitokens(inclusive(factors,
@@ -947,6 +998,10 @@ end
     @test eltype(semitokens(inclusive(factors,
                                          searchsortedfirst(factors,70),
                                          searchsortedlast(factors,70)))) ==
+        Tuple{IntSemiToken, Int, Int}
+    @test eltype(typeof(semitokens(inclusive(factors,
+                                         searchsortedfirst(factors,70),
+                                         searchsortedlast(factors,70))))) ==
         Tuple{IntSemiToken, Int, Int}
 
     sum3 = 0
@@ -962,6 +1017,11 @@ end
                                       searchsortedfirst(factors,61)))) ==
          Tuple{IntSemiToken, Int, Int}
 
+    @test eltype(typeof(semitokens(exclusive(factors,
+                                             searchsortedfirst(factors,60),
+                                             searchsortedfirst(factors,61))))) ==
+         Tuple{IntSemiToken, Int, Int}
+
     sum4 = 0
     for (st,k) in semitokens(keys(factors))
         @test deref_key((factors,st)) == k && mod(k,deref_value((factors,st))) == 0
@@ -969,6 +1029,7 @@ end
     end
     @test sum4 == sum1
     @test eltype(semitokens(keys(factors))) == Tuple{IntSemiToken,Int}
+    @test eltype(typeof(semitokens(keys(factors)))) == Tuple{IntSemiToken,Int}
 
     sum5 = 0
     for (st,v) in semitokens(values(factors))
@@ -977,6 +1038,7 @@ end
     end
     @test sum5 == sum2a
     @test eltype(semitokens(values(factors))) == Tuple{IntSemiToken,Int}
+    @test eltype(typeof(semitokens(values(factors)))) == Tuple{IntSemiToken,Int}
 
     sum2 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
@@ -991,6 +1053,11 @@ end
                                            searchsortedlast(factors,70))))) ==
         Tuple{IntSemiToken, Int}
 
+    @test eltype(typeof(semitokens(keys(inclusive(factors,
+                                           searchsortedfirst(factors,70),
+                                           searchsortedlast(factors,70)))))) ==
+        Tuple{IntSemiToken, Int}
+
     sum3 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
                                             searchsortedfirst(factors,60),
@@ -1002,6 +1069,10 @@ end
     @test eltype(semitokens(keys(inclusive(factors,
                                             searchsortedfirst(factors,60),
                                             searchsortedlast(factors,60))))) ==
+        Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(keys(inclusive(factors,
+                                                  searchsortedfirst(factors,60),
+                                                  searchsortedlast(factors,60)))))) ==
         Tuple{IntSemiToken, Int}
 
     sum2 = 0
@@ -1016,6 +1087,10 @@ end
                                               searchsortedfirst(factors,70),
                                               searchsortedlast(factors,70))))) ==
       Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(values(inclusive(factors,
+                                                    searchsortedfirst(factors,70),
+                                                    searchsortedlast(factors,70)))))) ==
+      Tuple{IntSemiToken, Int}
 
     sum3 = 0
     for (st,v) in semitokens(values(exclusive(factors,
@@ -1028,6 +1103,10 @@ end
     @test eltype(semitokens(values(exclusive(factors,
                                               searchsortedfirst(factors,60),
                                               searchsortedfirst(factors,61))))) ==
+       Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(values(exclusive(factors,
+                                              searchsortedfirst(factors,60),
+                                              searchsortedfirst(factors,61)))))) ==
        Tuple{IntSemiToken, Int}
 
     s = SortedSet([39, 24, 2, 14, 45, 107, 66])
@@ -1044,7 +1123,9 @@ end
         sum1 += k
     end
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
+    @test length(semitokens(s)) == length(s)
     @test eltype(semitokens(s)) == Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(s))) == Tuple{IntSemiToken, Int}
 
 
     sum1 = 0
@@ -1052,8 +1133,10 @@ end
         k = deref((s,st))
         sum1 += k
     end
+    @test length(onlysemitokens(s)) == length(s)
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
     @test eltype(onlysemitokens(s)) == IntSemiToken
+    @test eltype(typeof(onlysemitokens(s))) == IntSemiToken
 
 
     sum1 = 0
@@ -1062,7 +1145,9 @@ end
         sum1 += k
     end
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
+    @test length(eachindex(s)) == length(s)
     @test eltype(eachindex(s)) == IntSemiToken
+    @test eltype(typeof(eachindex(s))) == IntSemiToken
 
 
     sum2 = 0
@@ -1075,6 +1160,9 @@ end
     @test eltype(inclusive(s,
                        searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))) == Int
+    @test eltype(typeof(inclusive(s,
+                                  searchsortedfirst(s, 24),
+                                  searchsortedfirst(s, 66)))) == Int
 
 
     sum2 = 0
@@ -1087,8 +1175,9 @@ end
     @test eltype(eachindex(inclusive(s,
                                      searchsortedfirst(s, 24),
                                      searchsortedfirst(s, 66)))) == IntSemiToken
-
-
+    @test eltype(typeof(eachindex(inclusive(s,
+                                            searchsortedfirst(s, 24),
+                                            searchsortedfirst(s, 66))))) == IntSemiToken
 
 
     sum2 = 0
@@ -1100,9 +1189,13 @@ end
     end
     @test sum2 == 24 + 39 + 45 + 66
     @test eltype(semitokens(inclusive(s,
-                                       searchsortedfirst(s, 24),
-                                       searchsortedfirst(s, 66)))) ==
-      Tuple{IntSemiToken, Int}
+                                      searchsortedfirst(s, 24),
+                                      searchsortedfirst(s, 66)))) ==
+                                          Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(inclusive(s,
+                                         searchsortedfirst(s, 24),
+                                         searchsortedfirst(s, 66))))) ==
+                                             Tuple{IntSemiToken, Int}
 
 
     sum2 = 0
@@ -1115,6 +1208,10 @@ end
     @test eltype(onlysemitokens(inclusive(s,
                                           searchsortedfirst(s, 24),
                                           searchsortedfirst(s, 66)))) == IntSemiToken
+
+    @test eltype(typeof(onlysemitokens(inclusive(s,
+                                          searchsortedfirst(s, 24),
+                                          searchsortedfirst(s, 66))))) == IntSemiToken
 
 
 
@@ -1130,6 +1227,10 @@ end
                        searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))) == Int
 
+    @test eltype(typeof(exclusive(s,
+                       searchsortedfirst(s, 24),
+                       searchsortedfirst(s, 66)))) == Int
+
 
     sum3 = 0
     for (st,k) in semitokens(exclusive(s,
@@ -1143,6 +1244,10 @@ end
                                        searchsortedfirst(s, 24),
                                        searchsortedfirst(s, 66)))) ==
      Tuple{IntSemiToken, Int}
+    @test eltype(typeof(semitokens(exclusive(s,
+                                       searchsortedfirst(s, 24),
+                                       searchsortedfirst(s, 66))))) ==
+     Tuple{IntSemiToken, Int}
 
 
     sum3 = 0
@@ -1155,6 +1260,9 @@ end
     @test eltype(eachindex(exclusive(s,
                                      searchsortedfirst(s, 24),
                                      searchsortedfirst(s, 66)))) == IntSemiToken
+    @test eltype(typeof(eachindex(exclusive(s,
+                                            searchsortedfirst(s, 24),
+                                            searchsortedfirst(s, 66))))) == IntSemiToken
 end
 
 
@@ -1167,13 +1275,25 @@ end
     m2 = SortedDict{String,Int}()
     @test_throws BoundsError println(first(m2))
     @test_throws BoundsError println(last(m2))
-    state1 = start(m2)
-    @test_throws BoundsError next(m2, state1)
+    if VERSION < v"0.7.0-DEV.5126"
+        state1 = start(m2)
+        @test_throws BoundsError next(m2, state1)
+    end
     i1 = findkey(m,"a")
-    delete!((m,i1))
-    i2 = findkey(m,"bb")
-    @test_throws BoundsError start(inclusive(m,i1,i2))
-    @test_throws BoundsError start(exclusive(m,i1,i2))
+    if VERSION >= v"0.7.0-DEV.5126"
+        scrap, state1 = iterate(m)
+        delete!((m,i1))
+        i2 = findkey(m,"bb")
+        @test_throws BoundsError iterate(inclusive(m, i1, i2))
+        @test_throws BoundsError iterate(exclusive(m, i1, i2))
+        delete!((m,i2))
+        @test_throws BoundsError iterate(m, state1)
+    else
+        delete!((m,i1))
+        i2 = findkey(m,"bb")
+        @test_throws BoundsError start(inclusive(m,i1,i2))
+        @test_throws BoundsError start(exclusive(m,i1,i2))
+    end
     @test_throws KeyError delete!(m,"a")
     @test_throws KeyError pop!(m,"a")
     m3 = SortedDict((Dict{String, Int}()), Reverse)


### PR DESCRIPTION
 On branch newiterationsortedcontainers
 Changes to be committed:
	modified:   ../docs/src/sorted_containers.md
	modified:   DataStructures.jl
	modified:   balanced_tree.jl
	modified:   container_loops.jl
	modified:   ../test/test_sorted_containers.jl

This commit updates container_loops.jl to use the new iteration protocol
(introduced in 0.7.0-DEV). It should be backwards compatible with 0.6.2.

In addition, it fixes a bug in container_loops.jl in which the length()
function when applied to subranges (i.e.,  inclusive(a,b,c) or
exclusive(a,b,c)) returned the length of the whole container instead
of the length of the subrange.  (There should be no value returned
for the length of the subrange since the data structure does not support
an O(1) algorithm or even O(log n) algorithm to compute the length.)

Some other smaller changes in this commit are as follows.
 - IntSet was changed to BitSet (name change in 0.7.0-DEV)
 - Small updates to documentation
 - Some assert statements in balanced_tree.jl that were present
   during development are deleted.