### PR TITLE
feat(accumulators.jl) : add constructor to Accumulator

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -14,6 +14,7 @@ end
 
 Accumulator{T, V}() where {T,V<:Number} = Accumulator{T,V}(Dict{T,V}())
 Accumulator(map::AbstractDict) = Accumulator(Dict(map))
+Accumulator(ps::Pair...) = Accumulator(Dict(ps))
 
 counter(T::Type) = Accumulator{T,Int}()
 counter(dct::AbstractDict{T, V}) where {T, V<:Integer} = Accumulator{T, V}(Dict(dct))
@@ -234,4 +235,19 @@ function Base.intersect!(a::Accumulator, b::Accumulator)
         drop_nonpositive!(a, k) # Drop any that ended up zero
     end
     return a
+end
+function Base.show(io::IO, acc::Accumulator{T,V}) where {T,V}
+    l = length(acc)
+    if l>0
+        print(io, "Accumulator(")
+    else
+        print(io,"Accumulator{$T,$V}(")
+    end
+    for (count, (k, v)) in enumerate(acc)
+        print(io, k, " => ", v)
+        if count < l
+            print(io, ", ")
+        end
+    end
+    print(io, ")")
 end

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -51,6 +51,17 @@
         @test sum(ct) == 6
     end
 
+    @testset "From Pairs" begin 
+        acc = Accumulator("a" => 2, "b" => 3, "c" => 1)
+        @test isa(acc,Accumulator{String,Int})
+        @test haskey(acc,"a")
+        @test haskey(acc,"b")
+        @test haskey(acc,"c")
+        @test acc["a"] == 2
+        @test acc["b"] == 3
+        @test acc["c"] == 1
+    end
+
     @testset "From Vector" begin
         ct2 = counter(["a", "a", "b", "b", "a", "c", "c"])
         @test isa(ct2, Accumulator{String,Int})
@@ -245,7 +256,10 @@
             @test_throws DataStructures.MultiplicityException (nonmultiset ∩ counter("aabbcc"))
         end
 
-
+        @testset "show" begin
+            @test sprint(show,Accumulator(1 => 3)) == "Accumulator(1 => 3)"
+            @test sprint(show,Accumulator(1 => 3, 3 => 4)) == "Accumulator(3 => 4, 1 => 3)"
+        end
 
 
     end


### PR DESCRIPTION
fixes #573 
Made `Accumulator(2 => 2, 3 => 1, 1 => 2)` a valid constructor by accepting variable number of pairs as inputs and making dictionary out of them.