### PR TITLE
fix identity map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.12.0"
+version = "0.14.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/list.jl
+++ b/src/list.jl
@@ -69,7 +69,7 @@ map(f::Base.Callable, l::Nil) = l
 
 function map(f::Base.Callable, l::Cons{T}) where T
     first = f(l.head)
-    l2 = cons(first, nil(promote_type(typeof(first), T)))
+    l2 = cons(first, nil(typeof(first) <: T ? T : typeof(first)))
     for h in l.tail
         l2 = cons(f(h), l2)
     end

--- a/src/list.jl
+++ b/src/list.jl
@@ -67,9 +67,9 @@ end
 
 map(f::Base.Callable, l::Nil) = l
 
-function map(f::Base.Callable, l::Cons)
+function map(f::Base.Callable, l::Cons{T}) where T
     first = f(l.head)
-    l2 = cons(first, nil(typeof(first)))
+    l2 = cons(first, nil(promote_type(typeof(first), T)))
     for h in l.tail
         l2 = cons(f(h), l2)
     end

--- a/test/test_list.jl
+++ b/test/test_list.jl
@@ -103,4 +103,10 @@
         @test collect(l10) == [2; 4; 5.6; 10.5]
     end
 
+    @testset "l11" begin
+        ex = :(a+b+2 * 2 + foo(2))
+        l11 = list(ex.args...)
+        @test collect(map(x->x, l11)) == collect(l11)
+    end
+
 end # @testset LinkedList

--- a/test/test_list.jl
+++ b/test/test_list.jl
@@ -103,7 +103,7 @@
         @test collect(l10) == [2; 4; 5.6; 10.5]
     end
 
-    @testset "l11" begin
+    @testset "test identity map" begin
         ex = :(a+b+2 * 2 + foo(2))
         l11 = list(ex.args...)
         @test collect(map(x->x, l11)) == collect(l11)


### PR DESCRIPTION
MWE: when there is a `LinkedList{Any}`, the following will error:

```julia
ex = :(a+b+2 * 2 + foo(2))
tl = list(ex.args...)
map(x->x, tl)
```

This PR will fix it, and will allow more generic (each node has different generic types) linked list.