### PR TITLE
Changed inner constructor of BinaryHeap to allow for custom equality comparers

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -108,11 +108,13 @@ mutable struct BinaryHeap{T,Comp} <: AbstractHeap{T}
 
     BinaryHeap{T,Comp}() where {T,Comp} = new{T,Comp}(Comp(), Vector{T}())
 
-    function BinaryHeap{T,Comp}(xs::AbstractVector{T}) where {T,Comp}
-        valtree = _make_binary_heap(Comp(), T, xs)
-        new{T,Comp}(Comp(), valtree)
+    function BinaryHeap(comp::Comp, xs::AbstractVector{T}) where {T,Comp}
+        valtree = _make_binary_heap(comp, T, xs)
+        new{T,Comp}(comp, valtree)
     end
 end
+
+BinaryHeap{Comp}(xs::AbstractVector{T}) where {T,Comp} = BinaryHeap(Comp(), xs::AbstractVector{T})
 
 const BinaryMinHeap{T} = BinaryHeap{T, LessThan}
 const BinaryMaxHeap{T} = BinaryHeap{T, GreaterThan}


### PR DESCRIPTION
I changed one inner constructor of BinaryHeap to

    function BinaryHeap(comp::Comp, xs::AbstractVector{T}) where {T,Comp}
        valtree = _make_binary_heap(comp, T, xs)
        new{T,Comp}(comp, valtree)
    end

This enables the use of custom `Comp` types that are not created by `Comp()`. In other words, one can have a custom comparison type

    struct MyComp
        data::SomeData
    end

and have a specialization

    compare(comp::MyComp, x, y) = func(x,y, comp.data) 

and construct a binaryheap: `BinaryHeap(MyComp(data), Vector{T})`

The use case here is that the the binary heap array does not need to store the data used in the comparison. This is handy when heapifying an array based on external data not stored in the heap itself, e.g in Dijkstra's shortest path algorithm.
