### PR TITLE
Make the LinkedList implementation immutable

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -1,9 +1,9 @@
 abstract type LinkedList{T} end
 
-mutable struct Nil{T} <: LinkedList{T}
+struct Nil{T} <: LinkedList{T}
 end
 
-mutable struct Cons{T} <: LinkedList{T}
+struct Cons{T} <: LinkedList{T}
     head::T
     tail::LinkedList{T}
 end

--- a/test/test_list.jl
+++ b/test/test_list.jl
@@ -103,4 +103,9 @@
         @test collect(l10) == [2; 4; 5.6; 10.5]
     end
 
+    @testset "immutable" begin
+        @test isimmutable(list(1))
+        @test isimmutable(nil())
+    end
+
 end # @testset LinkedList


### PR DESCRIPTION
Nothing in the linked list uses mutation and the type can simply be
changed to immutable. This assumes that no code in the wild uses this
linked list as a mutable type.