### PR TITLE
[Do Not Merge] Julia0.6 Backports

### DIFF
--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -73,11 +73,13 @@ end
 
 function Compat.pushfirst!(cb::CircularBuffer, data)
     # if full, decrement and overwrite, otherwise pushfirst
-    if cb.length < cb.capacity
+    if length(cb) == cb.capacity
+        cb.first = (cb.first == 1 ? cb.capacity : cb.first - 1)
+        cb[1] = data
+    else
         cb.length += 1
+        pushfirst!(cb.buffer, data)
     end
-    cb.first = (cb.first == 1 ? cb.length : cb.first - 1)
-    cb.buffer[cb.first] = data
     cb
 end
 

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -11,15 +11,9 @@ function sort!(d::OrderedDict; byvalue::Bool=false, args...)
     else
         p = sortperm(d.keys; args...)
     end
-
-    for (i,key) in enumerate(d.keys)
-        idx = ht_keyindex(d, key, false)
-        d.slots[idx] = p[i]
-    end
-
     d.keys = d.keys[p]
     d.vals = d.vals[p]
-
+    rehash!(d)
     return d
 end
 

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -40,6 +40,12 @@
     for (idx, n) in enumerate(5:1)
         @test arr[idx] == n
     end
+    # Issue 379
+    cb = CircularBuffer{Int}(5)
+    pushfirst!(cb, 1)
+    @test cb == [1]
+    pushfirst!(cb, 2)
+    @test cb == [2, 1]
 
     # test empty!(cb)
     @test length(empty!(cb)) == 0

--- a/test/test_sorting.jl
+++ b/test/test_sorting.jl
@@ -24,4 +24,8 @@
     @test sort(unordered; rev=true) == rev
     @test sort(unordered; byvalue=true) == rev
     @test sort(unordered; byvalue=true, rev=true) == forward
+
+    @testset "Bug DataStructures.jl/#394" begin
+        @test sort(Dict(k=>string(k) for k in 1:3))[1] == "1"
+    end
 end


### PR DESCRIPTION
I've created this PR to give visibility to the Julia 0.6 backports (I.e. DataStructures.jl  v0.8.x  (for x > 3)),
 which are in this julia0.6 branch
and so I can easily find the CI status for it.

Don't merge it, instead tag releases (in the 0.8.x series) against it