### PR TITLE
CircularBuffer: Add benchmarks and improve performance

### DIFF
--- a/benchmark/bench_circular_buffer.jl
+++ b/benchmark/bench_circular_buffer.jl
@@ -1,0 +1,145 @@
+module BenchCircularBuffer
+
+using DataStructures
+using BenchmarkTools
+using Random
+
+const SUITE = BenchmarkGroup()
+const CAPS = [1024, 1024^2]
+
+# Empirically, 1 second is sufficient for consistent timings here.
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
+
+function init_cb(a)
+    len = length(a)
+    cb = CircularBuffer{Int}(len)
+    cb.first = 1 + div(len, 2)
+    return append!(cb, a)
+end
+
+function perf_chained_getindex(cb)
+    i = 1
+    for _ in eachindex(cb)
+        i = cb[i]
+    end
+    return i
+end
+
+function perf_first(cb)
+    total = 0
+    for i in 1:capacity(cb)
+        cb.first = i
+        total += first(cb)
+    end
+    return total
+end
+
+function perf_last(cb)
+    total = 0
+    for i in 1:capacity(cb)
+        cb.first = i
+        total += last(cb)
+    end
+    return total
+end
+
+g = addgroup!(SUITE, "access")
+
+# Creating a new copy for each sample seems to eliminates an unknown but substantial source
+# of timing variation on some machines. This is why each benchmark has `setup=(cb = deepcopy($cb))`.
+for cap in CAPS
+    Random.seed!(0)
+    cb = init_cb(randcycle(cap))
+
+    g["chained_getindex", cap] = @benchmarkable perf_chained_getindex(cb) setup=(cb = deepcopy($cb))
+
+    g["sum", cap] = @benchmarkable sum(cb) setup=(cb = deepcopy($cb))
+    g["foldl", cap] = @benchmarkable foldl(+, cb) setup=(cb = deepcopy($cb))
+    g["foldr", cap] = @benchmarkable foldr(+, cb) setup=(cb = deepcopy($cb))
+
+    g["first", cap] = @benchmarkable perf_first(cb) setup=(cb = deepcopy($cb))
+    g["last", cap] = @benchmarkable perf_last(cb) setup=(cb = deepcopy($cb); cb.length = div($cap, 2))
+
+    g["convert", cap] = @benchmarkable convert(Array, cb) setup=(cb = deepcopy($cb))
+end
+
+function perf_setindex!(cb, indices)
+    for i in indices
+        cb[i] = i
+    end
+    return cb
+end
+
+function perf_push!(cb)
+    for i in 1:capacity(cb)
+        push!(cb, i)
+    end
+    return cb
+end
+
+function perf_pushfirst!(cb)
+    for i in 1:capacity(cb)
+        pushfirst!(cb, i)
+    end
+    return cb
+end
+
+g = addgroup!(SUITE, "mutate")
+
+for cap in CAPS
+    cb = init_cb(-1:-1:-cap)
+
+    Random.seed!(0)
+    g["random_setindex!", cap] = @benchmarkable perf_setindex!(cb, $(randperm(cap))) setup=(cb = deepcopy($cb))
+    g["forward_setindex!", cap] = @benchmarkable perf_setindex!(cb, 1:$cap) setup=(cb = deepcopy($cb))
+    g["reverse_setindex!", cap] = @benchmarkable perf_setindex!(cb, $cap:-1:1) setup=(cb = deepcopy($cb))
+
+    g["full_push!", cap] = @benchmarkable perf_push!(cb) setup=(cb = deepcopy($cb))
+    g["full_pushfirst!", cap] = @benchmarkable perf_pushfirst!(cb) setup=(cb = deepcopy($cb))
+end
+
+perf_empty_push!(cb) = (empty!(cb); perf_push!(cb))
+perf_empty_pushfirst!(cb) = (empty!(cb); perf_pushfirst!(cb))
+
+function perf_pop!(cb)
+    cap = capacity(cb)
+    cb.length = cap
+    total = 0
+    for _ in 1:cap
+        total += pop!(cb)
+    end
+    return total
+end
+
+function perf_popfirst!(cb)
+    cap = capacity(cb)
+    cb.length = cap
+    total = 0
+    for _ in 1:cap
+        total += popfirst!(cb)
+    end
+    return total
+end
+
+perf_fill!(cb) = (empty!(cb); fill!(cb, 1))
+
+for cap in CAPS
+    cb = init_cb(-1:-1:-cap)
+    g["empty_push!", cap] = @benchmarkable perf_empty_push!(cb) setup=(cb = deepcopy($cb))
+    g["empty_pushfirst!", cap] = @benchmarkable perf_empty_pushfirst!(cb) setup=(cb = deepcopy($cb))
+    g["pop!", cap] = @benchmarkable perf_pop!(cb) setup=(cb = deepcopy($cb))
+    g["popfirst!", cap] = @benchmarkable perf_popfirst!(cb) setup=(cb = deepcopy($cb))
+    g["fill!", cap] = @benchmarkable perf_fill!(cb) setup=(cb = deepcopy($cb))
+end
+
+end  # module BenchCircularBuffer
+
+if @isdefined(SUITE)
+    BenchCircularBuffer.SUITE
+else
+    # This `else` branch allows this file to be called directly by PkgBenchmark via the
+    # `script` keyword in `PkgBenchmark.benchmarkpkg`.
+	using BenchmarkTools
+    const SUITE = BenchmarkGroup()
+    SUITE["CircularBuffer"] = BenchCircularBuffer.SUITE
+end

--- a/benchmark/bench_circular_buffer.jl
+++ b/benchmark/bench_circular_buffer.jl
@@ -45,7 +45,7 @@ end
 
 g = addgroup!(SUITE, "access")
 
-# Creating a new copy for each sample seems to eliminates an unknown but substantial source
+# Creating a new copy for each sample seems to eliminate an unknown but substantial source
 # of timing variation on some machines. This is why each benchmark has `setup=(cb = deepcopy($cb))`.
 for cap in CAPS
     Random.seed!(0)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -10,5 +10,6 @@ using BenchmarkTools
 
 const SUITE = BenchmarkGroup()
 
+SUITE["CircularBuffer"] = include("bench_circular_buffer.jl")
 SUITE["heap"] = include("bench_heap.jl")
 SUITE["SparseIntSet"] = include("bench_sparse_int_set.jl")


### PR DESCRIPTION
This PR adds a set of benchmarks for `CircularBuffer` and also improves its performance.

Here are some `PkgBenchmark` reports using the benchmarks and comparing the new performance:
- [Comparison with baseline](https://gist.github.com/vyu/51705d29b4aa65fd52162ac8fa6c07b9) on Julia 1.4.
- [Comparison with baseline](https://gist.github.com/vyu/4bbc48fd38cdbf764e8c5b660e985943) on Julia 1.0.
- [Timings on Julia 1.4](https://gist.github.com/vyu/2b64c9e3edaf00f45845a30213c21c46), on an N2D instance on GCP.

The benchmark file can be called directly by `PkgBenchmark` using the `script` keyword. For example, `PkgBenchmark.benchmarkpkg("DataStructures"; script="benchmark/bench_circular_buffer.jl")`.

I'll add commit comments here to explain the rationale behind some of the changes.

There was some inconsistency in the code over whether to use accessor functions (`capacity(cb)`) or dot notation (`cb.capacity`) to read field values. For consistency within the file, I've modified them to use accessor functions. They generate identical code since the functions get inlined.

I haven't worked on `append!` and `fill!` yet because improving those is more complicated. I might get to them later if this PR goes through.

Thanks!