### PR TITLE
remove redundant iterate method

### DIFF
--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -61,11 +61,6 @@ DefaultDictBase{K,V}(default::F; kwargs...) where {K,V,F} = DefaultDictBase{K,V,
 empty(d::DefaultDictBase{K,V,F}) where {K,V,F} = DefaultDictBase{K,V,F}(d.default; passkey=d.passkey)
 @deprecate similar(d::DefaultDictBase) empty(d)
 
-function iterate(v::Base.ValueIterator{T}, i::Int) where {T <: DefaultDictBase}
-    i > length(v.dict.d.vals) && return nothing
-    return (v.dict.d.vals[i], Base.skip_deleted(v.dict.d, i+1))
-end
-
 getindex(d::DefaultDictBase, key) = get!(d.d, key, d.default)
 
 function getindex(d::DefaultDictBase{K,V,F}, key) where {K,V,F<:Base.Callable}


### PR DESCRIPTION
the fallback method seems to work just as well.
This method also causes some invalidations so good to get rid of it

cc @timholy (playing around with new SnoopCompile)