### PR TITLE
Add export of peek to pass CI on Julia 0.7 and 1.0

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -101,7 +101,7 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
-    export PriorityQueue
+    export PriorityQueue, peek
 
     include("priorityqueue.jl")
     include("sparse_int_set.jl")


### PR DESCRIPTION
Removed in previous commit. Because of failure on nightlies.