### PR TITLE
Add Base.copy, Base.copymutable for Sorted containers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.18"
+version = "0.17.19"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -535,6 +535,11 @@ function mergetwo!(m::SortedDict{K,D,Ord},
     end
 end
 
+# Standard copy functions use packcopy - that is, they retain elements but not
+# the identical structure.
+Base.copymutable(m::SortedDict) = packcopy(m)
+Base.copy(m::SortedDict) = packcopy(m)
+
 """
     packcopy(sc)
 

--- a/src/sorted_multi_dict.jl
+++ b/src/sorted_multi_dict.jl
@@ -385,6 +385,11 @@ function mergetwo!(m::SortedMultiDict{K,D,Ord},
     end
 end
 
+# Standard copy functions use packcopy - that is, they retain elements but not
+# the identical structure.
+Base.copymutable(m::SortedMultiDict) = packcopy(m)
+Base.copy(m::SortedMultiDict) = packcopy(m)
+
 """
     packcopy(sc)
 

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -519,6 +519,11 @@ function issubset(iterable, m2::SortedSet)
     return true
 end
 
+# Standard copy functions use packcopy - that is, they retain elements but not
+# the identical structure.
+Base.copymutable(m::SortedSet) = packcopy(m)
+Base.copy(m::SortedSet) = packcopy(m)
+
 """
     packcopy(sc)
 

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1717,4 +1717,10 @@ end
     @test pop!(s,50, nothing) == nothing
     @test isempty(s)
 
+    # Test AbstractSet/AbstractDict interface
+    for m in [SortedSet([1,2]), SortedDict(1=>2, 2=>3), SortedMultiDict(1=>2, 1=>3)]
+        # copy()
+        @test isequal(copy(m), m)
+        @test isequal(Base.copymutable(m), m)
+    end
 end

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -1720,7 +1720,13 @@ end
     # Test AbstractSet/AbstractDict interface
     for m in [SortedSet([1,2]), SortedDict(1=>2, 2=>3), SortedMultiDict(1=>2, 1=>3)]
         # copy()
-        @test isequal(copy(m), m)
-        @test isequal(Base.copymutable(m), m)
+        let m1 = copy(m)
+            @test isequal(m1, m)
+            @test typeof(m1) === typeof(m)
+        end
+        let m1 = Base.copymutable(m)
+            @test isequal(m1, m)
+            @test typeof(m1) === typeof(m)
+        end
     end
 end


### PR DESCRIPTION
Per our notes in https://github.com/JuliaCollections/DataStructures.jl/pull/571#issuecomment-594125382, the sorted containers currently don't implement `Base.copy(x)`, which is "Strongly Recommended," but not "Required."

However, they do all already provide `packcopy(m)`, and as far as i can tell, that seems like a perfectly reasonable implementation of copy: it returns a new container with all the same elements but not necessarily the same structure. ✔️ 

So this PR simply aliases `copy` and `copymutable` to `packcopy`. Does that sound good? :)
Thanks!
~Nathan
