### PR TITLE
Provide support for 3-arguments pop! for SortedDict to match Base.pop

### DIFF
--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -462,16 +462,25 @@ Returns `sc`. Time: O(*c* log *n*)
 end
 
 """
-    pop!(sc, k)
+    pop!(sc, k[, default])
 
 Deletes the item with key `k` in SortedDict or SortedSet `sc` and
 returns the value that was associated with `k` in the case of
-SortedDict or `k` itself in the case of SortedSet. A `KeyError`
-results if `k` is not in `sc`. Time: O(*c* log *n*)
+SortedDict or `k` itself in the case of SortedSet. If `k` is not in `sc`
+return `default`, or throw a `KeyError` if `default` is not specified.
+Time: O(*c* log *n*)
 """
 @inline function pop!(m::SortedDict, k_)
     i, exactfound = findkey(m.bt, convert(keytype(m), k_))
     !exactfound && throw(KeyError(k_))
+    d = m.bt.data[i].d
+    delete!(m.bt, i)
+    d
+end
+
+@inline function pop!(m::SortedDict, k_, default)
+    i, exactfound = findkey(m.bt, convert(keytype(m), k_))
+    !exactfound && return default
     d = m.bt.data[i].d
     delete!(m.bt, i)
     d

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -236,17 +236,27 @@ end
 
 
 """
-    pop!(sc, k)
+    pop!(sc, k[, default])
 
 Deletes the item with key `k` in SortedDict or SortedSet `sc` and
 returns the value that was associated with `k` in the case of
-SortedDict or `k` itself in the case of SortedSet. A `KeyError`
-results if `k` is not in `sc`. Time: O(*c* log *n*)
+SortedDict or `k` itself in the case of SortedSet. If `k` is not in `sc`
+return `default`, or throw a `KeyError` if `default` is not specified.
+Time: O(*c* log *n*)
 """
 @inline function pop!(m::SortedSet, k_)
     k = convert(keytype(m),k_)
     i, exactfound = findkey(m.bt, k)
     !exactfound && throw(KeyError(k_))
+    d = m.bt.data[i].d
+    delete!(m.bt, i)
+    k
+end
+
+@inline function pop!(m::SortedSet, k_, default)
+    k = convert(keytype(m),k_)
+    i, exactfound = findkey(m.bt, k)
+    !exactfound && return default
     d = m.bt.data[i].d
     delete!(m.bt, i)
     k

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -373,7 +373,7 @@ function testSortedDictMethods()
         d2 = pop!(m1, i, -1.0)
         my_assert(d2 == -1.0)
         d3 = pop!(m1, i, nothing)
-        my_assert(isnothing(d3))
+        my_assert(d3 == nothing)
 
         if i % 200 == 0
             checkcorrectness(m1.bt, false)
@@ -1709,7 +1709,12 @@ end
     @test_throws ArgumentError (("a",6) in m)
     @test_throws ArgumentError ((2,5) in m1)
 
-
-
+    s = SortedSet([10,30,50])
+    @test pop!(s,10) == 10
+    @test pop!(s,30,-1) == 30
+    @test pop!(s,30, nothing) == nothing
+    @test pop!(s,50, nothing) == 50
+    @test pop!(s,50, nothing) == nothing
+    @test isempty(s)
 
 end

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -361,6 +361,26 @@ function testSortedDictMethods()
     end
     my_assert(isempty(m1))
     my_assert(length(m1) == 0)
+    N = 1000
+    for i = 2:N
+        m1[i] = convert(Float64,i) ^ 2
+    end
+    my_assert(!isempty(m1))
+    my_assert(length(m1) == N - 1)
+    for i = 2 : N
+        d = pop!(m1, i, -1.0)
+        my_assert(d == convert(Float64,i)^2)
+        d2 = pop!(m1, i, -1.0)
+        my_assert(d2 == -1.0)
+        d3 = pop!(m1, i, nothing)
+        my_assert(isnothing(d3))
+
+        if i % 200 == 0
+            checkcorrectness(m1.bt, false)
+        end
+    end
+    my_assert(isempty(m1))
+    my_assert(length(m1) == 0)
     for i = N : -1 : 2
         m1[i] = convert(Float64,i) ^ 2
         if i % 200 == 0


### PR DESCRIPTION
The standard `Base.pop!` provides a 3-arg function:
```
pop!(h::Dict, key, default) in Base at dict.jl:608
```
This functionality is missing in `OrderedDict` and hence making it impossible to use `OrderedDict` as a drop-in replacement for `Dict`. This adds the missing functionality along with the unit tests.