### PR TITLE
Update docs generation (minor)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.2
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,9 +29,4 @@ makedocs(
 
 deploydocs(
     repo = "github.com/JuliaCollections/DataStructures.jl.git",
-    julia  = "0.7",
-    latest = "master",
-    target = "build",
-    deps = nothing,  # we use the `format = :html`, without `mkdocs`
-    make = nothing,  # we use the `format = :html`, without `mkdocs`
 )


### PR DESCRIPTION
* Use Julia 1.2 for documentation build on travis
* Remove unnecessary/unused arguments to `deploydocs()`

Fixes #526 