### PR TITLE
Improve pretty-print

### DIFF
--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -90,11 +90,10 @@ end
     i == d.n + 1 ? nothing : (_unsafe_getindex(d, i), i+1)
 end
 
-function Base.show(io::IO, D::CircularDeque{T}) where T
-    print(io, "CircularDeque{$T}([")
-    for i = 1:length(D)
-        print(io, D[i])
-        i < length(D) && print(io, ',')
-    end
-    print(io, "])")
+function show(io::IO, cb::CircularDeque)
+    elem = collect(cb)
+    summary(io, cb, axes(elem))
+    isempty(cb) && return
+    println(io, ":")
+    Base.print_array(io, elem)
 end

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -92,7 +92,11 @@ end
 
 function show(io::IO, cb::CircularDeque)
     elem = collect(cb)
-    summary(io, cb, axes(elem))
+    if VERSION < v"1.2-DEV"
+        summary(io, cb, axes(elem))
+    else
+        Base.array_summary(io, cb, axes(elem))
+    end
     isempty(cb) && return
     println(io, ":")
     Base.print_array(io, elem)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -45,8 +45,12 @@ function reset!(blk::DequeBlock{T}, front::Int) where T
 end
 
 function show(io::IO, blk::DequeBlock)  # avoids recursion into prev and next
-    x = blk.data[blk.front:blk.back]
-    print(io, "$(typeof(blk))(capa = $(blk.capa), front = $(blk.front), back = $(blk.back)): $x")
+    x = view(blk.data, blk.front:blk.back)
+    summary(io, blk, axes(x))
+    print(io, " (capa = $(blk.capa), front = $(blk.front), back = $(blk.back))")
+    isempty(blk) && return
+    println(io, ":")
+    Base.print_array(io, x)
 end
 
 
@@ -157,8 +161,12 @@ Base.collect(q::Deque{T}) where {T} = T[x for x in q]
 
 # Showing
 
-function show(io::IO, q::Deque)
-    print(io, "Deque [$(collect(q))]")
+function Base.show(io::IO, q::Deque)
+    elem = collect(q)
+    summary(io, q, axes(elem))
+    isempty(q) && return
+    println(io, ":")
+    Base.print_array(io, elem)
 end
 
 function dump(io::IO, q::Deque)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -46,8 +46,12 @@ end
 
 function show(io::IO, blk::DequeBlock)  # avoids recursion into prev and next
     x = view(blk.data, blk.front:blk.back)
-    summary(io, blk, axes(x))
-    print(io, " (capa = $(blk.capa), front = $(blk.front), back = $(blk.back))")
+    if VERSION < v"1.2-DEV"
+        summary(io, blk, axes(x))
+    else
+        Base.array_summary(io, blk, axes(x))
+    end
+    print(io, "(capa = $(blk.capa), front = $(blk.front), back = $(blk.back))")
     isempty(blk) && return
     println(io, ":")
     Base.print_array(io, x)
@@ -163,7 +167,11 @@ Base.collect(q::Deque{T}) where {T} = T[x for x in q]
 
 function Base.show(io::IO, q::Deque)
     elem = collect(q)
-    summary(io, q, axes(elem))
+    if VERSION < v"1.2-DEV"
+        summary(io, q, axes(elem))
+    else
+        Base.array_summary(io, q, axes(elem))
+    end
     isempty(q) && return
     println(io, ":")
     Base.print_array(io, elem)

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -43,3 +43,11 @@ dequeue!(s::Queue) = popfirst!(s.store)
 iterate(q::Queue, s...) = iterate(q.store, s...)
 
 reverse_iter(q::Queue) = reverse_iter(q.store)
+
+function show(io::IO, q::Queue)
+    elements = collect(q)
+    summary(io, q, axes(elements))
+    isempty(q) && return
+    println(io, ":")
+    Base.print_array(io, elements)
+end

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -45,9 +45,13 @@ iterate(q::Queue, s...) = iterate(q.store, s...)
 reverse_iter(q::Queue) = reverse_iter(q.store)
 
 function show(io::IO, q::Queue)
-    elements = collect(q)
-    summary(io, q, axes(elements))
+    elem = collect(q)
+    if VERSION < v"1.2-DEV"
+        summary(io, q, axes(elem))
+    else
+        Base.array_summary(io, q, axes(elem))
+    end
     isempty(q) && return
     println(io, ":")
-    Base.print_array(io, elements)
+    Base.print_array(io, elem)
 end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -27,3 +27,11 @@ empty!(s::Stack) = (empty!(s.store); s)
 iterate(st::Stack, s...) = iterate(reverse_iter(st.store), s...)
 
 reverse_iter(s::Stack{T}) where {T} = DequeIterator{T}(s.store)
+
+function show(io::IO, s::Stack)
+    elements = collect(s)
+    summary(io, s, axes(elements))
+    isempty(s) && return
+    println(io, ":")
+    Base.print_array(io, elements)
+end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -29,9 +29,13 @@ iterate(st::Stack, s...) = iterate(reverse_iter(st.store), s...)
 reverse_iter(s::Stack{T}) where {T} = DequeIterator{T}(s.store)
 
 function show(io::IO, s::Stack)
-    elements = collect(s)
-    summary(io, s, axes(elements))
+    elem = collect(s)
+    if VERSION < v"1.2-DEV"
+        summary(io, s, axes(elem))
+    else
+        Base.array_summary(io, s, axes(elem))
+    end
     isempty(s) && return
     println(io, ":")
-    Base.print_array(io, elements)
+    Base.print_array(io, elem)
 end

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -2,6 +2,8 @@
 
     @testset "Core Functionality" begin
         D = CircularDeque{Int}(5)
+        intstr = sprint(show, Int)
+        @test sprint(show, D) == "0-element CircularDeque{$(intstr)}"
         @test eltype(D) == Int
         @test capacity(D) == 5
         @test length(D) == 0
@@ -21,11 +23,7 @@
         @test popfirst!(D) === 1
         @test front(D) === 2
         @test back(D) === 5
-        io = IOBuffer()
-        print(io, Int)
-        intstr = String(take!(io))
-        print(io, D)
-        @test String(take!(io)) == "CircularDeque{$intstr}([2,3,4,5])"
+        @test sprint(show, D) == "4-element CircularDeque{$(intstr)}:\n 2\n 3\n 4\n 5"
         push!(D, 6)
         @test front(D) === 2
         @test back(D) === 6

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -200,4 +200,20 @@
         @test isempty(q)
     end
 
+    @testset "show" begin
+        q = Deque{Int}()
+        intstr = sprint(show, Int)
+        @test sprint(show, q) == "0-element Deque{$(intstr)}"
+        push!(q, 1)
+        @test sprint(show, q) == "1-element Deque{Int64}:\n 1"
+        for i in 2:50
+            push!(q, i)
+        end
+        @test sprint(show, q) == "50-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "50-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        pop!(q)
+        @test sprint(show, q) == "49-element Deque{Int64}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "49-element Deque{Int64}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+    end
+
 end # @testset Deque

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -204,16 +204,22 @@
         q = Deque{Int}()
         intstr = sprint(show, Int)
         @test sprint(show, q) == "0-element Deque{$(intstr)}"
+        @test sprint(show, q.head) == "0-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 0)"
         push!(q, 1)
-        @test sprint(show, q) == "1-element Deque{Int64}:\n 1"
+        @test sprint(show, q) == "1-element Deque{$(intstr)}:\n 1"
+        @test sprint(show, q.head) == "1-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 1):\n 1"
         for i in 2:50
             push!(q, i)
         end
         @test sprint(show, q) == "50-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
         @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "50-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        @test sprint(show, q.head) == "50-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 50):\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q.head) == "50-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 50):\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
         pop!(q)
-        @test sprint(show, q) == "49-element Deque{Int64}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
-        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "49-element Deque{Int64}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+        @test sprint(show, q) == "49-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "49-element Deque{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+        @test sprint(show, q.head) == "49-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 49):\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q.head) == "49-element DataStructures.DequeBlock{$(intstr)}(capa = 1024, front = 1, back = 49):\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49"
     end
 
 end # @testset Deque

--- a/test/test_queue.jl
+++ b/test/test_queue.jl
@@ -77,4 +77,20 @@
         @test reverse(arr) == [i for i in reverse_iter(q)]
     end
 
+    @testset "show" begin
+        q = Queue{Int}()
+        intstr = sprint(show, Int)
+        @test sprint(show, q) == "0-element Queue{$(intstr)}"
+        enqueue!(q, 1)
+        @test sprint(show, q) == "1-element Queue{$(intstr)}:\n 1"
+        for i in 2:50
+            enqueue!(q, i)
+        end
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "50-element Queue{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        @test sprint(show, q) == "50-element Queue{$(intstr)}:\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        dequeue!(q)
+        @test sprint((io, x) -> show(IOContext(io, :limit=>true), x), q) == "49-element Queue{$(intstr)}:\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n  ⋮\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+        @test sprint(show, q) == "49-element Queue{$(intstr)}:\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n 11\n 12\n 13\n 14\n 15\n 16\n 17\n 18\n 19\n 20\n 21\n 22\n 23\n 24\n 25\n 26\n 27\n 28\n 29\n 30\n 31\n 32\n 33\n 34\n 35\n 36\n 37\n 38\n 39\n 40\n 41\n 42\n 43\n 44\n 45\n 46\n 47\n 48\n 49\n 50"
+    end
+
 end # @testset Queue

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -80,4 +80,20 @@
         @test reverse(arr) == [i for i in stk]
     end
 
+    @testset "show" begin
+        s = Stack{Int}()
+        intstr = sprint(show, Int)
+        @test sprint(show, s) == "0-element Stack{$(intstr)}"
+        push!(s, 1)
+        @test sprint(show, s) == "1-element Stack{$(intstr)}:\n 1"
+        for i in 2:50
+            push!(s, i)
+        end
+        @test sprint(show, s) == "50-element Stack{$(intstr)}:\n 50\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n 39\n 38\n 37\n 36\n 35\n 34\n 33\n 32\n 31\n 30\n 29\n 28\n 27\n 26\n 25\n 24\n 23\n 22\n 21\n 20\n 19\n 18\n 17\n 16\n 15\n 14\n 13\n 12\n 11\n 10\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
+        @test sprint((io,x) -> show(IOContext(io, :limit=>true), x), s) == "50-element Stack{$(intstr)}:\n 50\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n  ⋮\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
+        pop!(s)
+        @test sprint(show, s) == "49-element Stack{$(intstr)}:\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n 39\n 38\n 37\n 36\n 35\n 34\n 33\n 32\n 31\n 30\n 29\n 28\n 27\n 26\n 25\n 24\n 23\n 22\n 21\n 20\n 19\n 18\n 17\n 16\n 15\n 14\n 13\n 12\n 11\n 10\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
+        @test sprint((io,x) -> show(IOContext(io, :limit=>true), x), s) == "49-element Stack{Int64}:\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n  ⋮\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
+    end
+
 end # @testset Stack

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -93,7 +93,7 @@
         @test sprint((io,x) -> show(IOContext(io, :limit=>true), x), s) == "50-element Stack{$(intstr)}:\n 50\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n  ⋮\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
         pop!(s)
         @test sprint(show, s) == "49-element Stack{$(intstr)}:\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n 39\n 38\n 37\n 36\n 35\n 34\n 33\n 32\n 31\n 30\n 29\n 28\n 27\n 26\n 25\n 24\n 23\n 22\n 21\n 20\n 19\n 18\n 17\n 16\n 15\n 14\n 13\n 12\n 11\n 10\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
-        @test sprint((io,x) -> show(IOContext(io, :limit=>true), x), s) == "49-element Stack{Int64}:\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n  ⋮\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
+        @test sprint((io,x) -> show(IOContext(io, :limit=>true), x), s) == "49-element Stack{$(intstr)}:\n 49\n 48\n 47\n 46\n 45\n 44\n 43\n 42\n 41\n 40\n  ⋮\n  9\n  8\n  7\n  6\n  5\n  4\n  3\n  2\n  1"
     end
 
 end # @testset Stack


### PR DESCRIPTION
This PR improves pretty-print for `Deque`, `DequeBlock`, `CircularDeque`, `Stack`, and `Queue`.

Those data structures show all elements for pretty-print.
But it is not suitable if the number of elements become larger.
So I have modified them like an ordinary vector object.

Before
https://nbviewer.jupyter.org/gist/goropikari/038256179c09d7754c05f82951549e6f

After
https://nbviewer.jupyter.org/gist/goropikari/9dd445423751f247d51aaf1bde8c0517