### PR TITLE
Define empty! for PriorityQueue

### DIFF
--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -334,6 +334,12 @@ function delete!(pq::PriorityQueue, key)
     pq
 end
 
+function empty!(pq::PriorityQueue)
+    empty!(pq.xs)
+    empty!(pq.index)
+    pq
+end
+
 # Unordered iteration through key value pairs in a PriorityQueue
 function _iterate(pq::PriorityQueue, state)
     state == nothing && return nothing

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -23,7 +23,7 @@ PriorityQueue{String,Int64,Base.Order.ForwardOrdering} with 3 entries:
   "a" => 2
 ```
 """
-mutable struct PriorityQueue{K,V,O<:Ordering} <: AbstractDict{K,V}
+struct PriorityQueue{K,V,O<:Ordering} <: AbstractDict{K,V}
     # Binary heap of (element, priority) pairs.
     xs::Array{Pair{K,V}, 1}
     o::O

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -209,8 +209,17 @@ import Base.Order.Reverse
             @test pq === pq_out
             @test Set(collect(pq)) == Set(["a"=>2, "c"=>1])
         end
+
+        @testset "empty!" begin
+            pq = PriorityQueue(Base.Order.Forward, "a"=>2, "b"=>3, "c"=>1)
+            @test !isempty(pq)
+            empty!(pq)
+            @test isempty(pq)
+            enqueue!(pq, "a"=>2)
+            @test length(pq) == 1
+        end
     end
-    
+
     @testset "Iteration" begin
         pq = PriorityQueue('a'=>'A')
         @test collect(pq) == ['a' => 'A']


### PR DESCRIPTION
In addition to defining `empty!`, this makes `PriorityQueue` immutable. I don't see a reason it should be mutable, and indeed modifying its, e.g., ordering after filling it with items seems like a bad idea.