### PR TITLE
Correct the behavior of RobinDict for get, getkey, haskey, getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.17"
+version = "0.17.18"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/robin_dict.jl
+++ b/src/robin_dict.jl
@@ -291,7 +291,7 @@ function empty!(h::RobinDict{K,V}) where {K, V}
     return h
 end
 
-function rh_search(h::RobinDict{K, V}, key::K) where {K, V}
+function rh_search(h::RobinDict{K, V}, key) where {K, V}
     sz = length(h.keys)
     chash = hash_key(key)
     index = desired_index(chash, sz)
@@ -367,8 +367,7 @@ function _get!(default::Callable, h::RobinDict{K,V}, key::K) where V where K
     return v
 end
 
-function getindex(h::RobinDict{K, V}, key0) where {K, V}
-    key = convert(K, key0)
+function getindex(h::RobinDict{K, V}, key) where {K, V}
     index = rh_search(h, key)
     @inbounds return (index < 0) ? throw(KeyError(key)) : h.vals[index]
 end
@@ -392,8 +391,7 @@ julia> get(d, "c", 3)
 """
 get(collection, key, default)
 
-function get(h::RobinDict{K,V}, key0, default) where {K, V}
-    key = convert(K, key0)
+function get(h::RobinDict{K,V}, key, default) where {K, V}
     index = rh_search(h, key)
     @inbounds return (index < 0) ? default : h.vals[index]::V
 end
@@ -415,8 +413,7 @@ end
 """
 get(::Function, collection, key)
 
-function get(default::Callable, h::RobinDict{K,V}, key0) where {K, V}
-    key = convert(K, key0)
+function get(default::Callable, h::RobinDict{K,V}, key) where {K, V}
     index = rh_search(h, key)
     @inbounds return (index < 0) ? default() : h.vals[index]::V
 end
@@ -462,8 +459,7 @@ julia> getkey(D, 'd', 'a')
 'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
 ```
 """
-function getkey(h::RobinDict{K,V}, key0, default) where {K, V}
-    key = convert(K, key0)
+function getkey(h::RobinDict{K,V}, key, default) where {K, V}
     index = rh_search(h, key)
     @inbounds return (index < 0) ? default : h.keys[index]::K
 end

--- a/test/test_robin_dict.jl
+++ b/test/test_robin_dict.jl
@@ -107,6 +107,9 @@ end
         end
         @test get_KeyError
     end
+
+    h = RobinDict{Char, Int}()
+    @test_throws KeyError h[0.01] 
 end
 
 @testset "Filter function" begin
@@ -214,7 +217,7 @@ end
     @test eq(RobinDict(), sizehint!(RobinDict(),96))
 
     # Dictionaries of different types
-    @test_throws MethodError eq(RobinDict(1 => 2), RobinDict("dog" => "bone"))
+    @test !eq(RobinDict(1 => 2), RobinDict("dog" => "bone"))
     @test eq(RobinDict{Int,Int}(), RobinDict{AbstractString,AbstractString}())
 end
 
@@ -310,14 +313,14 @@ end
     @test haskey(h, 1) == true
     @test haskey(h, 2) == true
     @test haskey(h, 3) == false
-    @test_throws MethodError haskey(h, "1")
+    @test haskey(h, "1") == false
 end
 
 @testset "getkey" begin
     h = RobinDict(1=>2, 3 => 6, 5=>10)
     @test getkey(h, 1, 7) == 1
     @test getkey(h, 4, 6) == 6
-    @test_throws MethodError getkey(h, "1", 8)
+    @test getkey(h, "1", 8) == 8
 end
 
 @testset "empty" begin


### PR DESCRIPTION
Match to the behavior of `Base.Dict` in these scenarios.
Fixes #628