### PR TITLE
Trie now converts val to the correct type

### DIFF
--- a/src/trie.jl
+++ b/src/trie.jl
@@ -33,7 +33,8 @@ Trie(kv::AbstractVector{Tuple{K,V}}) where {K<:AbstractString,V} = Trie{V}(kv)
 Trie(kv::AbstractDict{K,V}) where {K<:AbstractString,V} = Trie{V}(kv)
 Trie(ks::AbstractVector{K}) where {K<:AbstractString} = Trie{Nothing}(ks, similar(ks, Nothing))
 
-function setindex!(t::Trie{T}, val::T, key::AbstractString) where T
+function setindex!(t::Trie{T}, val, key::AbstractString) where T
+    value = convert(T, val) # we don't want to iterate before finding out it fails
     node = t
     for char in key
         if !haskey(node.children, char)
@@ -42,7 +43,7 @@ function setindex!(t::Trie{T}, val::T, key::AbstractString) where T
         node = node.children[char]
     end
     node.is_key = true
-    node.value = val
+    node.value = value
 end
 
 function getindex(t::Trie, key::AbstractString)

--- a/test/test_trie.jl
+++ b/test/test_trie.jl
@@ -8,10 +8,11 @@
         t["emma"] = 30
         t["rob"] = 27
         t["roger"] = 52
+        t["kevin"] = Int8(11)
 
         @test haskey(t, "roger")
         @test get(t,"rob",nothing) == 27
-        @test sort(keys(t)) == ["amy", "ann", "emma", "rob", "roger"]
+        @test sort(keys(t)) == ["amy", "ann", "emma", "kevin", "rob", "roger"]
         @test t["rob"] == 27
         @test sort(keys_with_prefix(t,"ro")) == ["rob", "roger"]
     end


### PR DESCRIPTION
Making `setindex!` work similarly to the standard library `Dict` and other containers. Now this works:
```julia
julia> T = Trie{Int64}()
Trie{Int64}(140018024147216, Dict{Char,Trie{Int64}}(), false)

julia> T["abc"] = 3
3

julia> T["def"] = Int8(5)
5
```

where before it failed.