### PR TITLE
Add == for stack

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -25,3 +25,5 @@ empty!(s::Stack) = (empty!(s.store); s)
 iterate(st::Stack, s...) = iterate(reverse_iter(st.store), s...)
 
 reverse_iter(s::Stack{T}) where {T} = DequeIterator{T}(s.store)
+
+==(x::Stack, y::Stack) = x.store == y.store

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -38,6 +38,21 @@
             @test isempty(s) == (i == n)
             @test length(s) == n - i
         end
+        
+        s = Stack{Int}()
+        t = Stack{Int}()
+        
+        @test s == t
+        push!(s, 10)
+        @test s != t
+        push!(t, 10)
+        @test s == t
+        push!(t, 20)
+        @test s != t
+        
+        r = Stack{Float32}()
+        push!(r, 10)
+        @test s == r
     end
 
     @testset "empty!" begin

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -38,7 +38,9 @@
             @test isempty(s) == (i == n)
             @test length(s) == n - i
         end
-        
+    end
+    
+    @testset "==" begin
         s = Stack{Int}()
         t = Stack{Int}()
         
@@ -50,9 +52,11 @@
         push!(t, 20)
         @test s != t
         
-        r = Stack{Float32}()
-        push!(r, 10)
-        @test s == r
+        @testset "different types" begin
+            r = Stack{Float32}()
+            push!(r, 10)
+            @test s == r
+        end
     end
 
     @testset "empty!" begin


### PR DESCRIPTION
Currently this fails unless the stacks are the same object in memory. All that was needed is a fallback to the deque storage `==` test.