### PR TITLE
Display the type of list

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -29,7 +29,11 @@ function show(io::IO, l::LinkedList{T}) where T
             print(io, "nil(", T, ")")
         end
     else
-        print(io, "list(")
+        if T === Any
+            print(io, "list(")
+        else
+            print(io, "list{$T}(")
+        end
         show(io, head(l))
         for t in tail(l)
             print(io, ", ")


### PR DESCRIPTION
Fixes #591 .
Current behaviour:
```
julia> cons(1, cons(2, nil()))
list(1, 2)

julia> cons(1, cons(2, nil(Int32)))
list(1, 2)
```

On this branch:
```
julia> cons(1, cons(2, nil()))
list(1, 2)

julia> cons(1, cons(2, nil(Int32)))
list{Int32}(1, 2)
```