### PR TITLE
SparseIntSet speedups

### DIFF
--- a/src/sparse_int_set.jl
+++ b/src/sparse_int_set.jl
@@ -241,10 +241,10 @@ end
         return nothing
     end
     for i in state:iterator_length
-	    @inbounds id = it.shortest_set.packed[i]
-		if in_valid(id, it) && !in_excluded(id, it)
-			return map(x->findfirst_packed_id(id, x), it.valid_sets), i + 1
-		end
-	end
-	return nothing
+        @inbounds id = it.shortest_set.packed[i]
+        if in_valid(id, it) && !in_excluded(id, it)
+            return map(x->findfirst_packed_id(id, x), it.valid_sets), i + 1
+        end
+    end
+    return nothing
 end

--- a/src/sparse_int_set.jl
+++ b/src/sparse_int_set.jl
@@ -60,7 +60,7 @@ end
 
 length(s::SparseIntSet) = length(s.packed)
 
-function push!(s::SparseIntSet, i::Integer)
+@inline function push!(s::SparseIntSet, i::Integer)
     i <= 0 && throw(DomainError("Only positive Ints allowed."))
 
     pageid, offset = pageid_offset(s, i)
@@ -91,14 +91,14 @@ function push!(s::SparseIntSet, i::Integer)
     return s
 end
 
-function push!(s::SparseIntSet, is::Integer...)
+@inline function push!(s::SparseIntSet, is::Integer...)
     for i in is
         push!(s, i)
     end
     return s
 end
 
-Base.@propagate_inbounds function pop!(s::SparseIntSet)
+@inline Base.@propagate_inbounds function pop!(s::SparseIntSet)
     if isempty(s)
         throw(ArgumentError("Cannot pop an empty set."))
     end
@@ -110,7 +110,7 @@ Base.@propagate_inbounds function pop!(s::SparseIntSet)
     return id
 end
 
-Base.@propagate_inbounds function pop!(s::SparseIntSet, id::Integer)
+@inline Base.@propagate_inbounds function pop!(s::SparseIntSet, id::Integer)
     id < 0 && throw(ArgumentError("Int to pop needs to be positive."))
 
     @boundscheck if !in(id, s)
@@ -132,19 +132,19 @@ Base.@propagate_inbounds function pop!(s::SparseIntSet, id::Integer)
     return id
 end
 
-function cleanup!(s::SparseIntSet, pageid::Int)
+@inline function cleanup!(s::SparseIntSet, pageid::Int)
     if s.counters[pageid] == 0
         s.reverse[pageid] = NULL_INT_PAGE
     end
 end
 
-function pop!(s::SparseIntSet, id::Integer, default)
+@inline function pop!(s::SparseIntSet, id::Integer, default)
     id < 0 && throw(ArgumentError("Int to pop needs to be positive."))
     return in(id, s) ? (@inbounds pop!(s, id)) : default
 end
 popfirst!(s::SparseIntSet) = pop!(s, first(s))
 
-iterate(set::SparseIntSet, args...) = iterate(set.packed, args...)
+@inline iterate(set::SparseIntSet, args...) = iterate(set.packed, args...)
 
 last(s::SparseIntSet) = isempty(s) ? throw(ArgumentError("Empty set has no last element.")) : last(s.packed)
 
@@ -215,9 +215,9 @@ Base.zip(s::SparseIntSet...;kwargs...) = ZippedSparseIntSetIterator(s...;kwargs.
 length(it::ZippedSparseIntSetIterator) = length(it.shortest_set)
 
 # we know it is not in_excluded, as there are no excluded
-in_excluded(id, it::ZippedSparseIntSetIterator{VT,Tuple{}}) where {VT} = false
+@inline in_excluded(id, it::ZippedSparseIntSetIterator{VT,Tuple{}}) where {VT} = false
 
-function in_excluded(id, it)
+@inline function in_excluded(id, it)
     for e in it.excluded_sets
         if id in e
             return true
@@ -226,7 +226,7 @@ function in_excluded(id, it)
     return false
 end
 
-function in_valid(id, it)
+@inline function in_valid(id, it)
     for e in it.valid_sets
         if !in(id, e)
             return false
@@ -235,7 +235,7 @@ function in_valid(id, it)
     return true
 end
 
-function iterate(it::ZippedSparseIntSetIterator, state=1)
+@inline function iterate(it::ZippedSparseIntSetIterator, state=1)
     iterator_length = length(it)
     if state > iterator_length
         return nothing


### PR DESCRIPTION
So far,  the inlining made the pop!/push! benchmark around 15% faster, the new iteration style improved the iteration speed with 25-30%. 
So far I don't see any other directly obvious speedups.