### PR TITLE
prefixsum for non-positive index in FenwickTree

### DIFF
--- a/src/fenwick.jl
+++ b/src/fenwick.jl
@@ -84,8 +84,6 @@ julia> prefixsum(f, 3)
 function prefixsum(ft::FenwickTree{T}, ind::Integer) where T
     sum = zero(T)
     ind < 1 && return sum
-        return 0
-    end
     i = ind
     n = ft.n
     @boundscheck 1 <= i <= n || throw(ArgumentError("$i should be in between 1 and $n"))

--- a/src/fenwick.jl
+++ b/src/fenwick.jl
@@ -83,6 +83,9 @@ julia> prefixsum(f, 3)
 """
 function prefixsum(ft::FenwickTree{T}, ind::Integer) where T
     sum = zero(T)
+    if ind < 1
+        return 0
+    end
     i = ind
     n = ft.n
     @boundscheck 1 <= i <= n || throw(ArgumentError("$i should be in between 1 and $n"))

--- a/src/fenwick.jl
+++ b/src/fenwick.jl
@@ -83,7 +83,7 @@ julia> prefixsum(f, 3)
 """
 function prefixsum(ft::FenwickTree{T}, ind::Integer) where T
     sum = zero(T)
-    if ind < 1
+    ind < 1 && return sum
         return 0
     end
     i = ind

--- a/test/test_fenwick.jl
+++ b/test/test_fenwick.jl
@@ -31,9 +31,11 @@
         incdec!(f1, 2, 6, 3)
         @test prefixsum(f1, 3) == 3
         @test prefixsum(f1, 7) == 5
+        
+        @test prefixsum(f1, 0) == 0
+        @test prefixsum(f1, -100) == 0
 
         @test_throws ArgumentError inc!(f1, 11)
-        @test_throws ArgumentError inc!(f1, 0)
     end
 
 end


### PR DESCRIPTION
I think that `prefixsum(ft, x)` should give `0` when `x<1` instead of an ArgumentError, just like how `sum([12,3,4,5,6][1:0]) = 0`.
In particular I was editing some code, and I assumed that `sum(my_array[1:x]) == prefixsum(FenwickTree(my_array), x)` would always be `true`. I was surprised that it wasn't `true` for all `x`, and think that this should be changed.