### PR TITLE
Update heap constructors

### DIFF
--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -38,17 +38,17 @@ mutable binary heap (type `MutableBinaryHeap`) have been implemented.
 Examples of constructing a heap:
 
 ```julia
-h = binary_minheap(Int)
-h = binary_maxheap(Int)            # create an empty min/max binary heap of integers
+h = BinaryMinHeap{Int}()
+h = BinaryMaxHeap{Int}()          # create an empty min/max binary heap of integers
 
-h = binary_minheap([1,4,3,2])
-h = binary_maxheap([1,4,3,2])      # create a min/max heap from a vector
+h = BinaryMinHeap([1,4,3,2])
+h = BinaryMaxHeap([1,4,3,2])      # create a min/max heap from a vector
 
-h = mutable_binary_minheap(Int)
-h = mutable_binary_maxheap(Int)    # create an empty mutable min/max heap
+h = MutableBinaryMinHeap{Int}()
+h = MutableBinaryMaxHeap{Int}()   # create an empty mutable min/max heap
 
-h = mutable_binary_minheap([1,4,3,2])
-h = mutable_binary_maxheap([1,4,3,2])    # create a mutable min/max heap from a vector
+h = MutableBinaryMinHeap([1,4,3,2])
+h = MutableBinaryMaxHeap([1,4,3,2])    # create a mutable min/max heap from a vector
 ```
 
 ## Min-max heaps

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -33,7 +33,7 @@ module DataStructures
     export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set, root_union!
 
     export AbstractHeap, compare, extract_all!
-    export BinaryHeap, binary_minheap, binary_maxheap, nlargest, nsmallest
+    export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
     export MutableBinaryHeap, mutable_binary_minheap, mutable_binary_maxheap
     export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -34,7 +34,7 @@ module DataStructures
 
     export AbstractHeap, compare, extract_all!
     export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
-    export MutableBinaryHeap, mutable_binary_minheap, mutable_binary_maxheap
+    export MutableBinaryHeap, MutableBinaryMinHeap, MutableBinaryMaxHeap
     export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!
 

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -99,7 +99,7 @@ function nextreme(comp::Comp, n::Int, arr::AbstractVector{T}) where {T, Comp}
         return sort(arr, lt = (x, y) -> compare(comp, y, x))
     end
 
-    buffer = BinaryHeap{T,Comp}(comp)
+    buffer = BinaryHeap{T,Comp}()
 
     for i = 1 : n
         @inbounds xi = arr[i]

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -106,15 +106,19 @@ mutable struct BinaryHeap{T,Comp} <: AbstractHeap{T}
     comparer::Comp
     valtree::Vector{T}
 
-    function BinaryHeap{T,Comp}(comp::Comp) where {T,Comp}
-        new{T,Comp}(comp, Vector{T}())
-    end
+    BinaryHeap{T,Comp}() where {T,Comp} = new{T,Comp}(Comp(), Vector{T}())
 
-    function BinaryHeap{T,Comp}(comp::Comp, xs) where {T,Comp}  # xs is an iterable collection of values
-        valtree = _make_binary_heap(comp, T, xs)
-        new{T,Comp}(comp, valtree)
+    function BinaryHeap{T,Comp}(xs::AbstractVector{T}) where {T,Comp} 
+        valtree = _make_binary_heap(Comp(), T, xs)
+        new{T,Comp}(Comp(), valtree)
     end
 end
+                            
+const BinaryMinHeap{T} = BinaryHeap{T, LessThan}
+const BinaryMaxHeap{T} = BinaryHeap{T, GreaterThan}
+                            
+BinaryMinHeap(xs::AbstractVector{T}) where T = BinaryMinHeap{T}(xs)
+BinaryMaxHeap(xs::AbstractVector{T}) where T = BinaryMaxHeap{T}(xs)
 
 function binary_minheap(ty::Type{T}) where T
     BinaryHeap{T,LessThan}(LessThan())

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -122,11 +122,6 @@ BinaryMaxHeap(xs::AbstractVector{T}) where T = BinaryMaxHeap{T}(xs)
 
 # deprecated constructors
                             
-binary_minheap(::Type{T}) where T = BinaryMinHeap{T}()
-binary_maxheap(::Type{T}) where T = BinaryMaxHeap{T}()
-binary_minheap(xs::AbstractVector{T}) where T = BinaryMinHeap(xs)
-binary_maxheap(xs::AbstractVector{T}) where T = BinaryMaxHeap(xs)
-                            
 @deprecate binary_minheap(::Type{T}) where {T} BinaryMinHeap{T}()
 @deprecate binary_minheap(xs::AbstractVector{T}) where {T} BinaryMinHeap(xs)
 @deprecate binary_maxheap(::Type{T}) where {T} BinaryMaxHeap{T}()

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -120,6 +120,8 @@ const BinaryMaxHeap{T} = BinaryHeap{T, GreaterThan}
 BinaryMinHeap(xs::AbstractVector{T}) where T = BinaryMinHeap{T}(xs)
 BinaryMaxHeap(xs::AbstractVector{T}) where T = BinaryMaxHeap{T}(xs)
 
+# deprecated constructors
+                            
 function binary_minheap(ty::Type{T}) where T
     BinaryHeap{T,LessThan}(LessThan())
 end
@@ -127,6 +129,11 @@ end
 binary_maxheap(ty::Type{T}) where {T} = BinaryHeap{T,GreaterThan}(GreaterThan())
 binary_minheap(xs::AbstractVector{T}) where {T} = BinaryHeap{T,LessThan}(LessThan(), xs)
 binary_maxheap(xs::AbstractVector{T}) where {T} = BinaryHeap{T,GreaterThan}(GreaterThan(), xs)
+                            
+@deprecate binary_minheap(::Type{T}) where {T} BinaryMinHeap{T}()
+@deprecate binary_minheap(::AbstractVector{T}) where {T} BinaryMinHeap(::AbstractVector{T})
+@deprecate binary_maxheap(::Type{T}) where {T} BinaryMaxHeap{T}()
+@deprecate binary_maxheap(::AbstractVector{T}) where {T} BinaryMaxHeap(::AbstractVector{T})
 
 #################################################
 #

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -122,18 +122,15 @@ BinaryMaxHeap(xs::AbstractVector{T}) where T = BinaryMaxHeap{T}(xs)
 
 # deprecated constructors
                             
-function binary_minheap(ty::Type{T}) where T
-    BinaryHeap{T,LessThan}(LessThan())
-end
-
-binary_maxheap(ty::Type{T}) where {T} = BinaryHeap{T,GreaterThan}(GreaterThan())
-binary_minheap(xs::AbstractVector{T}) where {T} = BinaryHeap{T,LessThan}(LessThan(), xs)
-binary_maxheap(xs::AbstractVector{T}) where {T} = BinaryHeap{T,GreaterThan}(GreaterThan(), xs)
+binary_minheap(::Type{T}) where T = BinaryMinHeap{T}()
+binary_maxheap(::Type{T}) where T = BinaryMaxHeap{T}()
+binary_minheap(xs::AbstractVector{T}) where T = BinaryMinHeap(xs)
+binary_maxheap(xs::AbstractVector{T}) where T = BinaryMaxHeap(xs)
                             
 @deprecate binary_minheap(::Type{T}) where {T} BinaryMinHeap{T}()
-@deprecate binary_minheap(::AbstractVector{T}) where {T} BinaryMinHeap(::AbstractVector{T})
+@deprecate binary_minheap(xs::AbstractVector{T}) where {T} BinaryMinHeap(xs)
 @deprecate binary_maxheap(::Type{T}) where {T} BinaryMaxHeap{T}()
-@deprecate binary_maxheap(::AbstractVector{T}) where {T} BinaryMaxHeap(::AbstractVector{T})
+@deprecate binary_maxheap(xs::AbstractVector{T}) where {T} BinaryMaxHeap(xs)
 
 #################################################
 #

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -155,23 +155,35 @@ mutable struct MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
     nodes::Vector{MutableBinaryHeapNode{VT}}
     node_map::Vector{Int}
 
-    function MutableBinaryHeap{VT, Comp}(comp::Comp) where {VT, Comp}
+    function MutableBinaryHeap{VT, Comp}() where {VT, Comp}
         nodes = Vector{MutableBinaryHeapNode{VT}}()
         node_map = Vector{Int}()
-        new{VT, Comp}(comp, nodes, node_map)
+        new{VT, Comp}(Comp(), nodes, node_map)
     end
 
-    function MutableBinaryHeap{VT, Comp}(comp::Comp, xs) where {VT, Comp}  # xs is an iterable collection of values
-        nodes, node_map = _make_mutable_binary_heap(comp, VT, xs)
-        new{VT, Comp}(comp, nodes, node_map)
+    function MutableBinaryHeap{VT, Comp}(xs::AbstractVector{VT}) where {VT, Comp} 
+        nodes, node_map = _make_mutable_binary_heap(Comp(), VT, xs)
+        new{VT, Comp}(Comp(), nodes, node_map)
     end
 end
+                            
+const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, LessThan}
+const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, GreaterThan}
+                            
+MutableBinaryMinHeap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap{T}(xs)
+MutableBinaryMaxHeap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap{T}(xs)
 
-mutable_binary_minheap(ty::Type{T}) where {T} = MutableBinaryHeap{T,LessThan}(LessThan())
-mutable_binary_maxheap(ty::Type{T}) where {T} = MutableBinaryHeap{T,GreaterThan}(GreaterThan())
-
-mutable_binary_minheap(xs::AbstractVector{T}) where {T} = MutableBinaryHeap{T,LessThan}(LessThan(), xs)
-mutable_binary_maxheap(xs::AbstractVector{T}) where {T} = MutableBinaryHeap{T,GreaterThan}(GreaterThan(), xs)
+# deprecated constructors
+mutable_binary_minheap(::Type{T}) where T = MutableBinaryMinHeap{T}()
+mutable_binary_maxheap(::Type{T}) where T = MutableBinaryMaxHeap{T}()
+mutable_binary_minheap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap(xs)
+mutable_binary_maxheap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap(xs)
+                            
+@deprecate mutable_binary_minheap(::Type{T}) where {T} MutableBinaryMinHeap{T}()
+@deprecate mutable_binary_minheap(xs::AbstractVector{T}) where {T} MutableBinaryMinHeap(xs)
+@deprecate mutable_binary_maxheap(::Type{T}) where {T} MutableBinaryMaxHeap{T}()
+@deprecate mutable_binary_maxheap(xs::AbstractVector{T}) where {T} MutableBinaryMaxHeap(xs)
+    
 
 function show(io::IO, h::MutableBinaryHeap)
     print(io, "MutableBinaryHeap(")

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -174,10 +174,6 @@ MutableBinaryMinHeap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap{T}(xs
 MutableBinaryMaxHeap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap{T}(xs)
 
 # deprecated constructors
-mutable_binary_minheap(::Type{T}) where T = MutableBinaryMinHeap{T}()
-mutable_binary_maxheap(::Type{T}) where T = MutableBinaryMaxHeap{T}()
-mutable_binary_minheap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap(xs)
-mutable_binary_maxheap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap(xs)
                             
 @deprecate mutable_binary_minheap(::Type{T}) where {T} MutableBinaryMinHeap{T}()
 @deprecate mutable_binary_minheap(xs::AbstractVector{T}) where {T} MutableBinaryMinHeap(xs)

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -134,5 +134,13 @@
 
         @test isequal(h.valtree, [0.5, 5.0, 3.0, 10.1])
     end
+    
+    # test deprecated constructors
+    @testset "deprecated constructors" begin
+        @test_deprecated binary_minheap(Int)
+        @test_deprecated binary_minheap([1., 2., 3.])
+        @test_deprecated binary_maxheap(Int)
+        @test_deprecated binary_maxheap([1., 2., 3.])
+    end
 
 end # @testset BinaryHeap

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -6,7 +6,7 @@
         vs = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7]
 
         @testset "make min heap" begin
-            h = binary_minheap(vs)
+            h = BinaryMinHeap(vs)
 
             @test length(h) == 10
             @test !isempty(h)
@@ -15,7 +15,7 @@
         end
 
         @testset "make max heap" begin
-            h = binary_maxheap(vs)
+            h = BinaryMaxHeap(vs)
 
             @test length(h) == 10
             @test !isempty(h)
@@ -25,7 +25,7 @@
 
         @testset "push!" begin
             @testset "push! hmin" begin
-                hmin = binary_minheap(Int)
+                hmin = BinaryMinHeap{Int}()
                 @test length(hmin) == 0
                 @test isempty(hmin)
 
@@ -56,7 +56,7 @@
             end
 
             @testset "push! hmax" begin
-                hmax = binary_maxheap(Int)
+                hmax = BinaryMaxHeap{Int}()
                 @test length(hmax) == 0
                 @test isempty(hmax)
 
@@ -89,7 +89,7 @@
     end
 
     @testset "hybrid push! and pop!" begin
-        h = binary_minheap(Int)
+        h = BinaryMinHeap{Int}()
 
         @testset "push1" begin
             push!(h, 5)
@@ -126,7 +126,7 @@
     end
 
     @testset "push! type conversion" begin # issue 399
-        h = binary_minheap(Float64)
+        h = BinaryMinHeap{Float64}()
         push!(h, 3.0)
         push!(h, 5)
         push!(h, Rational(4, 8))

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -220,5 +220,14 @@ end
         update!(h, 2, 20)
         @test isequal(heap_values(h), [0.5, 10.1, 3.0, 20.0])
     end
+    
+    # test deprecated constructors
+    @testset "deprecated constructors" begin
+        @test_deprecated mutable_binary_minheap(Int)
+        @test_deprecated mutable_binary_minheap([1., 2., 3.])
+        @test_deprecated mutable_binary_maxheap(Int)
+        @test_deprecated mutable_binary_maxheap([1., 2., 3.])
+    end
+    
 
 end # @testset MutableBinheap

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -55,7 +55,7 @@ end
     vs = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7]
 
     @testset "make mutable binary minheap" begin
-        h = mutable_binary_minheap(vs)
+        h = MutableBinaryMinHeap(vs)
 
         @test length(h) == 10
         @test !isempty(h)
@@ -65,7 +65,7 @@ end
     end
 
     @testset "make mutable binary maxheap" begin
-        h = mutable_binary_maxheap(vs)
+        h = MutableBinaryMaxHeap(vs)
 
         @test length(h) == 10
         @test !isempty(h)
@@ -75,7 +75,7 @@ end
     end
 
     @testset "hmin / push! / pop!" begin
-        hmin = mutable_binary_minheap(Int)
+        hmin = MutableBinaryMinHeap{Int}()
         @test length(hmin) == 0
         @test isempty(hmin)
 
@@ -106,7 +106,7 @@ end
     end
 
     @testset "hmax / push! / pop!" begin
-        hmax = mutable_binary_maxheap(Int)
+        hmax = MutableBinaryMaxHeap{Int}()
         @test length(hmax) == 0
         @test isempty(hmax)
 
@@ -138,7 +138,7 @@ end
     end
 
     @testset "hybrid push! and pop!" begin
-        h = mutable_binary_minheap(Int)
+        h = MutableBinaryMinHeap{Int}()
 
         push!(h, 5)
         push!(h, 10)
@@ -160,7 +160,7 @@ end
     end
 
     @testset "test update! and top_with_handle" begin
-        for (hf,m) = [(mutable_binary_minheap,-2.0), (mutable_binary_maxheap,2.0)]
+        for (hf,m) = [(MutableBinaryMinHeap,-2.0), (MutableBinaryMaxHeap,2.0)]
             xs = rand(100)
             h = hf(xs)
             @test length(h) == 100
@@ -210,7 +210,7 @@ end
     end
 
     @testset "test push! and update! conversion" begin # issue 399
-        h = mutable_binary_minheap(Float64)
+        h = MutableBinaryMinHeap{Float64}()
         push!(h, 3.0)
         push!(h, 5)
         push!(h, Rational(4, 8))


### PR DESCRIPTION
This PR addresses #469 by deprecating the old pseudoconstructors `(mutable_)binary_{min|max}heap` and replacing them with `(Mutable)Binary{Min|Max}Heap` constructors.
