### PR TITLE
Expand benchmarking in anticipation of heap ordering change

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,3 +28,16 @@ julia --project=benchmark -e '
     include("benchmark/runjudge.jl");
     include("benchmark/pprintjudge.jl");'
 ```
+
+### To compare against baseline locally (without re-running baseline):
+
+Running the above baseline comparison produces a `benchmark/result-baseline.json` file which is
+used as a refrence for new changes.
+If the baseline remains unchanged during development, then it is unnecessary to regenerate this file,
+and the following command may be used to save benchmarking time.
+```
+julia --project=benchmark -e '
+    using Pkg; Pkg.instantiate();
+    include("benchmark/incrementalrunjudge.jl");
+    include("benchmark/pprintjudge.jl");'
+```

--- a/benchmark/bench_heap.jl
+++ b/benchmark/bench_heap.jl
@@ -4,7 +4,7 @@ using DataStructures
 using BenchmarkTools
 using Random
 
-function push_heap(h::AbstractHeap, xs::Vector{Float64})
+function push_heap(h::AbstractHeap, xs::Vector)
     n = length(xs)
 
     for i = 1 : n
@@ -20,19 +20,87 @@ function pop_heap(h::AbstractHeap)
     end
 end
 
-Random.seed!(0)
-xs = rand(10^6)
-
 suite = BenchmarkGroup()
 
-suite[["basic", "min", "push"]] =
-    @benchmarkable push_heap(h, $xs) setup=(h=BinaryMinHeap{Float64}())
-suite[["basic", "min", "pop"]] =
-    @benchmarkable pop_heap(h) setup=(h=BinaryMinHeap{Float64}($xs))
-suite[["mutable", "min", "push"]] =
-    @benchmarkable push_heap(h, $xs) setup=(h=MutableBinaryMinHeap{Float64}())
-suite[["mutable", "min", "pop"]] =
-    @benchmarkable pop_heap(h) setup=(h=MutableBinaryMinHeap{Float64}($xs))
+heaptypes = [BinaryHeap, MutableBinaryHeap]
+aexps = [1,3]
+datatypes = [Int, Float64]
+baseorderings = Dict(
+    "Min" => DataStructures.LessThan,
+    #"Max" => DataStructures.GreaterThan,
+    )
+fastfloatorderings = Dict(
+    # These will be enabled upon reordering change
+    #"FastMin" => DataStructures.FasterForward(),
+    #"FastMax" => DataStructures.FasterReverse(),
+    )
+
+for heap in heaptypes
+    for aexp in aexps
+        for dt in datatypes
+            Random.seed!(0)
+            a = rand(dt, 10^aexp)
+
+            orderings = baseorderings
+            if dt == Float64
+                # swap to faster ordering operation
+                for (k,v) in orderings
+                    if haskey(fastfloatorderings, k)
+                        orderings["Slow"*k] = v
+                        orderings[k] = fastfloatorderings[k]
+                    end
+                end
+            end
+
+            for (ord_str, ord) in orderings
+                prepath = [string(heap)]
+                postpath = [string(dt), "10^"*string(aexp), ord_str]
+                suite[vcat(prepath, ["make"], postpath)] =
+                    @benchmarkable $(heap){$dt,$ord}($a)
+                suite[vcat(prepath, ["push"], postpath)] =
+                    @benchmarkable push_heap(h, $a) setup=(h=$(heap){$dt,$ord}())
+                suite[vcat(prepath, ["pop"], postpath)] =
+                    @benchmarkable pop_heap(h) setup=(h=$(heap){$dt,$ord}($a))
+            end
+        end
+    end
+end
+
+# Quick check to ensure no Float regressions with Min/Max convenience functions
+# These don't fit in well with the above loop, since ordering is hardcoded.
+heapalias = Dict(
+    "BinaryMinHeap" => BinaryMinHeap,
+    "BinaryMaxHeap" => BinaryMaxHeap,
+    "BinaryMinMaxHeap" => BinaryMinMaxHeap, # <- no alias issue
+)
+for (heapname, heap) in heapalias
+    for aexp in aexps
+        for dt in [Float64]
+            Random.seed!(0)
+            a = rand(dt, 10^aexp)
+            prepath = [heapname]
+            postpath = [string(dt), "10^"*string(aexp)]
+            suite[vcat(prepath, ["make"], postpath)] =
+                @benchmarkable $(heap)($a)
+            suite[vcat(prepath, ["push"], postpath)] =
+                @benchmarkable push_heap(h, $a) setup=(h=$(heap){$dt}())
+            suite[vcat(prepath, ["pop"], postpath)] =
+                @benchmarkable pop_heap(h) setup=(h=$(heap)($a))
+        end
+    end
+end
+
+for func in [nlargest, nsmallest]
+    for aexp in [4]
+        Random.seed!(0);
+        a = rand(10^aexp);
+        for nexp in [2]
+            n = 10^nexp
+            suite[[string(func), "a=rand(10^"*string(aexp)*")", "n=10^"*string(nexp)]] =
+                @benchmarkable $(func)($n, $a)
+        end
+    end
+end
 
 end  # module
 

--- a/benchmark/incrementalrunjudge.jl
+++ b/benchmark/incrementalrunjudge.jl
@@ -1,0 +1,17 @@
+# This file was copied from Transducers.jl
+# which is available under an MIT license (see LICENSE).
+using PkgBenchmark
+
+mkconfig(; kwargs...) =
+    BenchmarkConfig(
+        env = Dict(
+            "JULIA_NUM_THREADS" => "1",
+        );
+        kwargs...
+    )
+
+group_target = benchmarkpkg(
+    dirname(@__DIR__),
+    mkconfig(),
+    resultfile = joinpath(@__DIR__, "result-target.json"),
+)


### PR DESCRIPTION
This PR includes #545.
It should be rebased after the above is merged in order for CI to track benchmarking differences.