### PR TITLE
Add `RobinDict` to sidebar in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(
         "heaps.md",
         "ordered_containers.md",
         "default_dict.md",
+        "robin_dict.md",
         "trie.md",
         "linked_list.md",
         "mutable_linked_list.md",


### PR DESCRIPTION
`RobinDict` was not listed in the sidebar in docs even though it has a page and is listed in index under contents.