### PR TITLE
deprecate path for partial_path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.19"
+version = "0.17.20"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/docs/src/trie.md
+++ b/docs/src/trie.md
@@ -22,12 +22,12 @@ Trie(kvs::AbstractVector{(K, V)})   # construct a Trie from the given vector of 
 Trie(kvs::AbstractDict{K, V})       # construct a Trie from the given associative structure
 ```
 
-This package also provides an iterator `path(t::Trie, str)` for looping
+This package also provides an iterator `partial_path(t::Trie, str)` for looping
 over all the nodes encountered in searching for the given string `str`.
 This obviates much of the boilerplate code needed in writing many trie
 algorithms. For example, to test whether a trie contains any prefix of a
 given string, use:
 
 ```julia
-seen_prefix(t::Trie, str) = any(v -> v.is_key, path(t, str))
+seen_prefix(t::Trie, str) = any(v -> v.is_key, partial_path(t, str))
 ```

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -41,7 +41,7 @@ module DataStructures
     export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!
 
-    export Trie, subtrie, keys_with_prefix, path
+    export Trie, subtrie, keys_with_prefix, partial_path
 
     export LinkedList, Nil, Cons, nil, cons, head, tail, list, filter, cat,
            reverse

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -6,3 +6,5 @@ export find_root
 const find_root = find_root!
 
 @deprecate deque(::Type{T}) where {T} Deque{T}()
+
+@deprecate path(t::Trie, str::AbstractString) partial_path(t::Trie, str::AbstractString)

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -120,5 +120,5 @@ function iterate(it::TrieIterator, (t, i) = (it.t, 0))
     end
 end
 
-path(t::Trie, str::AbstractString) = TrieIterator(t, str)
+partial_path(t::Trie, str::AbstractString) = TrieIterator(t, str)
 Base.IteratorSize(::Type{TrieIterator}) = Base.SizeUnknown()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,8 @@ import DataStructures: IntSet
 
 @test [] == detect_ambiguities(Base, Core, DataStructures)
 
-tests = ["int_set",
+tests = ["deprecations",
+         "int_set",
          "sparse_int_set",
          "deque",
          "circ_deque",

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -1,0 +1,17 @@
+# These are the tests for deprecated features, they should be deleted along with them
+
+@testset "Trie: path iterator" begin
+    t = Trie{Int}()
+    t["rob"] = 27
+    t["roger"] = 52
+    t["kevin"] = Int8(11)
+    t0 = t
+    t1 = t0.children['r']
+    t2 = t1.children['o']
+    t3 = t2.children['b']
+    @test collect(path(t, "b")) == [t0]
+    @test collect(path(t, "rob")) == [t0, t1, t2, t3]
+    @test collect(path(t, "robb")) == [t0, t1, t2, t3]
+    @test collect(path(t, "ro")) == [t0, t1, t2]
+    @test collect(path(t, "roa")) == [t0, t1, t2]
+end

--- a/test/test_trie.jl
+++ b/test/test_trie.jl
@@ -1,8 +1,6 @@
 @testset "Trie" begin
-
-    t = Trie{Int}()
-
     @testset "Core Functionality" begin
+        t = Trie{Int}()
         t["amy"] = 56
         t["ann"] = 15
         t["emma"] = 30
@@ -27,16 +25,19 @@
         @test isa(Trie(ks), Trie{Nothing})
     end
 
-    @testset "path iterator" begin
+    @testset "partial_path iterator" begin
+        t = Trie{Int}()
+        t["rob"] = 27
+        t["roger"] = 52
+        t["kevin"] = Int8(11)
         t0 = t
         t1 = t0.children['r']
         t2 = t1.children['o']
         t3 = t2.children['b']
-        @test collect(path(t, "b")) == [t0]
-        @test collect(path(t, "rob")) == [t0, t1, t2, t3]
-        @test collect(path(t, "robb")) == [t0, t1, t2, t3]
-        @test collect(path(t, "ro")) == [t0, t1, t2]
-        @test collect(path(t, "roa")) == [t0, t1, t2]
+        @test collect(partial_path(t, "b")) == [t0]
+        @test collect(partial_path(t, "rob")) == [t0, t1, t2, t3]
+        @test collect(partial_path(t, "robb")) == [t0, t1, t2, t3]
+        @test collect(partial_path(t, "ro")) == [t0, t1, t2]
+        @test collect(partial_path(t, "roa")) == [t0, t1, t2]
     end
-
 end # @testset Trie


### PR DESCRIPTION
Closes #633 
should be merged before https://github.com/JuliaCollections/DataStructures.jl/pull/643
which will need to be rebased to delete this deprecation