### PR TITLE
Switch DefaultDict to use `get`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.10"
+version = "0.17.11"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -66,15 +66,15 @@ function iterate(v::Base.ValueIterator{T}, i::Int) where {T <: DefaultDictBase}
     return (v.dict.d.vals[i], Base.skip_deleted(v.dict.d, i+1))
 end
 
-getindex(d::DefaultDictBase, key) = get!(d.d, key, d.default)
+getindex(d::DefaultDictBase, key) = get(d.d, key, d.default)
 
 function getindex(d::DefaultDictBase{K,V,F}, key) where {K,V,F<:Base.Callable}
     if d.passkey
-        return get!(d.d, key) do
+        return get(d.d, key) do
             d.default(key)
         end
     else
-        return get!(d.d, key) do
+        return get(d.d, key) do
             d.default()
         end
     end

--- a/test/test_default_dict.jl
+++ b/test/test_default_dict.jl
@@ -66,7 +66,7 @@ import DataStructures: DefaultDictBase
 
                 @test d['z'] == 26
                 @test d['@'] == 1
-                @test length(d) == 27
+                @test length(d) == 26
                 @test delete!(d, '@') === d
                 @test length(d) == 26
 
@@ -103,13 +103,13 @@ import DataStructures: DefaultDictBase
             end
             @test g["foobar"] == 6
             @test calls == 1
-            @test length(g) == 1
+            @test length(g) == 0
             @test g["baz"] == 3
             @test calls == 2
-            @test length(g) == 2
+            @test length(g) == 0
             @test g["foobar"] == 6
-            @test calls == 2
-            @test length(g) == 2
+            @test calls == 3
+            @test length(g) == 0
 
             @testset "Incorrect Usage" begin
                 bad_dds = [
@@ -124,9 +124,24 @@ import DataStructures: DefaultDictBase
             end
         end
 
-        # Alternate constructor
-        @test isa(DefaultDict(0.0), DefaultDict{Any, Any, Float64})
-        @test isa(DefaultDict(0.0, [(1, 1.0)]), DefaultDict{Int, Float64, Float64})
+        @testset "Alternate constructor" begin
+            @test isa(DefaultDict(0.0), DefaultDict{Any, Any, Float64})
+            @test isa(DefaultDict(0.0, [(1, 1.0)]), DefaultDict{Int, Float64, Float64})
+        end
+
+        @testset "Differently typed default" begin
+            # https://github.com/JuliaCollections/DataStructures.jl/issues/575
+            @testset "default: $def" for def in (missing, Missing, ()->missing)
+                dd_missing = DefaultDict(def, Dict(i => i for i in 1:3))
+                @test dd_missing[0] isa Missing
+            end
+        end
+
+        @testset "+=" begin
+            dd = DefaultDict(0, Dict('a'=>1, 'b'=>2))
+            dd['c'] += 10
+            @test dd['c'] == 10
+        end
     end
 
     @testset "DefaultOrderedDict" begin
@@ -173,7 +188,7 @@ import DataStructures: DefaultDictBase
 
                 @test d['z'] == 26
                 @test d['@'] == 1
-                @test length(d) == 27
+                @test length(d) == 26
                 @test delete!(d, '@') === d
                 @test length(d) == 26
 
@@ -198,7 +213,5 @@ import DataStructures: DefaultDictBase
         @testset "issue #216" begin
             @test DataStructures.isordered(DefaultOrderedDict{Int, String})
         end
-
     end
-
 end


### PR DESCRIPTION
Closes #575 

using `get!` means that the default must be the same type as the normal value.
Or we must during construction change the type of the value in the backing dict to be `Union{V, typeof(default)}`

using `get` does not have this requirement of matching types.

Note: this PR does change as to if multiple calls asking about the same key each call the `default` function (for the function case).
I think I prefer that it repeatedly call the default function over storing the default.
I think in most cases the default function is something cheap to compute, like a constructor.
where as hanging on to the defaults for something that is very rare could get very expensive.

E.g. if one has a set of pretrained word embeddings and one is looking them up to find the embeddings for each token in a text, then often one will encounter out of vocabulary words,
and storing all those keys and default values could start to use a lot of memory.