### PR TITLE
Adding constructors for Circular(Deque | Buffer) | Deque from iterators

### DIFF
--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -13,6 +13,12 @@ end
 
 CircularDeque{T}(n::Int) where {T} = CircularDeque(Vector{T}(undef, n), n, 0, 1, n)
 
+# constructor for iterator
+function CircularDeque(iter)
+    n = length(iter)
+    CircularDeque(collect(iter), n, n, 1, n)
+end
+
 Base.length(D::CircularDeque) = D.n
 Base.eltype(::Type{CircularDeque{T}}) where {T} = T
 capacity(D::CircularDeque) = D.capacity

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -12,11 +12,16 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     first::Int
     length::Int
     buffer::Vector{T}
-
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(undef, capacity))
 end
 
-CircularBuffer(capacity) = CircularBuffer{Any}(capacity)
+CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(capacity, 1, 0, Vector{T}(undef, capacity))
+CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
+
+# constructor for iterator
+function CircularBuffer(iter)
+    n = length(iter)
+    CircularBuffer{eltype(iter)}(n, 1, n, collect(iter))
+end
 
 """
     empty!(cb)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -80,6 +80,16 @@ Create a deque of type `T`.
 """
 deque(::Type{T}) where {T} = Deque{T}()
 
+# constructor for iterator
+function Deque(iter)
+    n = length(iter)
+    d = deque(eltype(iter))
+    for e in iter
+        push!(d, e)
+    end
+    d
+end
+
 isempty(q::Deque) = q.len == 0
 length(q::Deque) = q.len
 num_blocks(q::Deque) = q.nblocks

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -80,6 +80,35 @@
         for i in 1:5 push!(D, i) end
         @test collect([i for i in D]) == collect(1:5)
     end
+
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        D = CircularDeque(1:3)
+        @test_skip eltype(D) == Int
+        @test capacity(D) == 3
+        @test length(D) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        D = CircularDeque(MyIter(10))
+        @test_skip eltype(D) == Any
+        @test capacity(D) == 10
+        @test length(D) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError CircularDeque(MyIter2(10))
+    end
 end
 
 nothing

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -126,4 +126,34 @@
             @test Array(cb) == [21, 42, 42]
         end
     end
+
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        C = CircularBuffer(1:3)
+        @test_skip eltype(C) == Int
+        @test capacity(C) == 3
+        @test length(C) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        C = CircularBuffer(MyIter(10))
+        @test_skip eltype(C) == Any
+        @test capacity(C) == 10
+        @test length(C) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError CircularBuffer(MyIter2(10))
+    end
+
 end

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -200,4 +200,31 @@
         @test isempty(q)
     end
 
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        D = Deque(1:3)
+        @test_skip eltype(D) == Int
+        @test length(D) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        D = Deque(MyIter(10))
+        @test_skip eltype(D) == Any
+        @test length(D) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError Deque(MyIter2(10))
+    end
+
 end # @testset Deque


### PR DESCRIPTION
This adds constructors from iterators for `CircularDeque`, `CircularBuffer`, and `Deque`. I did not include `LinkedList` since the interface does not have a generic append method.

6 tests are skipped as they depend on #513.

This PR also removed an inner constructor for `CircularBuffer` and made it an outer constructor instead. 

Example:

```julia
julia> c = CircularDeque(1:3)
CircularDeque{Int64}([1,2,3])

julia> capacity(c)
3
```