### PR TITLE
Issue#369: Ordered iterator interface for priority queue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,14 @@ version = "0.14.0"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
+[compat]
+OrderedCollections = "1.0.1"
+
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Primes", "Random", "Serialization"]
-
-[compat]
-OrderedCollections = "1.0.1"

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -100,7 +100,7 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
-    export PriorityQueue, peek, PQOrderedIterator
+    export PriorityQueue, peek
 
     include("priorityqueue.jl")
 end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -100,7 +100,7 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
-    export PriorityQueue, peek
+    export PriorityQueue, peek, PQOrderedIterator
 
     include("priorityqueue.jl")
 end

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -357,6 +357,28 @@ function empty!(pq::PriorityQueue)
     pq
 end
 
+empty(pq::PriorityQueue) = PriorityQueue(empty(pq.xs), pq.o, empty(pq.index))
+
+function merge!(d::AbstractDict{K, V}, other::PriorityQueue{K, V}) where {K, V}
+    next = iterate(other, false)
+    while next !== nothing
+        (k, v), state = next
+        d[k] = v
+        next = iterate(other, state)
+    end
+    return d
+end
+
+function merge!(combine::Function, d::AbstractDict{K, V}, other::PriorityQueue{K, V}) where {K, V}
+    next = iterate(other, false)
+    while next !== nothing
+        (k, v), state = next
+        d[k] = haskey(d, k) ? combine(d[k], v) : v
+        next = iterate(other, state)
+    end
+    return d
+end
+
 # Opaque not to be exported. 
 mutable struct _PQIteratorState{K, V, O <: Ordering}
     pq::PriorityQueue{K, V, O}

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -359,7 +359,9 @@ end
 
 empty(pq::PriorityQueue) = PriorityQueue(empty(pq.xs), pq.o, empty(pq.index))
 
-function merge!(d::SortedDict{K, V, O1}, other::PriorityQueue{K, V, O}) where {K, V, O <: Ordering, O1 <: Ordering}
+merge!(d::SortedDict, other::PriorityQueue) = invoke(merge!, Tuple{AbstractDict, PriorityQueue}, d, other)
+
+function merge!(d::AbstractDict, other::PriorityQueue)
     next = iterate(other, false)
     while next !== nothing
         (k, v), state = next
@@ -369,17 +371,7 @@ function merge!(d::SortedDict{K, V, O1}, other::PriorityQueue{K, V, O}) where {K
     return d
 end
 
-function merge!(d::AbstractDict{K, V}, other::PriorityQueue{K, V, O}) where {K, V, O <: Ordering}
-    next = iterate(other, false)
-    while next !== nothing
-        (k, v), state = next
-        d[k] = v
-        next = iterate(other, state)
-    end
-    return d
-end
-
-function merge!(combine::Function, d::AbstractDict{K, V}, other::PriorityQueue{K, V, O}) where {K, V, O <:Ordering}
+function merge!(combine::Function, d::AbstractDict, other::PriorityQueue)
     next = iterate(other, false)
     while next !== nothing
         (k, v), state = next
@@ -423,5 +415,4 @@ function iterate(pq::PriorityQueue, state::_PQIteratorState)
 end
     
 iterate(pq::PriorityQueue, i) = _iterate(pq, iterate(pq.index, i))
-
 

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -359,7 +359,7 @@ end
 
 empty(pq::PriorityQueue) = PriorityQueue(empty(pq.xs), pq.o, empty(pq.index))
 
-function merge!(d::AbstractDict{K, V}, other::PriorityQueue{K, V}) where {K, V}
+function merge!(d::SortedDict{K, V, O1}, other::PriorityQueue{K, V, O}) where {K, V, O <: Ordering, O1 <: Ordering}
     next = iterate(other, false)
     while next !== nothing
         (k, v), state = next
@@ -369,7 +369,17 @@ function merge!(d::AbstractDict{K, V}, other::PriorityQueue{K, V}) where {K, V}
     return d
 end
 
-function merge!(combine::Function, d::AbstractDict{K, V}, other::PriorityQueue{K, V}) where {K, V}
+function merge!(d::AbstractDict{K, V}, other::PriorityQueue{K, V, O}) where {K, V, O <: Ordering}
+    next = iterate(other, false)
+    while next !== nothing
+        (k, v), state = next
+        d[k] = v
+        next = iterate(other, state)
+    end
+    return d
+end
+
+function merge!(combine::Function, d::AbstractDict{K, V}, other::PriorityQueue{K, V, O}) where {K, V, O <:Ordering}
     next = iterate(other, false)
     while next !== nothing
         (k, v), state = next

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -225,6 +225,13 @@ import Base.Order.Reverse
         @test collect(pq) == ['a' => 'A']
     end
 
+    @testset "OrderedIteration" begin
+        pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
+        @test Set(collect(pq)) == Set(["a" => 10, "b" => 5, "c" => 15])
+        it = PQOrderedIterator(pq)
+        @test collect(it) == ["b" => 5, "a" => 10, "c" => 15]
+    end
+
     @testset "LowLevelHeapOperations" begin
         pmax = 1000
         n = 10000

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -225,15 +225,30 @@ import Base.Order.Reverse
     end
 
     @testset "Iteration" begin
-        pq = PriorityQueue('a'=>'A')
-        @test collect(pq) == ['a' => 'A']
+        pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
+        @test collect(pq)         == ["b" => 5, "a" => 10, "c" => 15]
+        @test collect(keys(pq))   == ["b", "a", "c"]
+        @test collect(values(pq)) == [5, 10, 15]
     end
 
-    @testset "OrderedIteration" begin
+    @testset "UnorderedIteration" begin
         pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
-        @test Set(collect(pq)) == Set(["a" => 10, "b" => 5, "c" => 15])
-        it = PQOrderedIterator(pq)
-        @test collect(it) == ["b" => 5, "a" => 10, "c" => 15]
+        res = Pair{String, Int}[]
+        next = iterate(pq, false)
+        while next !== nothing
+            p, i = next
+            push!(res, p)
+            next = iterate(pq, i)
+        end
+        @test Set(res) == Set(["a" => 10, "b" => 5, "c" => 15])
+        empty!(res)
+        next = iterate(pq, true)
+        while next !== nothing
+            p, i = next
+            push!(res, p)
+            next = iterate(pq, i)
+        end
+        @test res == ["b" => 5, "a" => 10, "c" => 15]
     end
 
     @testset "LowLevelHeapOperations" begin

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -256,7 +256,7 @@ import Base.Order.Reverse
     @testset "Copy and Merge" begin
         v = [i for i=10000:-1:1]
         pq1 = PriorityQueue(zip(v, 10 .* v))
-        @test collect(copy!(Dict{Int, Int}(), pq1)) != collect(pq1)
+        @test collect(copy!(Dict(), pq1)) != collect(pq1)
         pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
         sd = SortedDict(["d"=>6, "e"=>4])
         merge!(sd, pq)

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -251,6 +251,26 @@ import Base.Order.Reverse
         @test res == ["b" => 5, "a" => 10, "c" => 15]
     end
 
+    # Copy and merge operations in PriorityQueue utilize unordered
+    # iteration
+    @testset "Copy and Merge" begin
+        pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
+        cpq = copy(pq)
+        res = Pair{String, Int}[]
+        next = iterate(cpq, false)
+        while next !== nothing
+            p, i = next
+            pushfirst!(res, p)
+            next = iterate(cpq, i)
+        end
+        @test res == ["a" => 10, "b" => 5, "c" => 15]
+        sd = SortedDict(["d"=>6, "e"=>4])
+        merge!(sd, pq)
+        @test collect(sd) == ["a" => 10, "b" => 5, "c" => 15, "d" => 6, "e" => 4]
+        d = merge!(Dict("d"=> 6), pq)
+        @test Set(collect(d)) == Set(["c" => 15, "b" => 5, "a" => 10, "d" => 6])
+    end
+
     @testset "LowLevelHeapOperations" begin
         pmax = 1000
         n = 10000

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -263,6 +263,11 @@ import Base.Order.Reverse
         @test collect(sd) == ["a" => 10, "b" => 5, "c" => 15, "d" => 6, "e" => 4]
         d = merge!(Dict("d"=> 6), pq)
         @test Set(collect(d)) == Set(["c" => 15, "b" => 5, "a" => 10, "d" => 6])
+        sd = SortedDict(["c"=>6, "e"=>4])
+        merge!(+, sd, pq)
+        @test collect(sd) == ["a" => 10, "b" => 5, "c" => 21, "e" => 4]
+        pq1 = empty(pq)
+        @test length(pq1) == 0
     end
 
     @testset "LowLevelHeapOperations" begin

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -268,6 +268,8 @@ import Base.Order.Reverse
         @test collect(sd) == ["a" => 10, "b" => 5, "c" => 21, "e" => 4]
         pq1 = empty(pq)
         @test length(pq1) == 0
+        pq1 = copy(pq)
+        @test pq1 isa PriorityQueue
     end
 
     @testset "LowLevelHeapOperations" begin

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -256,7 +256,7 @@ import Base.Order.Reverse
     @testset "Copy and Merge" begin
         v = [i for i=10000:-1:1]
         pq1 = PriorityQueue(zip(v, 10 .* v))
-        @test collect(copy!(Dict(), pq1)) != collect(pq1)
+        @test collect(merge!(Dict(), pq1)) != collect(pq1)
         pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
         sd = SortedDict(["d"=>6, "e"=>4])
         merge!(sd, pq)

--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -254,16 +254,10 @@ import Base.Order.Reverse
     # Copy and merge operations in PriorityQueue utilize unordered
     # iteration
     @testset "Copy and Merge" begin
+        v = [i for i=10000:-1:1]
+        pq1 = PriorityQueue(zip(v, 10 .* v))
+        @test collect(copy!(Dict{Int, Int}(), pq1)) != collect(pq1)
         pq = PriorityQueue(["a" => 10, "b" => 5, "c" => 15])
-        cpq = copy(pq)
-        res = Pair{String, Int}[]
-        next = iterate(cpq, false)
-        while next !== nothing
-            p, i = next
-            pushfirst!(res, p)
-            next = iterate(cpq, i)
-        end
-        @test res == ["a" => 10, "b" => 5, "c" => 15]
         sd = SortedDict(["d"=>6, "e"=>4])
         merge!(sd, pq)
         @test collect(sd) == ["a" => 10, "b" => 5, "c" => 15, "d" => 6, "e" => 4]


### PR DESCRIPTION
Ordered iterator interface for priority queues. 

The original unordered interface is preserved as that is used for most common functionalities like copying etc. This interface is a kind of a heapsort implementation but in place store has not been used. 