### PR TITLE
sprinkle at-inline and at-propagate_inbounds around

### DIFF
--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -15,14 +15,14 @@ function Base.empty!(cb::CircularBuffer)
     cb
 end
 
-function _buffer_index_checked(cb::CircularBuffer, i::Int)
-    if i < 1 || i > cb.length
+Base.@propagate_inbounds function _buffer_index_checked(cb::CircularBuffer, i::Int)
+    @boundscheck if i < 1 || i > cb.length
         throw(BoundsError(cb, i))
     end
     _buffer_index(cb, i)
 end
 
-function _buffer_index(cb::CircularBuffer, i::Int)
+@inline function _buffer_index(cb::CircularBuffer, i::Int)
     n = cb.capacity
     idx = cb.first + i - 1
     if idx > n
@@ -32,16 +32,16 @@ function _buffer_index(cb::CircularBuffer, i::Int)
     end
 end
 
-function Base.getindex(cb::CircularBuffer, i::Int)
+@inline Base.@propagate_inbounds function Base.getindex(cb::CircularBuffer, i::Int)
     cb.buffer[_buffer_index_checked(cb, i)]
 end
 
-function Base.setindex!(cb::CircularBuffer, data, i::Int)
+@inline Base.@propagate_inbounds function Base.setindex!(cb::CircularBuffer, data, i::Int)
     cb.buffer[_buffer_index_checked(cb, i)] = data
     cb
 end
 
-function Base.pop!(cb::CircularBuffer)
+@inline function Base.pop!(cb::CircularBuffer)
     if cb.length == 0
         throw(ArgumentError("array must be non-empty"))
     end
@@ -50,7 +50,7 @@ function Base.pop!(cb::CircularBuffer)
     cb.buffer[i]
 end
 
-function Base.push!(cb::CircularBuffer, data)
+@inline function Base.push!(cb::CircularBuffer, data)
     # if full, increment and overwrite, otherwise push
     if cb.length == cb.capacity
         cb.first = (cb.first == cb.capacity ? 1 : cb.first + 1)


### PR DESCRIPTION
Timings:

Before:
```
julia> using DataStructures

julia> using BenchmarkTools

julia> cb=CircularBuffer{Float64}(3)
0-element DataStructures.CircularBuffer{Float64}

julia> pusher(cb)=(@inbounds for i=1:10^6; push!(cb, 3.);end; nothing)
pusher (generic function with 1 method)

julia> @benchmark pusher(cb)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     6.944 ms (0.00% GC)
  median time:      6.995 ms (0.00% GC)
  mean time:        7.029 ms (0.00% GC)
  maximum time:     8.994 ms (0.00% GC)
  --------------
  samples:          713
  evals/sample:     1
```

After:
```
julia> @benchmark pusher(cb)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     2.400 ms (0.00% GC)
  median time:      2.414 ms (0.00% GC)
  mean time:        2.422 ms (0.00% GC)
  maximum time:     3.129 ms (0.00% GC)
  --------------
  samples:          2069
  evals/sample:     1
```

Similar results for larger buffers.