### PR TITLE
Allow custom comparer in BinaryHeap

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -106,11 +106,11 @@ mutable struct BinaryHeap{T,Comp} <: AbstractHeap{T}
     comparer::Comp
     valtree::Vector{T}
 
-    BinaryHeap{T,Comp}() where {T,Comp} = new{T,Comp}(Comp(), Vector{T}())
+    BinaryHeap{T,Comp}(; comparer::Comp = Comp()) where {T,Comp} = new{T,Comp}(comparer, Vector{T}())
 
-    function BinaryHeap{T,Comp}(xs::AbstractVector{T}) where {T,Comp}
-        valtree = _make_binary_heap(Comp(), T, xs)
-        new{T,Comp}(Comp(), valtree)
+    function BinaryHeap{T,Comp}(xs::AbstractVector{T}; comparer::Comp = Comp()) where {T,Comp}
+        valtree = _make_binary_heap(comparer, T, xs)
+        new{T,Comp}(comparer, valtree)
     end
 end
 


### PR DESCRIPTION
This allows using a custom ordering, in the same way you would for sorting an array of structs. Posting an array example for reference, and how this is easily applied to heaps.

#### Array example
``` julia
struct MyStruct
    a::Int64
    b::Int64
    c::Int64
end

struct FieldOrder
    sym::Symbol
    ord::Base.Ordering
end

struct MyStructOrdering <: Base.Ordering
    field_orderings::AbstractVector{FieldOrder}
end

function Base.lt(struct_ordering::MyStructOrdering, a, b)
    for field_ordering in struct_ordering.field_orderings
        sym = field_ordering.sym
        ord = field_ordering.ord
        va = getproperty(a, sym)
        vb = getproperty(b, sym)
        Base.lt(ord, va, vb) && return true
        Base.lt(ord, vb, va) && return false
    end
    false # a and b are equal
end

mystructs = collect(MyStruct(rand(-1:1, 3)...) for x=1:9)

mystruct_ordering = MyStructOrdering([
    FieldOrder(:a, Base.Reverse),
    FieldOrder(:b, Base.Forward),
    FieldOrder(:c, Base.Reverse)
    ])
    
sorted = sort(mystructs, order=mystruct_ordering)
```

#### Works for heaps too (leverages the above code)
``` julia
using DataStructures

#DataStructures.compare = Base.lt # Why won't this shorthand work?
function DataStructures.compare(comp::MyStructOrdering, a, b)
    Base.lt(comp, a, b)
end

# create heap
h = BinaryHeap{MyStruct,MyStructOrdering}(comparer=mystruct_ordering)

# fill heap from previous input array
for s in mystructs push!(h,s) end

# unload heap in sorted order
heapsorted = []
while !isempty(h) push!(heapsorted,pop!(h)) end

# ensure same results as previous sort(array) technique
sorted == heapsorted
```