### PR TITLE
Allow @inbounds for deque, queue and stack

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -97,6 +97,9 @@ Base.eltype(::Type{Deque{T}}) where T = T
     front(q::Deque)
 
 Returns the first element of the deque `q`.
+
+Throws an `ArgumentError` if the deque is empty. This check
+can be disabled with `@inbounds`.
 """
 @inline Base.@propagate_inbounds function first(q::Deque)
     @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
@@ -108,6 +111,9 @@ end
     back(q::Deque)
 
 Returns the last element of the deque `q`.
+
+Throws an `ArgumentError` if the deque is empty. This check
+can be disabled with `@inbounds`.
 """
 @inline Base.@propagate_inbounds function last(q::Deque)
     @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
@@ -281,6 +287,9 @@ end
     pop!(q::Deque{T})
 
 Remove the element at the back
+
+Throws an `ArgumentError` if the deque is empty. This check
+can be disabled with `@inbounds`.
 """
 @inline function pop!(q::Deque{T}) where T
     @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
@@ -306,6 +315,9 @@ end
     popfirst!(q::Deque{T})
 
 Remove the element at the front
+
+Throws an `ArgumentError` if the deque is empty. This check
+can be disabled with `@inbounds`.
 """
 @inline function popfirst!(q::Deque{T}) where T
     @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -94,7 +94,7 @@ num_blocks(q::Deque) = q.nblocks
 Base.eltype(::Type{Deque{T}}) where T = T
 
 """
-    front(q::Deque)
+    first(q::Deque)
 
 Returns the first element of the deque `q`.
 
@@ -108,7 +108,7 @@ can be disabled with `@inbounds`.
 end
 
 """
-    back(q::Deque)
+    last(q::Deque)
 
 Returns the last element of the deque `q`.
 

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -98,8 +98,8 @@ Base.eltype(::Type{Deque{T}}) where T = T
 
 Returns the first element of the deque `q`.
 """
-function first(q::Deque)
-    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
+@inline Base.@propagate_inbounds function first(q::Deque)
+    @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     blk = q.head
     blk.data[blk.front]
 end
@@ -109,8 +109,8 @@ end
 
 Returns the last element of the deque `q`.
 """
-function last(q::Deque)
-    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
+@inline Base.@propagate_inbounds function last(q::Deque)
+    @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     blk = q.rear
     blk.data[blk.back]
 end
@@ -282,8 +282,8 @@ end
 
 Remove the element at the back
 """
-function pop!(q::Deque{T}) where T
-    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
+@inline function pop!(q::Deque{T}) where T
+    @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     rear = q.rear
     @assert rear.back >= rear.front
 
@@ -307,8 +307,8 @@ end
 
 Remove the element at the front
 """
-function popfirst!(q::Deque{T}) where T
-    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
+@inline function popfirst!(q::Deque{T}) where T
+    @boundscheck isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     head = q.head
     @assert head.back >= head.front
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -16,10 +16,26 @@ isempty(s::Queue) = isempty(s.store)
 length(s::Queue) = length(s.store)
 Base.eltype(::Type{Queue{T}}) where T = T
 
+"""
+    first(q::Queue)
+
+Returns the first element of the queue `q`.
+
+Throws an `ArgumentError` if the queue is empty. This check
+can be disabled with `@inbounds`.
+"""
 Base.@propagate_inbounds function first(s::Queue)
     return first(s.store)
 end
 
+"""
+    last(q::Queue)
+
+Returns the last element of the queue `q`.
+
+Throws an `ArgumentError` if the queue is empty. This check
+can be disabled with `@inbounds`.
+"""
 Base.@propagate_inbounds function last(s::Queue)
     return last(s.store)
 end
@@ -38,6 +54,9 @@ end
     dequeue!(s::Queue)
 
 Removes an element from the front of the queue `s` and returns it.
+
+Throws an `ArgumentError` if the queue is empty. This check
+can be disabled with `@inbounds`.
 """
 Base.@propagate_inbounds function dequeue!(s::Queue)
     return popfirst!(s.store)

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -16,8 +16,13 @@ isempty(s::Queue) = isempty(s.store)
 length(s::Queue) = length(s.store)
 Base.eltype(::Type{Queue{T}}) where T = T
 
-first(s::Queue) = first(s.store)
-last(s::Queue) = last(s.store)
+Base.@propagate_inbounds function first(s::Queue)
+    return first(s.store)
+end
+
+Base.@propagate_inbounds function last(s::Queue)
+    return last(s.store)
+end
 
 """
     enqueue!(s::Queue, x)
@@ -34,7 +39,9 @@ end
 
 Removes an element from the front of the queue `s` and returns it.
 """
-dequeue!(s::Queue) = popfirst!(s.store)
+Base.@propagate_inbounds function dequeue!(s::Queue)
+    return popfirst!(s.store)
+end
 
 empty!(s::Queue) = (empty!(s.store); s)
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -40,14 +40,14 @@ Base.eltype(::Type{Stack{T}}) where T = T
 
 Get the top item from the stack. Sometimes called peek.
 """
-first(s::Stack) = last(s.store)
+Base.@propagate_inbounds first(s::Stack) = last(s.store)
 
 function push!(s::Stack, x)
     push!(s.store, x)
     s
 end
 
-pop!(s::Stack) = pop!(s.store)
+Base.@propagate_inbounds pop!(s::Stack) = pop!(s.store)
 
 empty!(s::Stack) = (empty!(s.store); s)
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -39,6 +39,9 @@ Base.eltype(::Type{Stack{T}}) where T = T
     first(s::Stack)
 
 Get the top item from the stack. Sometimes called peek.
+
+Throws an `ArgumentError` if the stack is empty. This check
+can be disabled with `@inbounds`.
 """
 Base.@propagate_inbounds first(s::Stack) = last(s.store)
 
@@ -47,6 +50,14 @@ function push!(s::Stack, x)
     s
 end
 
+"""
+    pop!(s::Stack)
+
+Remove the top item from the stack and return it.
+
+Throws an `ArgumentError` if the stack is empty. This check
+can be disabled with `@inbounds`.
+"""
 Base.@propagate_inbounds pop!(s::Stack) = pop!(s.store)
 
 empty!(s::Stack) = (empty!(s.store); s)


### PR DESCRIPTION
This PR allows disabling boundchecks for some methods in deque, queue and stack.

I should maybe mention, that the method `first` from the Julia base, does not allow one to disable boundchecks for Vectors, although this package already allows one to disable boundchecks for `first` on `CircularDeque`. 

I will now make a basic benchmark and post the results here.