### PR TITLE
fix push! and update! for heaps to convert the input value

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -134,13 +134,12 @@ length(h::BinaryHeap) = length(h.valtree)
 
 isempty(h::BinaryHeap) = isempty(h.valtree)
 
-function push!(h::BinaryHeap{T}, v::T) where T
+function push!(h::BinaryHeap, v)
     valtree = h.valtree
     push!(valtree, v)
     _heap_bubble_up!(h.comparer, valtree, length(valtree))
     h
 end
-
 
 """
     top(h::BinaryHeap)

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -197,12 +197,12 @@ length(h::MutableBinaryHeap) = length(h.nodes)
 
 isempty(h::MutableBinaryHeap) = isempty(h.nodes)
 
-function push!(h::MutableBinaryHeap{T}, v::T) where T
+function push!(h::MutableBinaryHeap{T}, v) where T
     nodes = h.nodes
     nodemap = h.node_map
     i = length(nodemap) + 1
     nd_id = length(nodes) + 1
-    push!(nodes, MutableBinaryHeapNode(v, i))
+    push!(nodes, MutableBinaryHeapNode(convert(T, v), i))
     push!(nodemap, nd_id)
     _heap_bubble_up!(h.comparer, nodes, nodemap, nd_id)
     i
@@ -228,15 +228,16 @@ pop!(h::MutableBinaryHeap{T}) where {T} = _binary_heap_pop!(h.comparer, h.nodes,
 Replace the element at index `i` in heap `h` with `v`.
 This is equivalent to `h[i]=v`.
 """
-function update!(h::MutableBinaryHeap{T}, i::Int, v::T) where T
+function update!(h::MutableBinaryHeap{T}, i::Int, v) where T
     nodes = h.nodes
     nodemap = h.node_map
     comp = h.comparer
 
     nd_id = nodemap[i]
     v0 = nodes[nd_id].value
-    nodes[nd_id] = MutableBinaryHeapNode(v, i)
-    if compare(comp, v, v0)
+    x = convert(T, v)
+    nodes[nd_id] = MutableBinaryHeapNode(x, i)
+    if compare(comp, x, v0)
         _heap_bubble_up!(comp, nodes, nodemap, nd_id)
     else
         _heap_bubble_down!(comp, nodes, nodemap, nd_id)

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -125,4 +125,14 @@
         end
     end
 
+    @testset "push! type conversion" begin # issue 399
+        h = binary_minheap(Float64)
+        push!(h, 3.0)
+        push!(h, 5)
+        push!(h, Rational(4, 8))
+        push!(h, Complex(10.1, 0.0))
+
+        @test isequal(h.valtree, [0.5, 5.0, 3.0, 10.1])
+    end
+
 end # @testset BinaryHeap

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -209,4 +209,16 @@ end
         end
     end
 
+    @testset "test push! and update! conversion" begin # issue 399
+        h = mutable_binary_minheap(Float64)
+        push!(h, 3.0)
+        push!(h, 5)
+        push!(h, Rational(4, 8))
+        push!(h, Complex(10.1, 0.0))
+        @test isequal(heap_values(h), [0.5, 5.0, 3.0, 10.1])
+
+        update!(h, 2, 20)
+        @test isequal(heap_values(h), [0.5, 10.1, 3.0, 20.0])
+    end
+
 end # @testset MutableBinheap


### PR DESCRIPTION
This fixes issue #399. That issue did not consider the case of updating a value in a mutable heap, but this PR contains a fix for that as well.