### PR TITLE
RobinDict empty! not zeroing hashes bugfix

### DIFF
--- a/src/robin_dict.jl
+++ b/src/robin_dict.jl
@@ -285,6 +285,7 @@ function empty!(h::RobinDict{K,V}) where {K, V}
     resize!(h.keys, sz)
     resize!(h.vals, sz)
     resize!(h.hashes, sz)
+    fill!(h.hashes, 0)
     h.count = 0
     h.idxfloor = 0
     return h

--- a/test/test_robin_dict.jl
+++ b/test/test_robin_dict.jl
@@ -330,6 +330,9 @@ end
     @test h.count == 0
     @test h.idxfloor == 0
     @test length(h.hashes) == length(h.keys) == length(h.vals) == length0
+    for i=-1000:1000
+      @test !haskey(h, i)
+    end
 end
 
 @testset "ArgumentError" begin


### PR DESCRIPTION
I believe without this change garbage keys from before `empty!` or garbage keys can be found in the dictionary which should be the case