### PR TITLE
Fix #394 with the missing keys after sorting

### DIFF
--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -11,15 +11,9 @@ function sort!(d::OrderedDict; byvalue::Bool=false, args...)
     else
         p = sortperm(d.keys; args...)
     end
-
-    for (i,key) in enumerate(d.keys)
-        idx = ht_keyindex(d, key, false)
-        d.slots[idx] = p[i]
-    end
-
     d.keys = d.keys[p]
     d.vals = d.vals[p]
-
+    rehash!(d)
     return d
 end
 

--- a/test/test_sorting.jl
+++ b/test/test_sorting.jl
@@ -24,4 +24,8 @@
     @test sort(unordered; rev=true) == rev
     @test sort(unordered; byvalue=true) == rev
     @test sort(unordered; byvalue=true, rev=true) == forward
+
+    @testset "Bug DataStructures.jl/#394" begin
+        @test sort(Dict(k=>string(k) for k in 1:3))[1] == "1"
+    end
 end


### PR DESCRIPTION
This is  my attempt at fixing #394.
Using ` idx = ht_keyindex2(d, key)` or `idx =  ht_keyindex(d, key, true)` 
fixes the problem with the key vanishing,
but causes problems with out of bounds errors.

I tried a few other things.
Then I took a look at how `rehash!`  worked,
and saw that it rebuilds the `slots` based only `keys` and `values` (if nothing has been deleted since last `rehash!`)
And so I figured: Just correct the `keys` and `values` and then `rehash` it.


I have also created a Julia0.6 branch with this change.
https://github.com/JuliaCollections/DataStructures.jl/tree/julia0.6
What I should have done is created a 0.6 branch without this change then PRed that.
So if this PR gets rejected cos it is wrong, that branch should be deleted.
Otherwise, that branch should be used to tag `v0.8.4`


@timholy  this does not need to be ported to OrderedCollections.jl (I tried without looking by just `stash apply`ing the change set, and was informed that) OrderedCollections.jl is missing sorting functionality and that corresponding file.
I think that file should be moved over.
But that can be done with this change applied.