### PR TITLE
Fix DisjointSets constructor error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.9"
+version = "0.17.10"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -13,7 +13,7 @@
 #
 ############################################################
 
-mutable struct IntDisjointSets <: AbstractSet{Int}
+mutable struct IntDisjointSets
     parents::Vector{Int}
     ranks::Vector{Int}
     ngroups::Int
@@ -147,7 +147,6 @@ empty(s::DisjointSets{T}, ::Type{U}=T) where {T,U} = DisjointSets{U}()
 function sizehint!(s::DisjointSets, n::Integer)
     sizehint!(s.intmap, n)
     sizehint!(s.revmap, n)
-    s.internal = IntDisjointSets(n)
     return s
 end
 

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -16,9 +16,9 @@
 """
     IntDisjointSets(n::Integer)
 
-A forest of disjoint sets of integers, which is a data structure 
-(also called a union–find data structure or merge–find set) 
-that tracks a set of elements partitioned 
+A forest of disjoint sets of integers, which is a data structure
+(also called a union–find data structure or merge–find set)
+that tracks a set of elements partitioned
 into a number of disjoint (non-overlapping) subsets.
 """
 mutable struct IntDisjointSets
@@ -112,7 +112,7 @@ end
 
 """
     push!(s::IntDisjointSets)
-    
+
 Make a new subset with an automatically chosen new element x.
 Returns the new element.
 """
@@ -216,7 +216,7 @@ root_union!(s::DisjointSets{T}, x::T, y::T) where {T} = s.revmap[root_union!(s.i
 
 """
     push!(s::DisjointSets{T}, x::T)
-    
+
 Make a new subset with an automatically chosen new element x.
 Returns the new element.
 """

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -61,6 +61,8 @@
             @test DisjointSets(collect(1:10)) isa DisjointSets{Int}
             @test DisjointSets(collect(1.0:10.0)...) isa DisjointSets{Float64}
             @test DisjointSets(x*im for x = 1:10) isa DisjointSets{Complex{Int}}
+            g = (x % 2 == 0 ? x+1//x : x*im for x = 1:10)
+            @test DisjointSets(g) isa DisjointSets{Number}
         end
 
         @testset "basic tests" begin
@@ -70,6 +72,10 @@
             @test eltype(typeof(s)) == Int
             @test length(empty(s)) == num_groups(empty(s)) == 0
             @test empty(s) isa DisjointSets{eltype(s)}
+            @test collect(s) == collect(1:10)
+            s1 = DisjointSets{Int}(1:10)
+            @test sizehint!(s1, 100) === s1
+            @test length(s1) == 100
 
             r = [find_root(s, i) for i in 1 : 10]
             @test isequal(r, collect(1:10))
@@ -116,6 +122,7 @@
         @testset "Some tests using non-integer disjoint sets" begin
             elems = ["a", "b", "c", "d"]
             a = DisjointSets{AbstractString}(elems)
+            @test collect(a) == ["a", "b", "c", "d"]
             union!(a, "a", "b")
             @test in_same_set(a,"a","b")
             @test find_root(a,"a") == find_root(a,"b")

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -73,9 +73,10 @@
             @test length(empty(s)) == num_groups(empty(s)) == 0
             @test empty(s) isa DisjointSets{eltype(s)}
             @test collect(s) == collect(1:10)
-            s1 = DisjointSets{Int}(1:10)
+            g = (x % 2 == 0 ? x+1//x : x*im for x = 1:10)
+            s1 = DisjointSets(g)
+            @test length(s1) == 10
             @test sizehint!(s1, 100) === s1
-            @test length(s1) == 100
 
             r = [find_root(s, i) for i in 1 : 10]
             @test isequal(r, collect(1:10))


### PR DESCRIPTION
Address error introduced by #567 in situations like the following:

```julia
DisjointSets(x % 2 == 0 ? x+1//x : x*im for x = 1:10)
```