### PR TITLE
WIP Adding constructors for Circular(Deque | Buffer) | Deque from iterators (strike 2)

### DIFF
--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -13,6 +13,12 @@ end
 
 CircularDeque{T}(n::Int) where {T} = CircularDeque(Vector{T}(undef, n), n, 0, 1, n)
 
+# constructor for iterator
+function CircularDeque(iter)
+    n = length(iter)
+    CircularDeque(collect(iter), n, n, 1, n)
+end
+
 Base.length(D::CircularDeque) = D.n
 Base.eltype(::Type{CircularDeque{T}}) where {T} = T
 

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -12,11 +12,16 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     first::Int
     length::Int
     buffer::Vector{T}
-
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(undef, capacity))
 end
 
-CircularBuffer(capacity) = CircularBuffer{Any}(capacity)
+CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(capacity, 1, 0, Vector{T}(undef, capacity))
+CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
+
+# constructor for iterator
+function CircularBuffer(iter)
+    n = length(iter)
+    CircularBuffer{eltype(iter)}(n, 1, n, collect(iter))
+end
 
 """
     empty!(cb::CircularBuffer)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -81,17 +81,17 @@ mutable struct Deque{T}
     Deque{T}() where {T} = Deque{T}(DEFAULT_DEQUEUE_BLOCKSIZE)
 end
 
+@deprecate deque(::Type{T}) where {T} Deque{T}()
+
+# constructor for iterator
 """
-    deque(T)
+    Deque{T}()
 
 Create a deque of type `T`.
 """
-deque(::Type{T}) where {T} = Deque{T}()
-
-# constructor for iterator
-function Deque(iter)
+function Deque(iter; blksize=DEFAULT_DEQUEUE_BLOCKSIZE)
     n = length(iter)
-    d = deque(eltype(iter))
+    d = Deque{eltype(iter)}(blksize)
     for e in iter
         push!(d, e)
     end

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -85,7 +85,6 @@ Deque{T}()
 Create a deque of type `T`.
 """
 function Deque(iter; blksize=DEFAULT_DEQUEUE_BLOCKSIZE)
-    n = length(iter)
     d = Deque{eltype(iter)}(; blksize=blksize)
     for e in iter
         push!(d, e)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -91,6 +91,7 @@ function Deque(iter; blksize=DEFAULT_DEQUEUE_BLOCKSIZE)
     end
     d
 end
+Deque(; blksize=DEFAULT_DEQUEUE_BLOCKSIZE) = Deque{Any}(; blksize=blksize)
 
 @deprecate deque(::Type{T}) where {T} Deque{T}()
 

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -88,6 +88,16 @@ Create a deque of type `T`.
 """
 deque(::Type{T}) where {T} = Deque{T}()
 
+# constructor for iterator
+function Deque(iter)
+    n = length(iter)
+    d = deque(eltype(iter))
+    for e in iter
+        push!(d, e)
+    end
+    d
+end
+
 isempty(q::Deque) = q.len == 0
 length(q::Deque) = q.len
 num_blocks(q::Deque) = q.nblocks

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -73,30 +73,28 @@ mutable struct Deque{T}
     head::DequeBlock{T}
     rear::DequeBlock{T}
 
-    function Deque{T}(blksize::Int) where T
+    function Deque{T}(; blksize=DEFAULT_DEQUEUE_BLOCKSIZE) where T
         head = rear = rear_deque_block(T, blksize)
         new{T}(1, blksize, 0, head, rear)
     end
-
-    Deque{T}() where {T} = Deque{T}(DEFAULT_DEQUEUE_BLOCKSIZE)
 end
 
-@deprecate deque(::Type{T}) where {T} Deque{T}()
-
-# constructor for iterator
 """
-    Deque{T}()
+Deque{T}()
 
 Create a deque of type `T`.
 """
 function Deque(iter; blksize=DEFAULT_DEQUEUE_BLOCKSIZE)
     n = length(iter)
-    d = Deque{eltype(iter)}(blksize)
+    d = Deque{eltype(iter)}(; blksize=blksize)
     for e in iter
         push!(d, e)
     end
     d
 end
+
+@deprecate deque(::Type{T}) where {T} Deque{T}()
+
 
 isempty(q::Deque) = q.len == 0
 length(q::Deque) = q.len

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -94,6 +94,7 @@ end
 Deque(; blksize=DEFAULT_DEQUEUE_BLOCKSIZE) = Deque{Any}(; blksize=blksize)
 
 @deprecate deque(::Type{T}) where {T} Deque{T}()
+@deprecate deque(blksize::Int) Deque(blksize=blksize)
 
 
 isempty(q::Deque) = q.len == 0

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -10,7 +10,7 @@ end
 Create a `Queue` object containing elements of type `T`.
 """
 Queue{T}() where {T} = Queue(Deque{T}())
-Queue{T}(blksize::Integer) where {T} = Queue(Deque{T}(blksize))
+Queue{T}(blksize::Integer) where {T} = Queue(Deque{T}(blksize=blksize))
 
 isempty(s::Queue) = isempty(s.store)
 length(s::Queue) = length(s.store)

--- a/test/bench_deque.jl
+++ b/test/bench_deque.jl
@@ -11,7 +11,7 @@ function batch_pushback!(v::Container, n::Int, e::T) where {Container,T}
 end
 
 v = Int[]
-q = deque(Int)
+q = Deque{Int}()
 
 batch_pushback!(v, 10, 0)
 t1 = @elapsed batch_pushback!(v, 10^7, 0)
@@ -33,7 +33,7 @@ function batch_pushfront!(v::Container, n::Int, e::T) where {Container,T}
 end
 
 v = Int[]
-q = deque(Int)
+q = Deque{Int}()
 
 batch_pushfront!(v, 10, 0)
 t1 = @elapsed batch_pushfront!(v, 10^7, 0)

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -1,3 +1,15 @@
+struct KnownLengthIter
+    n::Int
+end
+Base.iterate(M::KnownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.length(M::KnownLengthIter) = M.n
+
+struct UnknownLengthIter
+    n::Int
+end
+Base.iterate(M::UnknownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
+
 @testset "CircularDeque" begin
 
     @testset "Core Functionality" begin
@@ -90,25 +102,13 @@
         @test length(D) == 3
 
         # when eltype is not known
-        struct MyIter
-            n::Int
-        end
-        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.length(M::MyIter) = M.n
-
-        D = CircularDeque(MyIter(10))
+        D = CircularDeque(KnownLengthIter(10))
         @test_skip eltype(D) == Any
         @test capacity(D) == 10
         @test length(D) == 10
 
         # when length is not known
-        struct MyIter2
-            n::Int
-        end
-        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
-
-        @test_throws MethodError CircularDeque(MyIter2(10))
+        @test_throws MethodError CircularDeque(UnknownLengthIter(10))
     end
 end
 

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -81,6 +81,35 @@
         for i in 1:5 push!(D, i) end
         @test collect([i for i in D]) == collect(1:5)
     end
+
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        D = CircularDeque(1:3)
+        @test_skip eltype(D) == Int
+        @test capacity(D) == 3
+        @test length(D) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        D = CircularDeque(MyIter(10))
+        @test_skip eltype(D) == Any
+        @test capacity(D) == 10
+        @test length(D) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError CircularDeque(MyIter2(10))
+    end
 end
 
 nothing

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -101,9 +101,9 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         @test capacity(D) == 3
         @test length(D) == 3
 
-        # when eltype is not known
+        # when eltype is Any
         D = CircularDeque(KnownLengthIter(10))
-        @test_skip eltype(D) == Any
+        @test eltype(D) == Any
         @test capacity(D) == 10
         @test length(D) == 10
 

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -1,3 +1,15 @@
+struct KnownLengthIter
+    n::Int
+end
+Base.iterate(M::KnownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.length(M::KnownLengthIter) = M.n
+
+struct UnknownLengthIter
+    n::Int
+end
+Base.iterate(M::UnknownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
+
 @testset "CircularBuffer" begin
 
     @testset "Core Functionality" begin
@@ -141,25 +153,13 @@
         @test length(C) == 3
 
         # when eltype is not known
-        struct MyIter
-            n::Int
-        end
-        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.length(M::MyIter) = M.n
-
-        C = CircularBuffer(MyIter(10))
+        C = CircularBuffer(KnownLengthIter(10))
         @test_skip eltype(C) == Any
         @test capacity(C) == 10
         @test length(C) == 10
 
         # when length is not known
-        struct MyIter2
-            n::Int
-        end
-        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
-
-        @test_throws MethodError CircularBuffer(MyIter2(10))
+        @test_throws MethodError CircularBuffer(UnknownLengthIter(10))
     end
 
 end

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -132,4 +132,34 @@
             @test Array(cb) == [21, 42, 42]
         end
     end
+
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        C = CircularBuffer(1:3)
+        @test_skip eltype(C) == Int
+        @test capacity(C) == 3
+        @test length(C) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        C = CircularBuffer(MyIter(10))
+        @test_skip eltype(C) == Any
+        @test capacity(C) == 10
+        @test length(C) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError CircularBuffer(MyIter2(10))
+    end
+
 end

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -202,4 +202,31 @@
         @test isempty(q)
     end
 
+    @testset "constructing from iterator" begin
+        # when eltype is known
+        D = Deque(1:3)
+        @test_skip eltype(D) == Int
+        @test length(D) == 3
+
+        # when eltype is not known
+        struct MyIter
+            n::Int
+        end
+        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.length(M::MyIter) = M.n
+
+        D = Deque(MyIter(10))
+        @test_skip eltype(D) == Any
+        @test length(D) == 10
+
+        # when length is not known
+        struct MyIter2
+            n::Int
+        end
+        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
+
+        @test_throws MethodError Deque(MyIter2(10))
+    end
+
 end # @testset Deque

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -33,7 +33,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         end
 
         @testset "empty dequeue 3" begin
-            q = Deque{Int}(3)
+            q = Deque{Int}(blksize=3)
             @test length(q) == 0
             @test isempty(q)
             @test q.blksize == 3
@@ -49,8 +49,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         n = 10
 
         @testset "push back / pop back" begin
-            q = Deque{Int}(3)
-
+            q = Deque{Int}(blksize=3)
             @testset "push back" begin
                 for i = 1 : n
                     push!(q, i)
@@ -96,7 +95,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         end
 
         @testset "push front / pop front" begin
-            q = Deque{Int}(3)
+            q = Deque{Int}(blksize=3)
 
             @testset "push front" begin
                 for i = 1 : n
@@ -138,7 +137,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
     end
 
     @testset "random operations" begin
-        q = Deque{Int}(5)
+        q = Deque{Int}(blksize=5)
         r = Int[]
         m = 100
 
@@ -176,8 +175,8 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
     end
 
     @testset "hash and ==" begin
-        a = Deque{Int64}(2)
-        b = Deque{Int64}(3)
+        a = Deque{Int64}(blksize=2)
+        b = Deque{Int64}(blksize=3)
         # Note: blksize does not distinguish == or hash
         @test a == b
         @test hash(a) === hash(b)
@@ -194,7 +193,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
     end
 
     @testset "issue #38" begin
-        q = Deque{Int}(1)
+        q = Deque{Int}(blksize=1)
         push!(q,1)
         @test !isempty(q)
         empty!(q)
@@ -202,7 +201,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
     end
 
     @testset "empty!" begin
-        q = Deque{Int}(1)
+        q = Deque{Int}(blksize=1)
         push!(q,1)
         push!(q,2)
         @test length(sprint(dump,q)) >= 0

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -1,3 +1,15 @@
+struct KnownLengthIter
+    n::Int
+end
+Base.iterate(M::KnownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.length(M::KnownLengthIter) = M.n
+
+struct UnknownLengthIter
+    n::Int
+end
+Base.iterate(M::UnknownLengthIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
+Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
+
 @testset "Deque" begin
     @testset "empty dequeue" begin
         @testset "empty dequeue 1" begin
@@ -209,24 +221,12 @@
         @test length(D) == 3
 
         # when eltype is not known
-        struct MyIter
-            n::Int
-        end
-        Base.iterate(M::MyIter, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.length(M::MyIter) = M.n
-
-        D = Deque(MyIter(10))
+        D = Deque(KnownLengthIter(10))
         @test_skip eltype(D) == Any
         @test length(D) == 10
 
         # when length is not known
-        struct MyIter2
-            n::Int
-        end
-        Base.iterate(M::MyIter2, state=1) = state > M.n ? nothing : (iseven(state) ? ('a', state+1) : (1, state+1))
-        Base.IteratorSize(::MyIter2) = Base.SizeUnknown()
-
-        @test_throws MethodError Deque(MyIter2(10))
+        @test_throws MethodError Deque(UnknownLengthIter(10))
     end
 
 end # @testset Deque

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -25,10 +25,6 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         end
 
         @testset "empty dequeue 2" begin
-            @test typeof(deque(Int)) === typeof(Deque{Int}())
-        end
-
-        @testset "empty dequeue 3" begin
             q = DataStructures.DequeBlock{Int}(0,0)
             @test length(q) == 0
             @test capacity(q) == 0
@@ -36,7 +32,7 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
             @test length(sprint(show,q)) >= 0
         end
 
-        @testset "empty dequeue 4" begin
+        @testset "empty dequeue 3" begin
             q = Deque{Int}(3)
             @test length(q) == 0
             @test isempty(q)

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -219,9 +219,6 @@ Base.IteratorSize(::UnknownLengthIter) = Base.SizeUnknown()
         D = Deque(KnownLengthIter(10))
         @test_skip eltype(D) == Any
         @test length(D) == 10
-
-        # when length is not known
-        @test_throws MethodError Deque(UnknownLengthIter(10))
     end
 
 end # @testset Deque


### PR DESCRIPTION
@kmsquire I took the PR from @mcognetta (#514) and pushed it along, addressing your concerns. I chose to make `blksize` a keyword argument to the constructor. It seems reasonable to me, but it would involve a bunch of other deprecations, and changing `Stack(12)` to `Stack(blksize=12)` etc. What do you think?