### PR TITLE
Fix method ambiguities introduced by DataStructures.jl (when combined with Setfield.jl)

### DIFF
--- a/src/delegate.jl
+++ b/src/delegate.jl
@@ -9,6 +9,18 @@ function unquote(e::QuoteNode)
     return e.value
 end
 
+const _arities = Dict(
+    :get => 3,
+    :get! => 3,
+)
+
+_argsig(funcname) =
+    if haskey(_arities, funcname)
+        :(args::Vararg{<:Any, $(_arities[funcname] - 1)})
+    else
+        :(args::Vararg)
+    end
+
 macro delegate(source, targets)
     typename = esc(source.args[1])
     fieldname = unquote(source.args[2])
@@ -18,7 +30,7 @@ macro delegate(source, targets)
     for i in 1:n
         funcname = esc(funcnames[i])
         fdefs[i] = quote
-                     ($funcname)(a::($typename), args...) =
+                     ($funcname)(a::($typename), $(_argsig(funcnames[i]))) =
                        ($funcname)(a.$fieldname, args...)
                    end
     end
@@ -34,7 +46,7 @@ macro delegate_return_parent(source, targets)
     for i in 1:n
         funcname = esc(funcnames[i])
         fdefs[i] = quote
-                     ($funcname)(a::($typename), args...) =
+                     ($funcname)(a::($typename), $(_argsig(funcnames[i]))) =
                        (($funcname)(a.$fieldname, args...); a)
                    end
     end


### PR DESCRIPTION
(This PR is more like an issue report but I wanted to attach a possible solution.  I am open to alternative fixes if any.)

It seems that the combination of `DataStructures` and [`Setfield`](https://github.com/jw3126/Setfield.jl) introduces some method ambiguities to `Base.get`.  They are between `get(::DictType_from_DataStructures.jl, ...)` and `get(obj, ::Setfield.Lens)`.  I'm posting the issue here because I think it's easier to fix in DataStructures.jl. (cc @jw3126)

You can invoke the ambiguity by, for example

```julia
julia> using Setfield, DataStructures

julia> get(MultiDict(:a=>[1]), @lens _[:a])
ERROR: MethodError: get(::MultiDict{Symbol,Int64}, ::Setfield.IndexLens{Tuple{Symbol}}) is ambiguous. Candidates:
  get(obj, l::Setfield.IndexLens) in Setfield at /home/takafumi/.julia/dev/Setfield/src/lens.jl:224
  get(a::MultiDict, args...) in DataStructures at /home/takafumi/.julia/packages/DataStructures/6r6kb/src/delegate.jl:21
Possible fix, define
  get(::MultiDict, ::Setfield.IndexLens)
```

I think the problem is that the `@delegate` macro declares the ownership of too many method signatures.  It can be fixed by only delegating the 3-arg `get` method.  In this PR, I propose to do this by adding a mapping between the method name and the desired arity like this

https://github.com/JuliaCollections/DataStructures.jl/blob/3f5c280dbed8752d4fa277319f8ad299f9b1f027/src/delegate.jl#L12-L15

It's not the most elegant solution but it works and extensible (i.e., supporting a new method can be done by just adding a new entry to `_arities`).
