### PR TITLE
Change `delete!()` for Sorted{Set,Dict} to no-op if key not found.

### DIFF
--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -453,8 +453,9 @@ Returns `sc`. Time: O(*c* log *n*)
 """
 @inline function delete!(m::SortedDict, k_)
     i, exactfound = findkey(m.bt, convert(keytype(m), k_))
-    !exactfound && throw(KeyError(k_))
-    delete!(m.bt, i)
+    if exactfound
+        delete!(m.bt, i)
+    end
     m
 end
 

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -229,8 +229,9 @@ Returns `sc`. Time: O(*c* log *n*)
 """
 @inline function delete!(m::SortedSet, k_)
     i, exactfound = findkey(m.bt,convert(keytype(m),k_))
-    !exactfound && throw(KeyError(k_))
-    delete!(m.bt, i)
+    if exactfound
+        delete!(m.bt, i)
+    end
     return m
 end
 

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1676,7 +1676,7 @@ end
     i2 = findkey(m,"bb")
     @test_throws BoundsError iterate(inclusive(m,i1,i2))
     @test_throws BoundsError iterate(exclusive(m,i1,i2))
-    @test_throws KeyError delete!(m,"a")
+    @test m === delete!(m,"a") # Okay to delete! nonexistent keys
     @test_throws KeyError pop!(m,"a")
     m3 = SortedDict((Dict{String, Int}()), Reverse)
     @test_throws ArgumentError isequal(m2, m3)
@@ -1697,7 +1697,7 @@ end
     @test_throws BoundsError last(m1)
 
     s = SortedSet([3,5])
-    @test_throws KeyError delete!(s,7)
+    @test s === delete!(s,7) # Okay to delete! nonexistent keys
     @test_throws KeyError pop!(s, 7)
     pop!(s)
     pop!(s)


### PR DESCRIPTION
This makes SortedSet and SortedDict behave more like Julia Base's Set and Dict.

Fixes https://github.com/JuliaCollections/DataStructures.jl/issues/387