### PR TITLE
Remove trailing whitespace and newlines

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -91,7 +91,7 @@ v0.4.2 / 2016-01-13
 ==================
 
   * Fix OrderedDict constructors (with tests)
-  * Add IntSet to DataStructures 
+  * Add IntSet to DataStructures
     (see #114, https://github.com/JuliaLang/julia/pull/10065)
   * Dead code, tree.jl removal
 
@@ -341,7 +341,7 @@ v0.2.5 / 2013-10-08
   * Revised implementation of Deque, without using Union(Nothing, DequeBlock).
   * Fixed the doc regarding API for heaps: binary_heap -> binary_{min|max}heap and mutable_binary_heap -> mutable_binary_{min|max}heap
   * Added 1 missing API call to the documentation
-  * Fixed bugs related to Dequeue functions front and back. 
+  * Fixed bugs related to Dequeue functions front and back.
     * Front would give garbage data when called on a newly created queue, and back when popping a queue from the front.
   * Implemented simple show method inside Dequeue to hide unnecessary (large!) implementation detail from the client, in particular when using REPL
 
@@ -374,4 +374,3 @@ v0.2.5 / 2013-10-08
   * add stack and queue (tested)
   * add Dequeue (tested)
   * Initial commit
-

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -108,4 +108,3 @@ SUITE["SparseIntSet"]["iterate two"] =
 
 SUITE["SparseIntSet"]["iterate two exclude one"] =
 	@benchmarkable iterate_two_exclude_one_bench(x,y,z) setup=x_y_z_setup
-

--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -55,7 +55,7 @@ h = MutableBinaryMaxHeap([1,4,3,2])    # create a mutable min/max heap from a ve
 ```
 
 ## Min-max heaps
-Min-max heaps maintain the minimum _and_ the maximum of a set, 
+Min-max heaps maintain the minimum _and_ the maximum of a set,
 allowing both to be retrieved in constant (`O(1)`) time.
 The min-max heaps in this package are subtypes of `AbstractMinMaxHeap <: AbstractHeap`
 and have the same interface as other heaps with the following additions:
@@ -73,7 +73,7 @@ popmax!(h, k)  # remove and return the largest k elements
 popall!(h)     # remove and return all the elements, sorted smallest to largest
 popall!(h, o)  # remove and return all the elements according to ordering o
 ```
-The usual `top(h)` and `pop!(h)` are defined to be `minimum(h)` and `popmin!(h)`, 
+The usual `top(h)` and `pop!(h)` are defined to be `minimum(h)` and `popmin!(h)`,
 respectively.
 
 This package includes an implementation of a binary min-max heap (`BinaryMinMaxHeap`).

--- a/docs/src/sorted_containers.md
+++ b/docs/src/sorted_containers.md
@@ -452,7 +452,7 @@ end
 
 Here, `st1` and `st2` are semitokens that refer to the container `sc`.
 Token `(sc,st1)` may not be the before-start token and
-token `(sc,st2)` may not be the past-end token. 
+token `(sc,st2)` may not be the past-end token.
 It is acceptable for `(sc,st1)` to be the past-end token or `(sc,st2)`
 to be the before-start token or both (in these cases, the body is not executed).
 If `compare(sc,st1,st2)==1` then the body is not executed. A second
@@ -765,7 +765,7 @@ Lt((x,y) -> isless(lowercase(x),lowercase(y)))
 The ordering object is indicated in the above list of constructors in
 the `o` position (see above for constructor syntax).
 
-This approach may suffer from a performance hit because higher performance 
+This approach may suffer from a performance hit because higher performance
 may be possible if an equality method is also available as well as a
 less-than method.
 A more complicated but higher-performance method to implement

--- a/docs/src/sparse_int_set.md
+++ b/docs/src/sparse_int_set.md
@@ -1,8 +1,8 @@
 # DataStructures.SparseIntSet
 
 Implementation of a __Sparse Integer Set__, for background see [Sparse Sets](https://www.computist.xyz/2018/06/sparse-sets.html).
-Only positive non-zero `Int`s are allowed inside the set. 
+Only positive non-zero `Int`s are allowed inside the set.
 The idea is to have one **packed** `Vector` storing all the `Int`s contained in the set as to allow for fast iteration, and a sparse, paged **reverse** `Vector` with the position of a particular `Int` inside the **packed** `Vector`. This allows for very fast iteration, insertion and deletion of indices.
-Most behavior is similar to a normal `IntSet`, however `collect`, `first` and `last` are with respected to the **packed** vector, in which the ordering is not guaranteed. 
-The **reverse** `Vector` is paged, meaning that it is a `Vector{Vector{Int}}` where each of the `Vector{Int}`s has the length of one memory page of `Int`s. Every time an index that was not yet in the range of the already present pages, a new one will be created and added to the **reverse**, allowing for dynamical growth. 
-Popping the last `Int` of a particular page will automatically clean up the memory of that page. 
+Most behavior is similar to a normal `IntSet`, however `collect`, `first` and `last` are with respected to the **packed** vector, in which the ordering is not guaranteed.
+The **reverse** `Vector` is paged, meaning that it is a `Vector{Vector{Int}}` where each of the `Vector{Int}`s has the length of one memory page of `Int`s. Every time an index that was not yet in the range of the already present pages, a new one will be created and added to the **reverse**, allowing for dynamical growth.
+Popping the last `Int` of a particular page will automatically clean up the memory of that page.

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,8 +1,8 @@
 """
     CircularBuffer{T}(n)
 
-The CircularBuffer type implements a circular buffer of fixed capacity 
-where new items are pushed to the back of the list, overwriting values 
+The CircularBuffer type implements a circular buffer of fixed capacity
+where new items are pushed to the back of the list, overwriting values
 in a circular fashion.
 
 Allocate a buffer of elements of type `T` with maximum capacity `n`.
@@ -115,7 +115,7 @@ end
 """
     pushfirst!(cb, data)
 
-Insert one or more items at the beginning of CircularBuffer 
+Insert one or more items at the beginning of CircularBuffer
 and overwrite back if full.
 """
 function pushfirst!(cb::CircularBuffer, data)

--- a/src/container_loops.jl
+++ b/src/container_loops.jl
@@ -258,7 +258,7 @@ onlysemitokens(ba::SAIterableTypesBase) = SAOnlySemiTokensIteration(ba)
 
 
 
-    
+
 function nexthelper(c::SAContainer, state::SAIterationState)
     sn = state.next
     (sn < 3 || !(sn in c.bt.useddatacells)) && throw(BoundsError())
@@ -266,12 +266,12 @@ function nexthelper(c::SAContainer, state::SAIterationState)
 end
 
 
-    
+
 getitem(::SDMIterableTypesBase, dt, sn) = dt.k => dt.d
 getitem(::SSIterableTypesBase, dt, sn) = dt.k
 getitem(::SDMKeyIteration, dt, sn) = dt.k
 getitem(::SDMValIteration, dt, sn) = dt.d
-getitem(::SDMSemiTokenIteration, dt, sn) = (IntSemiToken(sn), dt.k, dt.d) 
+getitem(::SDMSemiTokenIteration, dt, sn) = (IntSemiToken(sn), dt.k, dt.d)
 getitem(::SSSemiTokenIteration, dt, sn) = (IntSemiToken(sn), dt.k)
 getitem(::SDMSemiTokenKeyIteration, dt, sn) = (IntSemiToken(sn), dt.k)
 getitem(::SDMSemiTokenValIteration, dt, sn) = (IntSemiToken(sn), dt.d)

--- a/src/fenwick.jl
+++ b/src/fenwick.jl
@@ -5,17 +5,17 @@ end
 
 """
     FenwickTree{T}(n)
-    
+
 Constructs a [`FenwickTree`](https://en.wikipedia.org/wiki/Fenwick_tree) of length `n`.
- 
+
 """
 FenwickTree{T}(n::Integer) where T = FenwickTree{T}(zeros(T, n), n)
 
 """
-    FenwickTree(counts::AbstractArray) 
-    
+    FenwickTree(counts::AbstractArray)
+
 Constructs a [`FenwickTree`](https://en.wikipedia.org/wiki/Fenwick_tree) from an array of `counts`
- 
+
 """
 function FenwickTree(a::AbstractVector{U}) where U
     n = length(a)
@@ -34,7 +34,7 @@ Base.eltype(::Type{FenwickTree{T}}) where T = T
 
 Increases the value of the [`FenwickTree`] by `val` from the index `ind` upto the length of the Fenwick Tree.
 
-""" 
+"""
 function inc!(ft::FenwickTree{T}, ind::Integer, val = 1) where T
     val0 = convert(T, val)
     i = ind
@@ -51,7 +51,7 @@ end
 
 Decreases the value of the [`FenwickTree`] by `val` from the index `ind` upto the length of the Fenwick Tree.
 
-""" 
+"""
 dec!(ft::FenwickTree, ind::Integer, val = 1 ) = inc!(ft, ind, -val)
 
 """
@@ -59,7 +59,7 @@ dec!(ft::FenwickTree, ind::Integer, val = 1 ) = inc!(ft, ind, -val)
 
 Increases the value of the [`FenwickTree`] by `val` from the indices from `left` and decreases it from the `right`.
 
-"""    
+"""
 function incdec!(ft::FenwickTree{T}, left::Integer, right::Integer, val = one(T)) where T
     val0 = convert(T, val)
     inc!(ft, left, val0)
@@ -68,7 +68,7 @@ end
 
 """
     prefixsum(ft::FenwickTree{T}, ind)
-    
+
 Return the cumulative sum from index 1 upto `ind` of the [`FenwickTree`](@ref)
 
 # Examples
@@ -86,7 +86,7 @@ function prefixsum(ft::FenwickTree{T}, ind::Integer) where T
     i = ind
     n = ft.n
     @boundscheck 1 <= i <= n || throw(ArgumentError("$i should be in between 1 and $n"))
-    @inbounds while i > 0 
+    @inbounds while i > 0
         sum += ft.bi_tree[i]
         i -= i&(-i)
     end

--- a/src/heaps/minmax_heap.jl
+++ b/src/heaps/minmax_heap.jl
@@ -6,9 +6,9 @@
 
 mutable struct BinaryMinMaxHeap{T} <: AbstractMinMaxHeap{T}
     valtree::Vector{T}
-    
+
     BinaryMinMaxHeap{T}() where {T} = new{T}(Vector{T}())
-    
+
     function BinaryMinMaxHeap(xs::AbstractVector{T}) where {T}
         valtree = _make_binary_minmax_heap(xs)
         new{T}(valtree)
@@ -41,7 +41,7 @@ function _minmax_heap_bubble_up!(A::AbstractVector, i::Integer)
             # bubble up min
             _minmax_heap_bubble_up!(A, i, Forward)
         end
-        
+
     else
         # max level
         if i > 1 && A[i] < A[hparent(i)]
@@ -55,7 +55,7 @@ function _minmax_heap_bubble_up!(A::AbstractVector, i::Integer)
             _minmax_heap_bubble_up!(A, i, Reverse)
         end
     end
-   return 
+   return
 end
 
 function _minmax_heap_bubble_up!(A::AbstractVector, i::Integer, o::Ordering, x=A[i])
@@ -67,7 +67,7 @@ function _minmax_heap_bubble_up!(A::AbstractVector, i::Integer, o::Ordering, x=A
             _minmax_heap_bubble_up!(A, gparent, o)
         end
     end
-    return          
+    return
 end
 
 function _minmax_heap_trickle_down!(A::AbstractVector, i::Integer)
@@ -80,7 +80,7 @@ function _minmax_heap_trickle_down!(A::AbstractVector, i::Integer)
 end
 
 function _minmax_heap_trickle_down!(A::AbstractVector, i::Integer, o::Ordering, x=A[i])
-                    
+
     if haschildren(i, A)
         # get the index of the extremum (min or max) descendant
         extremum = o === Forward ? minimum : maximum
@@ -106,7 +106,7 @@ function _minmax_heap_trickle_down!(A::AbstractVector, i::Integer, o::Ordering, 
     end
     return
 end
-                    
+
 ################################################
 #
 # utilities
@@ -118,10 +118,10 @@ end
 @inline rchild(i) = 2*i+1
 @inline children(i) = (lchild(i), rchild(i))
 @inline hparent(i) = i ÷ 2
-@inline on_minlevel(i) = level(i) % 2 == 0 
+@inline on_minlevel(i) = level(i) % 2 == 0
 @inline haschildren(i, A) = lchild(i) ≤ length(A)
 @inline isgrandchild(j, i) = j > rchild(i)
-@inline hasgrandparent(i) = i ≥ 4 
+@inline hasgrandparent(i) = i ≥ 4
 
 """
     children_and_grandchildren(maxlen, i)
@@ -189,7 +189,7 @@ end
 
 """
     popmin!(h::BinaryMinMaxHeap) -> min
-                        
+
 Remove the minimum value from the heap.
 """
 function popmin!(h::BinaryMinMaxHeap)
@@ -204,19 +204,19 @@ function popmin!(h::BinaryMinMaxHeap)
     return x
 end
 
-                        
+
 """
     popmin!(h::BinaryMinMaxHeap, k::Integer) -> vals
-                        
+
 Remove up to the `k` smallest values from the heap.
 """
-@inline function popmin!(h::BinaryMinMaxHeap, k::Integer) 
+@inline function popmin!(h::BinaryMinMaxHeap, k::Integer)
     return [popmin!(h) for _ in 1:min(length(h), k)]
 end
 
 """
     popmax!(h::BinaryMinMaxHeap) -> max
-                        
+
 Remove the maximum value from the heap.
 """
 function popmax!(h::BinaryMinMaxHeap)
@@ -228,55 +228,54 @@ function popmax!(h::BinaryMinMaxHeap)
         @inbounds valtree[i] = y
         _minmax_heap_trickle_down!(valtree, i)
     end
-    return x    
+    return x
 end
 
 """
     popmax!(h::BinaryMinMaxHeap, k::Integer) -> vals
-                        
+
 Remove up to the `k` largest values from the heap.
 """
-@inline function popmax!(h::BinaryMinMaxHeap, k::Integer) 
-    return [popmax!(h) for _ in 1:min(length(h), k)]                    
+@inline function popmax!(h::BinaryMinMaxHeap, k::Integer)
+    return [popmax!(h) for _ in 1:min(length(h), k)]
 end
-                        
-                        
+
+
 function push!(h::BinaryMinMaxHeap, v)
-    valtree = h.valtree        
+    valtree = h.valtree
     push!(valtree, v)
     _minmax_heap_bubble_up!(valtree, length(valtree))
 end
 
 """
     top(h::BinaryMinMaxHeap)
-                        
+
 Get the top (minimum) of the heap.
 """
 @inline top(h::BinaryMinMaxHeap) = minimum(h)
 
-@inline function minimum(h::BinaryMinMaxHeap) 
+@inline function minimum(h::BinaryMinMaxHeap)
     valtree = h.valtree
     !isempty(h) || throw(ArgumentError("heap must be non-empty"))
     return @inbounds h.valtree[1]
 end
 
-@inline function maximum(h::BinaryMinMaxHeap) 
+@inline function maximum(h::BinaryMinMaxHeap)
     valtree = h.valtree
     !isempty(h) || throw(ArgumentError("heap must be non-empty"))
     return @inbounds maximum(valtree[1:min(end, 3)])
 end
-                        
+
 empty!(h::BinaryMinMaxHeap) = (empty!(h.valtree); h)
-                        
+
 
 """
     popall!(h::BinaryMinMaxHeap, ::Ordering = Forward)
-                        
+
 Remove and return all the elements of `h` according to
-the given ordering. Default is `Forward` (smallest to 
+the given ordering. Default is `Forward` (smallest to
 largest).
 """
 popall!(h::BinaryMinMaxHeap) = popall!(h, Forward)
 popall!(h::BinaryMinMaxHeap, ::ForwardOrdering) = popmin!(h, length(h))
 popall!(h::BinaryMinMaxHeap, ::ReverseOrdering) = popmax!(h, length(h))
-

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -165,25 +165,25 @@ mutable struct MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
         new{VT, Comp}(Comp(), nodes, node_map)
     end
 
-    function MutableBinaryHeap{VT, Comp}(xs::AbstractVector{VT}) where {VT, Comp} 
+    function MutableBinaryHeap{VT, Comp}(xs::AbstractVector{VT}) where {VT, Comp}
         nodes, node_map = _make_mutable_binary_heap(Comp(), VT, xs)
         new{VT, Comp}(Comp(), nodes, node_map)
     end
 end
-                            
+
 const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, LessThan}
 const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, GreaterThan}
-                            
+
 MutableBinaryMinHeap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap{T}(xs)
 MutableBinaryMaxHeap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap{T}(xs)
 
 # deprecated constructors
-                            
+
 @deprecate mutable_binary_minheap(::Type{T}) where {T} MutableBinaryMinHeap{T}()
 @deprecate mutable_binary_minheap(xs::AbstractVector{T}) where {T} MutableBinaryMinHeap(xs)
 @deprecate mutable_binary_maxheap(::Type{T}) where {T} MutableBinaryMaxHeap{T}()
 @deprecate mutable_binary_maxheap(xs::AbstractVector{T}) where {T} MutableBinaryMaxHeap(xs)
-    
+
 
 function show(io::IO, h::MutableBinaryHeap)
     print(io, "MutableBinaryHeap(")
@@ -265,8 +265,8 @@ end
 """
     delete!{T}(h::MutableBinaryHeap{T}, i::Int)
 
-Deletes the element with handle `i` from heap `h` . 
-"""     
+Deletes the element with handle `i` from heap `h` .
+"""
 function delete!(h::MutableBinaryHeap{T}, i::Int) where T
      nd_id = h.node_map[i]
     _binary_heap_pop!(h.comparer, h.nodes, h.node_map, nd_id)

--- a/src/multi_dict.jl
+++ b/src/multi_dict.jl
@@ -57,8 +57,8 @@ empty!(d::MultiDict) = (empty!(d.d); d)
 function insert!(d::MultiDict{K,V}, k, v) where {K,V}
     if !haskey(d.d, k)
         d.d[k] = V[]
-    end    
-    push!(d.d[k], v)    
+    end
+    push!(d.d[k], v)
     return d
 end
 

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -381,7 +381,7 @@ function merge!(combine::Function, d::AbstractDict, other::PriorityQueue)
     return d
 end
 
-# Opaque not to be exported. 
+# Opaque not to be exported.
 mutable struct _PQIteratorState{K, V, O <: Ordering}
     pq::PriorityQueue{K, V, O}
     _PQIteratorState{K, V, O}(pq::PriorityQueue{K, V, O}) where {K, V, O <: Ordering} = new(pq)
@@ -400,7 +400,7 @@ _iterate(pq::PriorityQueue, ::Nothing) = nothing
 iterate(pq::PriorityQueue, ::Nothing) = nothing
 
 function iterate(pq::PriorityQueue, ordered::Bool=true)
-    if ordered 
+    if ordered
         isempty(pq) && return nothing
         state = _PQIteratorState(PriorityQueue(copy(pq.xs), pq.o, copy(pq.index)))
         return dequeue_pair!(state.pq), state
@@ -413,6 +413,5 @@ function iterate(pq::PriorityQueue, state::_PQIteratorState)
     isempty(state.pq) && return nothing
     return dequeue_pair!(state.pq), state
 end
-    
-iterate(pq::PriorityQueue, i) = _iterate(pq, iterate(pq.index, i))
 
+iterate(pq::PriorityQueue, i) = _iterate(pq, iterate(pq.index, i))

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -84,7 +84,7 @@ SortedDict{K,D}(ps::Pair...) where {K,D} = SortedDict{K,D,ForwardOrdering}(Forwa
     SortedDict(o, k1=>v1, k2=>v2, ...)
 
 Construct a `SortedDict` from the given pairs with the specified
-ordering `o`. The key type and value type are inferred from the 
+ordering `o`. The key type and value type are inferred from the
 given pairs.
 """
 SortedDict(o::Ordering, ps::Pair...) = SortedDict(o, ps)

--- a/src/sparse_int_set.jl
+++ b/src/sparse_int_set.jl
@@ -5,7 +5,7 @@ const NULL_INT_PAGE = Vector{Int}()
 mutable struct SparseIntSet
     packed ::Vector{Int}
     reverse::Vector{Vector{Int}}
-    counters::Vector{Int}  # counts the number of real elements in each page of reverse. 
+    counters::Vector{Int}  # counts the number of real elements in each page of reverse.
 end
 
 SparseIntSet() = SparseIntSet(Int[], Vector{Int}[], Int[])
@@ -117,7 +117,7 @@ Base.@propagate_inbounds function pop!(s::SparseIntSet, id::Integer)
         throw(BoundsError(s, id))
     end
     @inbounds begin
-        packed_endid = s.packed[end] 
+        packed_endid = s.packed[end]
         from_page, from_offset = pageid_offset(s, id)
         to_page, to_offset = pageid_offset(s, packed_endid)
 
@@ -144,7 +144,7 @@ function pop!(s::SparseIntSet, id::Integer, default)
 end
 popfirst!(s::SparseIntSet) = pop!(s, first(s))
 
-iterate(set::SparseIntSet, args...) = iterate(set.packed, args...) 
+iterate(set::SparseIntSet, args...) = iterate(set.packed, args...)
 
 last(s::SparseIntSet) = isempty(s) ? throw(ArgumentError("Empty set has no last element.")) : last(s.packed)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ tests = ["int_set",
          "multi_dict",
          "circular_buffer",
          "sorting",
-         "priority_queue", 
-         "fenwick", 
+         "priority_queue",
+         "fenwick",
          "robin_dict",
         ]
 

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -3,7 +3,7 @@
 @testset "Accumulators" begin
 
     ct = counter(String)
-    
+
     @testset "Core Functionality" begin
         @assert isa(ct, Accumulator{String,Int})
 
@@ -174,12 +174,12 @@
 
         @test_throws BoundsError nsmallest(counter("a"),2)
     end
-    
+
     @testset "reset!" begin
         ct = counter("abbbcddddda") # ['d'=>5, 'b'=>3, 'a'=>2, 'c'=>1]
         @test reset!(ct, 'b') == 3
         @test ct == counter("acddddda")
-        
+
         @test reset!(ct, 'x') == 0
     end
 
@@ -187,60 +187,57 @@
         orig = counter("aabbbcccc")
         dup = copy(orig)
         @test orig == dup
-        
+
         # Modifying copy should not modify original
         inc!(orig, 'a')
         @test orig != dup
     end
-    
+
     @testset "Multiset" begin
         @testset "issubset" begin
             @test issubset(counter([1,2,3]), counter([1,2,3]))
             @test !issubset(counter([1,2,3,4]), counter([1,2,3]))
             @test issubset(counter([1,2]), counter([1,2,3]))
-            
+
             @test issubset(counter([1,2,3]), counter([1,2,3,3]))
             @test !issubset(counter([1,2,3,3]), counter([1,2,3]))
         end
-        
+
         @testset "setdiff" begin
             @test setdiff(counter([1,2,3]), counter([2, 4])) == counter([3, 1])
             @test setdiff(counter([1,2,3]), counter([2,2,4])) == counter([3, 1])
             @test setdiff(counter([1,2,2,2,3]), counter([2,2,4])) == counter([1,2,3])
-            
+
             nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException setdiff(counter("aabbcc"), nonmultiset)
         end
-        
+
         @testset "union" begin
             @test ∪(counter([1,2,3]), counter([1,2,3])) == counter([1,2,3])
             @test ∪(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,2,3])
             @test ∪(counter([1,3]), counter([2,2])) == counter([1,2,2,3])
             @test ∪(counter([1,2,3]), counter(Int[])) == counter([1,2,3])
-            
+
             nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∪ nonmultiset)
             @test_throws DataStructures.MultiplicityException (nonmultiset ∪ counter("aabbcc"))
         end
- 
+
         @testset "intersect" begin
             @test ∩(counter([1,2,3]), counter([1,2,3])) == counter([1,2,3])
             @test ∩(counter([1,2,3]), counter([1,2,2,3])) == counter([1,2,3])
             @test ∩(counter([1,3]), counter([2,2])) == counter(Int[])
             @test ∩(counter([1,2,3]), counter(Int[])) == counter(Int[])
-            
-            
+
+
             nonmultiset = counter(Dict([('a',-10), ('b',20)]))
             @test_throws DataStructures.MultiplicityException (counter("aabbcc") ∩ nonmultiset)
             @test_throws DataStructures.MultiplicityException (nonmultiset ∩ counter("aabbcc"))
         end
 
 
-    
+
 
     end
 
 end # @testset Accumulators
-
-
-

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -65,7 +65,7 @@
             @test popfirst!(D) === i
         end
     end
-    
+
     @testset "pushfirst! works on an empty deque" begin
         # Test that pushfirst! works on an empty deque, and that front/back give the right answer
         D = CircularDeque{Int}(5)

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -11,14 +11,14 @@
             @test eltype(cb) == Int
             @test eltype(typeof(cb)) == Int
         end
-        
+
         @testset "With 1 element" begin
             push!(cb, 1)
             @test length(cb) == 1
             @test capacity(cb) == 5
             @test isfull(cb) == false
         end
-        
+
         @testset "Appending many elements" begin
             append!(cb, 2:8)
             @test length(cb) == capacity(cb)
@@ -27,7 +27,7 @@
             @test isfull(cb) == true
             @test convert(Array, cb) == Int[4,5,6,7,8]
         end
-            
+
         @testset "getindex" begin
             @test cb[1] == 4
             @test cb[2] == 5
@@ -39,19 +39,19 @@
             @test cb[3:4] == Int[6,7]
             @test cb[[1,5]] == Int[4,8]
         end
-        
+
         @testset "setindex" begin
             cb[3] = 999
             @test convert(Array, cb) == Int[4,5,999,7,8]
         end
     end
-    
+
     @testset "other constructor" begin
         cb = CircularBuffer(10)
         @test length(cb) == 0
         @test typeof(cb) <: CircularBuffer{Any}
     end
-    
+
     @testset "pushfirst" begin
         cb = CircularBuffer{Int}(5)  # New, empty one for full test coverage
         for i in -5:5
@@ -63,7 +63,7 @@
             @test arr[idx] == n
         end
     end
-    
+
     @testset "Issue 429" begin
         cb = CircularBuffer{Int}(5)
         map(x -> pushfirst!(cb, x), 1:8)
@@ -81,7 +81,7 @@
         pushfirst!(cb, 2)
         @test cb == [2, 1]
     end
-    
+
     @testset "empty!" begin
         cb = CircularBuffer{Int}(5)
         push!(cb, 13)
@@ -101,7 +101,7 @@
         @test isempty(cb)
         @test_throws ArgumentError pop!(cb)
     end
-    
+
     @testset "popfirst!" begin
         cb = CircularBuffer{Int}(5)
         for i in 0:5    # one extra to force wraparound
@@ -114,7 +114,7 @@
         @test isempty(cb)
         @test_throws ArgumentError popfirst!(cb)
     end
-    
+
     @testset "fill!" begin
         @testset "fill an empty buffer" begin
             cb = CircularBuffer{Int}(3)

--- a/test/test_default_dict.jl
+++ b/test/test_default_dict.jl
@@ -198,7 +198,7 @@ import DataStructures: DefaultDictBase
         @testset "issue #216" begin
             @test DataStructures.isordered(DefaultOrderedDict{Int, String})
         end
-    
+
     end
 
 end

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -39,10 +39,10 @@
 
     @testset "Core Functionality" begin
         n = 10
-        
+
         @testset "push back / pop back" begin
             q = Deque{Int}(3)
-            
+
             @testset "push back" begin
                 for i = 1 : n
                     push!(q, i)

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -114,7 +114,7 @@
             @test find_root(a,"a") == union!(a,"b","c")
             union!(a,"c","d")
             # Now they should be in same set, and a is transitively connected to d
-            @test in_same_set(a,"a", "d") 
+            @test in_same_set(a,"a", "d")
             # Root element should thus be same for all:
             @test all(find_root(a,first(elems)) .== map(x->find_root(a,x),elems))
 

--- a/test/test_fenwick.jl
+++ b/test/test_fenwick.jl
@@ -5,13 +5,13 @@
         @test length(f1) == 5
         @test eltype(f1) == Float64
         @test eltype(typeof(f1)) == Float64
-        
+
         arr = [1.2, 8.7, 7.2, 3.5]
         f3 = FenwickTree(arr)
         @test f3[1] == 1.2
         @test length(f3) == length(arr)
     end
-    
+
     @testset "Point update and Point queries" begin
         f1 = FenwickTree{Int}(10)
         inc!(f1, 10, 5)
@@ -23,17 +23,17 @@
         @test prefixsum(f1, 10) == 12
         @test prefixsum(f1, 5) == 7
         @test prefixsum(f1, 4) == 0
-        
+
         dec!(f1, 7, 2)
         @test prefixsum(f1, 8) == 5
         @test prefixsum(f1, 6) == 7
-        
+
         incdec!(f1, 2, 6, 3)
         @test prefixsum(f1, 3) == 3
         @test prefixsum(f1, 7) == 5
-        
+
         @test_throws ArgumentError inc!(f1, 11)
         @test_throws ArgumentError inc!(f1, 0)
     end
-    
+
 end

--- a/test/test_int_set.jl
+++ b/test/test_int_set.jl
@@ -78,7 +78,7 @@ import DataStructures: IntSet
     @testset "complement! / pop!" begin
         c1 = complement!(IntSet())
         s1 = IntSet([1,2,3])
-        
+
         pop!(c1, 1)
         pop!(c1, 2)
         pop!(c1, 3)

--- a/test/test_minmax_heap.jl
+++ b/test/test_minmax_heap.jl
@@ -3,7 +3,7 @@ using DataStructures: _make_binary_minmax_heap, is_minmax_heap, children_and_gra
 using Base.Order: Forward, Reverse
 
 @testset "Binary MinMax Heaps" begin
-    
+
     @testset "is_minmax_heap tests" begin
         mmheap = [0, 10, 9, 2, 3, 4, 5]
         @test is_minmax_heap(mmheap)
@@ -20,10 +20,10 @@ using Base.Order: Forward, Reverse
         @test eltype(typeof(h)) == Int
         @test sizehint!(h, 100) === h
     end
-    
+
     @testset "make heap tests" begin
         vs = [10, 4, 6, 1, 16, 2, 20, 17, 13, 5]
-        
+
         @testset "make from array tests" begin
             h = BinaryMinMaxHeap(vs)
             @test length(h) == 10
@@ -32,7 +32,7 @@ using Base.Order: Forward, Reverse
             @test maximum(h) == 20
             @test is_minmax_heap(h.valtree)
         end
-        
+
         @testset "make from random arrays tests" begin
             for i = 1:20
                 A = rand(50)
@@ -40,13 +40,13 @@ using Base.Order: Forward, Reverse
                 @test is_minmax_heap(vtree)
             end
         end
-        
+
         @testset "push! tests" begin
             h = BinaryMinMaxHeap{Int}()
-            
+
             @test length(h) == 0
             @test isempty(h)
-            
+
             push!(h, 1)
             @test top(h) == 1
             push!(h, 2)
@@ -65,7 +65,7 @@ using Base.Order: Forward, Reverse
             end
         end
     end
-    
+
     @testset "pop! tests" begin
         @testset "popmin! tests" begin
             h = BinaryMinMaxHeap([1])
@@ -103,7 +103,7 @@ using Base.Order: Forward, Reverse
             @test maximum(h) == 2
         end
     end
-    
+
     @testset "empty!" begin
         h = BinaryMinMaxHeap([1, 4, 3, 10, 2])
         ret = empty!(h)
@@ -120,7 +120,7 @@ using Base.Order: Forward, Reverse
             @test popall!(h) == sorted_A
             @test isempty(h)
             @test length(h) == 0
-            
+
             h = BinaryMinMaxHeap(A)
             @test popmin!(h, 10) == sorted_A[1:10]
             @test !isempty(h)
@@ -133,24 +133,24 @@ using Base.Order: Forward, Reverse
             @test popall!(h, Reverse) == sorted_A
             @test length(h) == 0
             @test isempty(h)
-            
+
             h = BinaryMinMaxHeap(A)
             @test popmax!(h, 10) == sorted_A[1:10]
             @test length(h) == 40
             @test !isempty(h)
         end
     end
-    
+
     @testset "type conversion" begin
         h = BinaryMinMaxHeap{Float64}()
         push!(h, 3.)
         push!(h, 5)
         push!(h, Rational(4, 8))
         push!(h, Complex(10.1, 0.0))
-        
+
         @test h.valtree == [0.5, 10.1, 3.0, 5.0]
     end
-    
+
     @testset "children_and_grandchildren tests" begin
         @test children_and_grandchildren(1, 1) == Int[]
         @test children_and_grandchildren(2, 1) == [2]
@@ -158,17 +158,17 @@ using Base.Order: Forward, Reverse
         @test children_and_grandchildren(7, 1) == [2, 4, 5, 3, 6, 7]
         @test children_and_grandchildren(10, 2) == [4, 8, 9, 5, 10]
     end
-    
+
     @testset "throw errors tests" begin
         h = BinaryMinMaxHeap{Int}()
         @test_throws ArgumentError pop!(h)
         @test_throws ArgumentError popmin!(h)
-        
+
         @test_throws ArgumentError popmax!(h)
-        
+
         @test_throws ArgumentError top(h)
         @test_throws ArgumentError minimum(h)
         @test_throws ArgumentError maximum(h)
-        
+
     end
 end

--- a/test/test_multi_dict.jl
+++ b/test/test_multi_dict.jl
@@ -61,8 +61,8 @@
 
         @testset "in" begin
             @test in(('c', 1), d)
-            @test in(('a', 1), d)            
-            @test in(('a', 2), d)            
+            @test in(('a', 1), d)
+            @test in(('a', 2), d)
         end
 
         @testset "isempty / empty!" begin
@@ -79,7 +79,7 @@
             @test pop!(d, 'a') == 1
             @test !haskey(d, 'a')
             @test pop!(d, 'b', 0) == 0
-        end 
+        end
     end
 
     @testset "delete!" begin

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -113,7 +113,7 @@ end
 
         # test pop!
         @test isequal(extract_all!(hmin), [1, 2, 3, 4, 7, 8, 9, 10, 14, 16])
-        @test isempty(hmin)    
+        @test isempty(hmin)
     end
 
     @testset "hmax / push! / pop!" begin
@@ -168,7 +168,7 @@ end
         @test pop!(h) == 2
         @test isequal(heap_values(h), [7, 10])
         @test isequal(list_values(h), [10, 7])
-        
+
     end
 
     @testset "test delete!" begin
@@ -254,7 +254,7 @@ end
         update!(h, 2, 20)
         @test isequal(heap_values(h), [0.5, 10.1, 3.0, 20.0])
     end
-    
+
     # test deprecated constructors
     @testset "deprecated constructors" begin
         @test_deprecated mutable_binary_minheap(Int)
@@ -262,6 +262,6 @@ end
         @test_deprecated mutable_binary_maxheap(Int)
         @test_deprecated mutable_binary_maxheap([1., 2., 3.])
     end
-    
+
 
 end # @testset MutableBinheap

--- a/test/test_queue.jl
+++ b/test/test_queue.jl
@@ -46,7 +46,7 @@
     @testset "==" begin
         t = Queue{Int}()
         s = Queue{Int}()
-        
+
         @test s == t
         enqueue!(s, 10)
         @test s != t
@@ -61,7 +61,7 @@
             @test s == r
         end
     end
-    
+
     @testset "emptyness" begin
         s = Queue{Int}()
         enqueue!(s, 1)
@@ -70,7 +70,7 @@
         empty!(s)
         @test isempty(s)
     end
-    
+
     @testset "iter should return a FIFO collection" begin
         q = Queue{Int}(10)
         n = 100

--- a/test/test_robin_dict.jl
+++ b/test/test_robin_dict.jl
@@ -82,7 +82,7 @@ end
 	        @test k in [3, 8, 6]
 	    end
 	end
-    
+
     let y = RobinDict{Any, Int}(3=>3, 5=>5, "8"=>8, 6=>6)
         pop!(y, "8")
         for k in keys(y)
@@ -112,7 +112,7 @@ end
 @testset "Filter function" begin
     _d = RobinDict("a"=>0)
     @test isa([k for k in filter(x->length(x)==1, collect(keys(_d)))], Vector{String})
-    
+
     h = RobinDict{Int, Int}()
     for i in 1:100
         h[i] = i
@@ -238,7 +238,7 @@ end
     @test isequal(RobinDict(missing=>1), RobinDict(missing=>1))
 end
 
-@testset "get!" begin 
+@testset "get!" begin
     f(x) = x^2
     d = RobinDict(8=>19)
     @test get!(d, 8, 5) == 19
@@ -346,14 +346,14 @@ end
 @testset "get_idxfloor" begin
     h = RobinDict()
     @test get_idxfloor(h) == 0
-    
+
     h["a"] = 1
     h[2] = "b"
     @test h.idxfloor == get_idxfloor(h)
     pop!(h)
     @test h.idxfloor == get_idxfloor(h)
     pop!(h)
-    @test h.idxfloor == get_idxfloor(h) == 0 
+    @test h.idxfloor == get_idxfloor(h) == 0
 end
 
 @testset "invariants" begin
@@ -361,7 +361,7 @@ end
     for i in 1:300
         h1[i] = i
     end
-    
+
     for i in 1:length(h1.keys)
         if isslotfilled(h1, i)
             @test hash_key(h1.keys[i]) == h1.hashes[i]
@@ -372,7 +372,7 @@ end
     for i in 1:300
         h2[rand()] = rand()
     end
-    
+
     for i in 1:length(h2.keys)
         if isslotfilled(h2, i)
             @test hash_key(h2.keys[i]) == h2.hashes[i]
@@ -383,7 +383,7 @@ end
     for i in 1:300
         h3[randstring()] = i
     end
-    
+
     for i in 1:length(h3.keys)
         if isslotfilled(h3, i)
             @test hash_key(h3.keys[i]) == h3.hashes[i]
@@ -424,4 +424,4 @@ end
         h[i] = i+1
     end
     check_invariants(h)
-end 
+end

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1637,14 +1637,14 @@ end
 @testset "SortedContainers" begin
     @test testSortedDictBasic()
     @test testSortedDictMethods()
-    @test testSortedDictLoops()    
+    @test testSortedDictLoops()
     @test testSortedDictOrderings()
     @test testSortedMultiDict()
     @test testSortedSet()
     @test testSortedDictConstructors()
     @test testSortedMultiDictConstructors()
 
-    
+
     # test all the errors of sorted containers
     m = SortedDict(Dict("a" => 6, "bb" => 9))
     @test_throws KeyError println(m["b"])
@@ -1690,6 +1690,6 @@ end
     @test_throws ArgumentError ((2,5) in m1)
 
 
-    
-    
+
+
 end

--- a/test/test_sparse_int_set.jl
+++ b/test/test_sparse_int_set.jl
@@ -186,4 +186,4 @@ import DataStructures: SparseIntSet
 	    @test s1 == 4*24
 	end
 
-end 
+end

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -39,11 +39,11 @@
             @test length(s) == n - i
         end
     end
-    
+
     @testset "==" begin
         s = Stack{Int}()
         t = Stack{Int}()
-        
+
         @test s == t
         push!(s, 10)
         @test s != t
@@ -51,7 +51,7 @@
         @test s == t
         push!(t, 20)
         @test s != t
-        
+
         @testset "different types" begin
             r = Stack{Float32}()
             push!(r, 10)


### PR DESCRIPTION
Makes life a bit easier when using editors that remove it automatically on save. Touches quite a lot of code though, so I am not sure if you actually want this.

Done by running this at the root of the repo (take care -- it will corrupt things if you run it in the wrong place):

```
find . -type f -not -path './.git/*' -exec sed --in-place -e :a -e '/^\n*$/{$d;N;};/\n$/ba' {} \;
find . -type f -not -path './.git/*' -exec sed --in-place 's/[[:space:]]\+$//' {} \;
```