### PR TITLE
deprecate ClassifierCollection

### DIFF
--- a/src/classified_collections.jl
+++ b/src/classified_collections.jl
@@ -6,6 +6,11 @@
 
 mutable struct ClassifiedCollections{K, Collection}
     map::Dict{K, Collection}
+
+    function ClassifiedCollections{K, Collection}(map) where {K, Collection}
+        @warn "ClassifiedCollections will be removed from DataStructures.jl in a future release."
+        return new(map)
+    end
 end
 
 ## constructors

--- a/src/classified_collections.jl
+++ b/src/classified_collections.jl
@@ -8,7 +8,7 @@ mutable struct ClassifiedCollections{K, Collection}
     map::Dict{K, Collection}
 
     function ClassifiedCollections{K, Collection}(map) where {K, Collection}
-        @warn "ClassifiedCollections will be removed from DataStructures.jl in a future release."
+        @warn "ClassifiedCollections will be removed from DataStructures.jl in v0.18."
         return new(map)
     end
 end


### PR DESCRIPTION
First part of #496  

I don't know what to recommend using instead.
Probably a `DefaultDict(Collection)`?
