### PR TITLE
Define multiset operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package implements a variety of data structures, including
 -   CircularDeque
 -   Stack
 -   Queue
--   Accumulators and Counters
+-   Accumulators and Counters (i.e. Multisets / Bags)
 -   Disjoint Sets
 -   Binary Heap
 -   Mutable Binary Heap

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -52,7 +52,7 @@ reset!(a, x)     # remove a key x from a, and return its current value
 merge!(a, a2)    # add all counts from a2 to a1
 merge(a, a2)     # return a new accumulator/counter that combines the
                  # values/counts in both a and a2
-                 # `a1[v] + a2[v]` over all `v` in the universe
+                 # `a[v] + a2[v]` over all `v` in the universe
 ```
 
 `merge` is the multiset sum operation (sometimes written ⊎).

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -70,7 +70,7 @@ Note that these operations will throw an error if the accumulator has negative o
 ```julia
 
 setdiff(a1, a2)          # The opposite of `merge` (i.e. multiset sum),
-                         # Returns `a1` with the count of items in `a2` removed, down to a minimum of zero
+                         # returns a new multiset with the count of items in `a2` removed from `a1`, down to a minimum of zero
                          # `max(a1[v] - a2[v], 0)` over all `v` in the universe
 
 

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -62,7 +62,7 @@ merge(a, a2)     # return a new accumulator/counter that combines the
 An `Accumulator{T, <:Integer} where T` such as is returned by `counter`,
 is a [multiset](https://en.wikipedia.org/wiki/Multiset) or Bag, of objects of type `T`.
 If the count type is not an integer but a more general real number, then this is a form of fuzzy multiset.
-We support a number of operations supporting the use of `Accumulators` as multisets.
+We support a number of operations supporting the use of `Accumulator`s as multisets.
 
 
 Note that these operations will throw an error if the accumulator has negative or zero counts for any items.

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -55,7 +55,7 @@ merge(a, a2)     # return a new accumulator/counter that combines the
                  # `a1[v] + a2[v]` over all `v` in the universe
 ```
 
-`merge` is the multiset sum (Sometimes written ⊎) operation.
+`merge` is the multiset sum operation (sometimes written ⊎).
 
 ## Use as a multiset
 

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -55,4 +55,31 @@ merge(a, a2)     # return a new accumulator/counter that combines (sums) the
                  # values/counts in both a and a2.
 ```
 
+merge is the multiset sum (Sometimes written ⊎) operation.
 
+## Use as a MultiSet
+
+An `Accumulator{T, <:Integer}` such as is returned by `counter`, is a [multiset](https://en.wikipedia.org/wiki/Multiset) or Bag, of objects of type `T`.
+If the count type is not an integer but a more general real number,
+then this is a form of fuzzy multiset.
+We support a number of operations to support the use of `Accumulators` as multisets.
+
+
+Note that these multiset operations will throw an error if the accumulator has negative or zero counts for any items,.
+
+```julia
+
+setdiff(a1, a2)          # The opposite of `merge` (i.e. multiset sum),
+                         # Returns `a1` with the count of items in `a2` removed, down to a minimum of zero
+                         # max(a1[v] - a2[v], 0) over all `v` in universe
+
+
+union(a1, a2)            # multiset union (sometimes called maximum, or lowest common multiple)
+                         # returns a new multiset with the counts being the higher of those in `a1` or `a2`.
+                         # max(a1[v], a2[v]) over all `v` in universe
+
+intersection(a1, a2)     # multiset intersection (sometimes called infimum or greatest common divisor)
+                         # returns a new multiset with the counts being the lowest of those in `a1` or `a2`.
+                         # Note that this means things not occurring in both with be removed (count zero).
+                         # min(a1[v], a2[v]) over all `v` in universe
+```

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -41,7 +41,6 @@ a[x]             # get the current value/count for x,
 
 a[x] = v         # sets the current value/count for `x` to `v`
 
-
 inc!(a, x)       # increment the value/count for x by 1
 inc!(a, x, v)    # increment the value/count for x by v
 
@@ -51,35 +50,36 @@ dec!(a, x, v)    # decrement the value/count for x by v
 reset!(a, x)     # remove a key x from a, and return its current value
 
 merge!(a, a2)    # add all counts from a2 to a1
-merge(a, a2)     # return a new accumulator/counter that combines (sums) the
-                 # values/counts in both a and a2.
+merge(a, a2)     # return a new accumulator/counter that combines the
+                 # values/counts in both a and a2
+                 # `a1[v] + a2[v]` over all `v` in the universe
 ```
 
-merge is the multiset sum (Sometimes written ⊎) operation.
+`merge` is the multiset sum (Sometimes written ⊎) operation.
 
-## Use as a MultiSet
+## Use as a multiset
 
-An `Accumulator{T, <:Integer}` such as is returned by `counter`, is a [multiset](https://en.wikipedia.org/wiki/Multiset) or Bag, of objects of type `T`.
-If the count type is not an integer but a more general real number,
-then this is a form of fuzzy multiset.
-We support a number of operations to support the use of `Accumulators` as multisets.
+An `Accumulator{T, <:Integer} where T` such as is returned by `counter`,
+is a [multiset](https://en.wikipedia.org/wiki/Multiset) or Bag, of objects of type `T`.
+If the count type is not an integer but a more general real number, then this is a form of fuzzy multiset.
+We support a number of operations supporting the use of `Accumulators` as multisets.
 
 
-Note that these multiset operations will throw an error if the accumulator has negative or zero counts for any items,.
+Note that these operations will throw an error if the accumulator has negative or zero counts for any items.
 
 ```julia
 
 setdiff(a1, a2)          # The opposite of `merge` (i.e. multiset sum),
                          # Returns `a1` with the count of items in `a2` removed, down to a minimum of zero
-                         # max(a1[v] - a2[v], 0) over all `v` in universe
+                         # `max(a1[v] - a2[v], 0)` over all `v` in the universe
 
 
 union(a1, a2)            # multiset union (sometimes called maximum, or lowest common multiple)
                          # returns a new multiset with the counts being the higher of those in `a1` or `a2`.
-                         # max(a1[v], a2[v]) over all `v` in universe
+                         # `max(a1[v], a2[v])` over all `v` in the universe
 
 intersect(a1, a2)        # multiset intersection (sometimes called infimum or greatest common divisor)
                          # returns a new multiset with the counts being the lowest of those in `a1` or `a2`.
                          # Note that this means things not occurring in both with be removed (count zero).
-                         # min(a1[v], a2[v]) over all `v` in universe
+                         # `min(a1[v], a2[v])` over all `v` in the universe
 ```

--- a/docs/src/accumulators.md
+++ b/docs/src/accumulators.md
@@ -78,7 +78,7 @@ union(a1, a2)            # multiset union (sometimes called maximum, or lowest c
                          # returns a new multiset with the counts being the higher of those in `a1` or `a2`.
                          # max(a1[v], a2[v]) over all `v` in universe
 
-intersection(a1, a2)     # multiset intersection (sometimes called infimum or greatest common divisor)
+intersect(a1, a2)        # multiset intersection (sometimes called infimum or greatest common divisor)
                          # returns a new multiset with the counts being the lowest of those in `a1` or `a2`.
                          # Note that this means things not occurring in both with be removed (count zero).
                          # min(a1[v], a2[v]) over all `v` in universe

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -32,7 +32,6 @@ function eltype_for_accumulator(seq::T) where {T<:Base.Generator}
 end
 
 
-
 copy(ct::Accumulator) = Accumulator(copy(ct.map))
 
 length(a::Accumulator) = length(a.map)
@@ -198,10 +197,6 @@ end
 drop_nonpositive!(a::Accumulator, k) = (a[k] > 0 || reset!(a, k); nothing)
 
 
-support(a::Accumulator) = Set(k for (k,v) in a if v > 0)
-
-Base.setdiff(a::Accumulator, b) = setdiff(a, convert(typeof(a), b))
-
 function Base.setdiff(a::Accumulator, b::Accumulator)
     ret = copy(a)
     for (k, v) in b
@@ -212,7 +207,6 @@ function Base.setdiff(a::Accumulator, b::Accumulator)
     return ret
 end
 
-Base.issubset(a, b::T) where T<:Accumulator= issubset(convert(T, a), b)
 Base.issubset(a::Accumulator, b::Accumulator) = all(b[k] >= v for (k, v) in a)
 
 Base.union(a::Accumulator, b::Accumulator) = Base.union!(copy(a), b)
@@ -233,7 +227,6 @@ function Base.intersect!(a::Accumulator, b::Accumulator)
     end
     # Need to do this bidirectionally, as anything not in both needs to be removed
     for (ka,va) in a
-        va > 0 || throw(MultiplicyException(ka, va))
         a[ka] = min(b[ka], va)
     
         drop_nonpositive!(a, ka) # Drop any that ended up zero

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -215,7 +215,7 @@ function Base.union!(a::Accumulator, b::Accumulator)
     for (kb, vb) in b
         va = a[kb]
         vb > 0 || throw(MultiplicityException(kb, vb))
-        va > 0 || throw(MultiplicityException(ka, va))
+        va > 0 || throw(MultiplicityException(kb, va))
         a[kb] = max(va, vb)
     end
     return a

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -213,8 +213,10 @@ Base.union(a::Accumulator, b::Accumulator, c::Accumulator...) = union(union(a,b)
 Base.union(a::Accumulator, b::Accumulator) = union!(copy(a), b)
 function Base.union!(a::Accumulator, b::Accumulator)
     for (kb, vb) in b
+        va = a[kb]
         vb > 0 || throw(MultiplicityException(kb, vb))
-        a[kb] = max(a[kb], vb)
+        va > 0 || throw(MultiplicityException(ka, va))
+        a[kb] = max(va, vb)
     end
     return a
 end

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -214,8 +214,8 @@ Base.union(a::Accumulator, b::Accumulator) = union!(copy(a), b)
 function Base.union!(a::Accumulator, b::Accumulator)
     for (kb, vb) in b
         va = a[kb]
-        vb > 0 || throw(MultiplicityException(kb, vb))
-        va > 0 || throw(MultiplicityException(kb, va))
+        vb >= 0 || throw(MultiplicityException(kb, vb))
+        va >= 0 || throw(MultiplicityException(kb, va))
         a[kb] = max(va, vb)
     end
     return a
@@ -225,17 +225,15 @@ end
 Base.intersect(a::Accumulator, b::Accumulator, c::Accumulator...) = insersect(intersect(a,b), c...)
 Base.intersect(a::Accumulator, b::Accumulator) = intersect!(copy(a), b)
 function Base.intersect!(a::Accumulator, b::Accumulator)
-    for (kb, vb) in b
-        vb > 0 || throw(MultiplicityException(kb, vb))
-        a[kb] = min(a[kb], vb)
-        drop_nonpositive!(a, kb) # Drop any that ended up zero
-    end
-    # Need to do this bidirectionally, as anything not in both needs to be removed
-    for (ka,va) in a
-        va > 0 || throw(MultiplicityException(ka, va))
-        a[ka] = min(b[ka], va)
-    
-        drop_nonpositive!(a, ka) # Drop any that ended up zero
+    for k in union(keys(a), keys(b)) # union not interection as we want to check both multiplicties
+        va = a[k]
+        vb = b[k]
+        va >= 0 || throw(MultiplicityException(k, va))
+        vb >= 0 || throw(MultiplicityException(k, vb))
+        
+        a[k] = min(va, vb)
+        drop_nonpositive!(a, k) # Drop any that ended up zero
     end
     return a
 end
+

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -190,7 +190,7 @@ struct MultiplicityException{K,V} <: Exception
 end
 
 function Base.showerror(io::IO, err::MultiplicityException)
-    print(io, "When using an Accumulator as a Multiset, all elements must have positive multiplicity")
+    print(io, "When using an `Accumulator` as a multiset, all elements must have positive multiplicity")
     print(io, " element `$(err.k)` has multiplicity $(err.v)")
 end
 

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -224,9 +224,11 @@ function Base.intersect!(a::Accumulator, b::Accumulator)
     for (kb, vb) in b
         vb > 0 || throw(MultiplicyException(kb, vb))
         a[kb] = min(a[kb], vb)
+        drop_nonpositive!(a, kb) # Drop any that ended up zero
     end
     # Need to do this bidirectionally, as anything not in both needs to be removed
     for (ka,va) in a
+        va > 0 || throw(MultiplicyException(ka, va))
         a[ka] = min(b[ka], va)
     
         drop_nonpositive!(a, ka) # Drop any that ended up zero

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Serialization
 
 import DataStructures: IntSet
 
-@test isempty(detect_ambiguities(Base, Core, DataStructures))
+@test [] == detect_ambiguities(Base, Core, DataStructures)
 
 tests = ["int_set",
          "deque",

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -209,8 +209,8 @@
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
             
             nonmultiset = counter(Dict([("a",-10), ("b",20)]))
-            @test_throws DataStructures.MultiplicityException ∪(counter("aabbcc"), nonmultiset)
-            @test_throws DataStructures.MultiplicityException ∪(nonmultiset, counter("aabbcc"))
+            @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∪ nonmultiset)
+            @test_throws DataStructures.MultiplicityException (nonmultiset ∪ counter("aabbcc"))
         end
  
         @testset "intersect" begin
@@ -221,8 +221,8 @@
             
             
             nonmultiset = counter(Dict([("a",-10), ("b",20)]))
-            @test_throws DataStructures.MultiplicityException ∩(counter("aabbcc"), nonmultiset)
-            @test_throws DataStructures.MultiplicityException ∩(nonmultiset, counter("aabbcc"))
+            @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∩ nonmultiset)
+            @test_throws DataStructures.MultiplicityException (nonmultiset ∩ counter("aabbcc"))
         end
 
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -183,6 +183,16 @@
         @test reset!(ct, 'x') == 0
     end
 
+    @testset "copy" begin
+        orig = counter("aabbbcccc")
+        dup = copy(orig)
+        @test orig == dup
+        
+        # Modifying copy should not modify original
+        inc!(orig, 'a')
+        @test orig == dup
+    end
+    
     @testset "Multiset" begin
         @testset "issubset" begin
             @test issubset(counter([1,2,3]), counter([1,2,3]))
@@ -226,7 +236,7 @@
         end
 
 
-
+    
 
     end
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -175,6 +175,32 @@
         @test_throws BoundsError nsmallest(counter("a"),2)
     end
 
+    @testset "Multiset" begin
+        @testset "setdiff" begin
+            @test setdiff(counter([1,2,3]), counter([2, 4])) == counter([3, 1])
+            @test setdiff(counter([1,2,3]), counter([2,2,4])) == counter([3, 1])
+            @test setdiff(counter([1,2,2,2,3]), counter([2,2,4])) == counter([1,2,3])
+        end
+        
+        @testset "union" begin
+            @test ∪(counter([1,2,3]), counter([1,2,3])) == counter([1,2,3])
+            @test ∪(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,2,3])
+            @test ∪(counter([1,3]), counter([2,2])) == counter([1,2,2,3])
+            @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
+        end
+ 
+        @testset "union" begin
+            @test ∩(counter([1,2,3]), counter([1,2,3])) == counter([1,2,3])
+            @test ∩(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,3])
+            @test ∩(counter([1,3]), counter([2,2])) == counter(Int[])
+            @test ∩(counter([1,2,3]), counter(Int[])) == counter(Int[])
+        end
+
+
+
+
+    end
+
 end # @testset Accumulators
 
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -199,7 +199,7 @@
             @test setdiff(counter([1,2,2,2,3]), counter([2,2,4])) == counter([1,2,3])
             
             nonmultiset = counter(Dict([("a",-10), ("b",20)]))
-            @test_throws DataStructures.MultiplicityException setdiff(counter("aabbcc"). nonmultiset)
+            @test_throws DataStructures.MultiplicityException setdiff(counter("aabbcc"), nonmultiset)
         end
         
         @testset "union" begin
@@ -209,7 +209,7 @@
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
             
             nonmultiset = counter(Dict([("a",-10), ("b",20)]))
-            @test_throws DataStructures.MultiplicityException ∪(counter("aabbcc"). nonmultiset)
+            @test_throws DataStructures.MultiplicityException ∪(counter("aabbcc"), nonmultiset)
             @test_throws DataStructures.MultiplicityException ∪(nonmultiset, counter("aabbcc"))
         end
  
@@ -221,7 +221,7 @@
             
             
             nonmultiset = counter(Dict([("a",-10), ("b",20)]))
-            @test_throws DataStructures.MultiplicityException ∩(counter("aabbcc"). nonmultiset)
+            @test_throws DataStructures.MultiplicityException ∩(counter("aabbcc"), nonmultiset)
             @test_throws DataStructures.MultiplicityException ∩(nonmultiset, counter("aabbcc"))
         end
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -189,7 +189,7 @@
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
         end
  
-        @testset "union" begin
+        @testset "intersect" begin
             @test ∩(counter([1,2,3]), counter([1,2,3])) == counter([1,2,3])
             @test ∩(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,3])
             @test ∩(counter([1,3]), counter([2,2])) == counter(Int[])

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -174,12 +174,32 @@
 
         @test_throws BoundsError nsmallest(counter("a"),2)
     end
+    
+    @testset "reset!" begin
+        ct = counter("abbbcddddda") # ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>1]
+        @test reset!(ct, 'b') == 3
+        @test ct == counter("acddddda")
+        
+        @test reset!(ct, 'x') == 0
+    end
 
     @testset "Multiset" begin
+        @testset "issubset" begin
+            @test issubset(counter([1,2,3]), counter([1,2,3]))
+            @test !issubset(counter([1,2,3,4]), counter([1,2,3]))
+            @test issubset(counter([1,2]), counter([1,2,3]))
+            
+            @test !issubset(counter([1,2,3]), counter([1,2,3,3]))
+            @test !issubset(counter([1,2,3,3]), counter([1,2,3]))
+        end
+        
         @testset "setdiff" begin
             @test setdiff(counter([1,2,3]), counter([2, 4])) == counter([3, 1])
             @test setdiff(counter([1,2,3]), counter([2,2,4])) == counter([3, 1])
             @test setdiff(counter([1,2,2,2,3]), counter([2,2,4])) == counter([1,2,3])
+            
+            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            @test_throws DataStructures.MultiplicityException setdiff(counter("aabbcc"). nonmultiset)
         end
         
         @testset "union" begin
@@ -187,6 +207,10 @@
             @test ∪(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,2,3])
             @test ∪(counter([1,3]), counter([2,2])) == counter([1,2,2,3])
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
+            
+            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            @test_throws DataStructures.MultiplicityException ∪(counter("aabbcc"). nonmultiset)
+            @test_throws DataStructures.MultiplicityException ∪(nonmultiset, counter("aabbcc"))
         end
  
         @testset "intersect" begin
@@ -194,6 +218,11 @@
             @test ∩(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,3])
             @test ∩(counter([1,3]), counter([2,2])) == counter(Int[])
             @test ∩(counter([1,2,3]), counter(Int[])) == counter(Int[])
+            
+            
+            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            @test_throws DataStructures.MultiplicityException ∩(counter("aabbcc"). nonmultiset)
+            @test_throws DataStructures.MultiplicityException ∩(nonmultiset, counter("aabbcc"))
         end
 
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -189,7 +189,7 @@
             @test !issubset(counter([1,2,3,4]), counter([1,2,3]))
             @test issubset(counter([1,2]), counter([1,2,3]))
             
-            @test !issubset(counter([1,2,3]), counter([1,2,3,3]))
+            @test issubset(counter([1,2,3]), counter([1,2,3,3]))
             @test !issubset(counter([1,2,3,3]), counter([1,2,3]))
         end
         
@@ -198,7 +198,7 @@
             @test setdiff(counter([1,2,3]), counter([2,2,4])) == counter([3, 1])
             @test setdiff(counter([1,2,2,2,3]), counter([2,2,4])) == counter([1,2,3])
             
-            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException setdiff(counter("aabbcc"), nonmultiset)
         end
         
@@ -208,7 +208,7 @@
             @test ∪(counter([1,3]), counter([2,2])) == counter([1,2,2,3])
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
             
-            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∪ nonmultiset)
             @test_throws DataStructures.MultiplicityException (nonmultiset ∪ counter("aabbcc"))
         end
@@ -220,7 +220,7 @@
             @test ∩(counter([1,2,3]), counter(Int[])) == counter(Int[])
             
             
-            nonmultiset = counter(Dict([("a",-10), ("b",20)]))
+            nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∩ nonmultiset)
             @test_throws DataStructures.MultiplicityException (nonmultiset ∩ counter("aabbcc"))
         end

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -190,7 +190,7 @@
         
         # Modifying copy should not modify original
         inc!(orig, 'a')
-        @test orig == dup
+        @test orig != dup
     end
     
     @testset "Multiset" begin


### PR DESCRIPTION
needs tests
needs docs

Solves #474 

when documented will solve #133 

https://en.wikipedia.org/wiki/Multiset#Basic_properties_and_operations


It is tempting to define `zero(A::Type(<:Accumulator)=A()`
which would give us a group (in the mathematical sense).
If we are willing to think of `merge` and `setdiff` as the same operation, but one of which creating the inverse element.