### PR TITLE
Fix `first` and `last` function names in `Deque` docstrings

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -94,7 +94,7 @@ num_blocks(q::Deque) = q.nblocks
 Base.eltype(::Type{Deque{T}}) where T = T
 
 """
-    front(q::Deque)
+    first(q::Deque)
 
 Returns the first element of the deque `q`.
 """
@@ -105,7 +105,7 @@ function first(q::Deque)
 end
 
 """
-    back(q::Deque)
+    last(q::Deque)
 
 Returns the last element of the deque `q`.
 """


### PR DESCRIPTION
Function names were changed in #565, but the docstrings for methods on `Deque` weren't updated