### PR TITLE
Make `SortedSet{K}` be a subtype of `AbstractSet{K}`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.10"
+version = "0.18.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.0"
+version = "0.17.13"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -15,7 +15,7 @@ Construct a SortedSet using keys given by iterable `iter` (e.g., an
 array) and ordering object `o`. The ordering object defaults to
 `Forward` if not specified.
 """
-mutable struct SortedSet{K, Ord <: Ordering}
+mutable struct SortedSet{K, Ord <: Ordering} <: AbstractSet{K}
     bt::BalancedTree23{K,Nothing,Ord}
 
     function SortedSet{K,Ord}(o::Ord=Forward, iter=[]) where {K,Ord<:Ordering}


### PR DESCRIPTION
Have `SortedSet{K}` implement <: `AbstractSet{K}`. Fixes https://github.com/JuliaCollections/DataStructures.jl/issues/291.

Are there other things one needs to do to complete this? 
https://docs.julialang.org/en/v1/base/collections/
