### PR TITLE
SplayTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This package implements a variety of data structures, including
 -   SparseIntSet
 -   DiBitVector (in which each element can store two bits)
 -   Red Black Tree
--   Splay Tree
 -   AVL Tree
 -   Splay Tree
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This package implements a variety of data structures, including
 -   DiBitVector (in which each element can store two bits)
 -   Red Black Tree
 -   AVL Tree
+-   Splay Tree
 
 Resources
 ---------

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(
         "dibit_vector.md",
         "red_black_tree.md",
         "avl_tree.md",
+        "splay_tree.md",
     ],
     modules = [DataStructures],
     format = Documenter.HTML()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,6 @@ makedocs(
         "sorted_containers.md",
         "dibit_vector.md",
         "red_black_tree.md",
-        "splay_tree.md",
         "avl_tree.md",
         "splay_tree.md",
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,6 +25,7 @@ This package implements a variety of data structures, including
 -   DiBitVector
 -   Red Black Tree
 -   AVL Tree
+-   Splay Tree
 
 ## Contents
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,6 @@ This package implements a variety of data structures, including
 -   SparseIntSet
 -   DiBitVector
 -   Red Black Tree
--   Splay Tree
 -   AVL Tree
 -   Splay Tree
 
@@ -53,6 +52,7 @@ Pages = [
     "sparse_int_set.md",
     "dibit_vector.md",
     "red_black_tree.md",
-    "avl_tree.md"
+    "avl_tree.md",
+    "splay_tree.md",
 ]
 ```

--- a/docs/src/splay_tree.md
+++ b/docs/src/splay_tree.md
@@ -1,0 +1,34 @@
+```@meta
+DocTestSetup = :(using DataStructures)
+```
+
+# Splay Tree
+
+The `SplayTree` type is an implementation of Splay Tree in Julia. It is a self-balancing binary search tree with the additional property that recently accessed elements are quick to access again. Operations such as search, insert and delete can be done in `O(log n)` amortized time, where `n` is the number of nodes in the `SplayTree`.
+
+Examples:
+
+```jldoctest
+julia> tree = SplayTree{Int}();
+
+julia> for k in 1:2:20
+           push!(tree, k)
+       end
+
+julia> haskey(tree, 3)
+true
+
+julia> tree[4]
+7
+
+julia> for k in 1:2:10
+           delete!(tree, k)
+       end
+
+julia> haskey(tree, 5)
+false
+```
+
+```@meta
+DocTestSetup = nothing
+```

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -107,6 +107,7 @@ module DataStructures
     include("dibit_vector.jl")
     include("avl_tree.jl")
     include("red_black_tree.jl")
-
+    include("splay_tree.jl")
     include("deprecations.jl")
+
 end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -52,6 +52,7 @@ module DataStructures
 
     export RBTree, search_node, minimum_node
     export AVLTree, sorted_rank
+    export SplayTree, maximum_node
 
     export findkey
 

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -216,7 +216,7 @@ function Base.push!(tree::SplayTree{K}, key0) where K
 end
 
 function Base.getindex(tree::SplayTree{K}, ind) where K 
-    @boundscheck (1 <= ind <= tree.count) || throw(BoundsError("$ind should be in between 1 and $(tree.count)"))
+    @boundscheck (1 <= ind <= tree.count) || throw(KeyError("$ind should be in between 1 and $(tree.count)"))
     function traverse_tree_inorder(node::SplayTreeNode_or_null)
         if (node != nothing)
             left = traverse_tree_inorder(node.leftChild)

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -2,11 +2,10 @@ mutable struct SplayTreeNode{K}
     leftChild::Union{SplayTreeNode{K}, Nothing}
     rightChild::Union{SplayTreeNode{K}, Nothing}
     parent::Union{SplayTreeNode{K}, Nothing}
-    dirty::Bool
     data::K
 
-    SplayTreeNode{K}() where K = new{K}(nothing, nothing, nothing, true)
-    SplayTreeNode{K}(d::K) where K = new{K}(nothing, nothing, nothing, false, d)
+    SplayTreeNode{K}() where K = new{K}(nothing, nothing, nothing)
+    SplayTreeNode{K}(d::K) where K = new{K}(nothing, nothing, nothing, d)
 end
 
 SplayTreeNode_or_null{K} = Union{SplayTreeNode{K}, Nothing}
@@ -14,7 +13,6 @@ SplayTreeNode_or_null{K} = Union{SplayTreeNode{K}, Nothing}
 SplayTreeNode(d) = SplayTreeNode{Any}(d)
 SplayTreeNode() = SplayTreeNode{Any}()
 
-isdirty(node::SplayTreeNode) = node.dirty
 
 mutable struct SplayTree{K}
     root::SplayTreeNode_or_null{K}
@@ -155,7 +153,7 @@ function search_key(tree::SplayTree{K}, d::K) where K
     end
 end
 
-function delete!(tree::SplayTree{K}, d::K) where K
+function Base.delete!(tree::SplayTree{K}, d::K) where K
     node = tree.root
     x = search_by_node(node, d)
     isa(x, Nothing) && return tree
@@ -180,7 +178,7 @@ function delete!(tree::SplayTree{K}, d::K) where K
     return tree
 end
 
-function insert!(tree::SplayTree{K}, d::K) where K
+function Base.insert!(tree::SplayTree{K}, d::K) where K
     is_present = search_by_node(tree.root, d)
     if !isa(is_present, Nothing) && (is_present.data == d)
         return tree

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -109,7 +109,7 @@ end
 # This is a two-step process.
 # In the first step, splay the largest node in S. This moves the largest node to the root node.
 # In the second step, set the right child of the new root of S to T.
-function _join(tree::SplayTree, s::Union{SplayTreeNode, Nothing}, t::Union{SplayTreeNode, Nothing})
+function _join!(tree::SplayTree, s::Union{SplayTreeNode, Nothing}, t::Union{SplayTreeNode, Nothing})
     if s === nothing
         return t
     elseif t === nothing
@@ -173,7 +173,7 @@ function Base.delete!(tree::SplayTree{K}, d::K) where K
         s.leftChild.parent = nothing
     end
 
-    tree.root = _join(tree, s.leftChild, t)
+    tree.root = _join!(tree, s.leftChild, t)
     tree.count -= 1
     return tree
 end

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -178,7 +178,7 @@ function Base.delete!(tree::SplayTree{K}, d::K) where K
     return tree
 end
 
-function insert!(tree::SplayTree{K}, d::K) where K
+function Base.insert!(tree::SplayTree{K}, d::K) where K
     is_present = search_node(tree, d)
     if (is_present !== nothing) && (is_present.data == d)
         return tree

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -178,7 +178,8 @@ function Base.delete!(tree::SplayTree{K}, d::K) where K
     return tree
 end
 
-function Base.insert!(tree::SplayTree{K}, d::K) where K
+function Base.push!(tree::SplayTree{K}, d0) where K
+    d = convert(K, d0)
     is_present = search_node(tree, d)
     if (is_present !== nothing) && (is_present.data == d)
         return tree
@@ -208,11 +209,6 @@ function Base.insert!(tree::SplayTree{K}, d::K) where K
     splay!(tree, node)
     tree.count += 1
     return tree
-end
-
-function Base.push!(tree::SplayTree{K}, key0) where K
-    key = convert(K, key0)
-    insert!(tree, key)
 end
 
 function Base.getindex(tree::SplayTree{K}, ind) where K 

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -1,0 +1,212 @@
+mutable struct SplayTreeNode{K}
+    leftChild::Union{SplayTreeNode{K}, Nothing}
+    rightChild::Union{SplayTreeNode{K}, Nothing}
+    parent::Union{SplayTreeNode{K}, Nothing}
+    dirty::Bool
+    data::K
+
+    SplayTreeNode{K}() where K = new{K}(nothing, nothing, nothing, true)
+    SplayTreeNode{K}(d::K) where K = new{K}(nothing, nothing, nothing, false, d)
+end
+
+SplayTreeNode_or_null{K} = Union{SplayTreeNode{K}, Nothing}
+
+SplayTreeNode(d) = SplayTreeNode{Any}(d)
+SplayTreeNode() = SplayTreeNode{Any}()
+
+isdirty(node::SplayTreeNode) = node.dirty
+
+mutable struct SplayTree{K}
+    root::SplayTreeNode_or_null{K}
+
+    SplayTree{K}() where K = new{K}(nothing)
+end 
+
+SplayTree(d) = SplayTree{Any}(d)
+SplayTree() = SplayTree{Any}()
+
+function left_rotate!(tree::SplayTree, node_x::SplayTreeNode)
+    node_y = node_x.rightChild
+    node_x.rightChild = node_y.leftChild
+    if node_y.leftChild != nothing
+        node_y.leftChild.parent = node_x
+    end
+    node_y.parent = node_x.parent
+
+    if node_x.parent == nothing
+        tree.root = node_y
+    elseif (node_x == node_x.parent.leftChild)
+        node_x.parent.leftChild = node_y
+    else
+        node_x.parent.rightChild = node_y
+    end
+    if node_y != nothing
+        node_y.leftChild = node_x
+    end
+    node_x.parent = node_y
+end    
+
+function right_rotate!(tree::SplayTree, node_x::SplayTreeNode)
+    node_y = node_x.leftChild
+    node_x.leftChild = node_y.rightChild
+    if node_y.rightChild != nothing
+        node_y.rightChild.parent = node_x
+    end
+    node_y.parent = node_x.parent
+    if node_x.parent == nothing
+        tree.root = node_y
+    elseif (node_x == node_x.parent.leftChild)
+        node_x.parent.leftChild = node_y
+    else
+        node_x.parent.rightChild = node_y
+    end
+    node_y.rightChild = node_x
+    node_x.parent = node_y
+end 
+
+
+function splay!(tree::SplayTree, node_x::SplayTreeNode)
+    while !isa(node_x.parent, Nothing)
+        parent = node_x.parent
+        grand_parent = node_x.parent.parent
+        # grand-parent is Null
+        if isa(grand_parent, Nothing)
+            # single rotation
+            if node_x == parent.leftChild
+                # zig rotation
+                right_rotate!(tree, node_x.parent)
+            else 
+                # zag rotation
+                left_rotate!(tree, node_x.parent)
+            end
+            # double rotation
+        elseif node_x == parent.leftChild && parent == grand_parent.leftChild
+            # zig-zig rotation
+            right_rotate!(tree, grand_parent)
+            right_rotate!(tree, parent)
+        elseif node_x == parent.rightChild && parent == grand_parent.rightChild
+            # zag-zag rotation
+            left_rotate!(tree, grand_parent)
+            left_rotate!(tree, parent)
+        elseif node_x == parent.rightChild && parent == grand_parent.leftChild
+            # zig-zag rotation
+            left_rotate!(tree, node_x.parent)
+            right_rotate!(tree, node_x.parent)
+        else
+            # zag-zig rotation
+            right_rotate!(tree, node_x.parent)
+            left_rotate!(tree, node_x.parent)
+        end
+    end
+end
+
+function maximum(node::SplayTreeNode)
+    while !isa(node.rightChild, Nothing)
+        node = node.rightChild
+    end
+    return node
+end
+
+function _join(tree::SplayTree ,s::SplayTreeNode_or_null, t::SplayTreeNode_or_null)
+    if isa(s, Nothing)
+        return t
+    elseif isa(t, Nothing)
+        return s
+    else
+        x = maximum(s)
+        splay!(tree, x)
+        x.rightChild = t
+        t.parent = x
+        return x
+    end
+end
+
+function search_by_node(node::SplayTreeNode_or_null{K}, d::K) where K
+    while !isa(node, Nothing)
+        if node.data == d
+            break
+        elseif node.data < d
+            if !isa(node.rightChild, Nothing)
+                node = node.rightChild
+            else
+                break
+            end
+        else
+            if isa(node.leftChild, Nothing)
+                node = node.leftChild
+            else
+                break
+            end
+        end
+    end
+    return node
+end
+
+function search_key(tree::SplayTree{K}, d::K) where K
+    node = tree.root
+    if isa(node, Nothing)
+        return false
+    else
+        node = search_by_node(node, d)
+        isa(node, Nothing) && return false
+        is_found = (node.data == d)
+        is_found && splay!(tree, node)
+        return is_found
+    end
+end
+
+function delete!(tree::SplayTree{K}, d::K) where K
+    node = tree.root
+    x = search_by_node(node, d)
+    isa(x, Nothing) && return tree
+    t = nothing
+    s = nothing 
+    
+    splay!(tree, x)
+    
+    if !isa(x.rightChild, Nothing)
+        t = x.rightChild
+        t.parent = nothing
+    end
+
+    s = x
+    s.rightChild = nothing
+
+    if !isa(s.leftChild, Nothing)
+        s.leftChild.parent = nothing
+    end
+
+    tree.root = _join(tree, s.leftChild, t)
+    return tree
+end
+
+function insert!(tree::SplayTree{K}, d::K) where K
+    is_present = search_by_node(tree.root, d)
+    if !isa(is_present, Nothing) && (is_present.data == d)
+        return tree
+    end
+    # only unique keys are inserted
+    node = SplayTreeNode{K}(d)
+    y = nothing
+    x = tree.root
+
+    while !isa(x, Nothing)
+        y = x
+        if node.data > x.data
+            x = x.rightChild
+        else
+            x = x.leftChild
+        end
+    end
+    node.parent = y
+
+    if isa(y, Nothing)
+        tree.root = node
+    elseif node.data < y.data
+        y.leftChild = node
+    else
+        y.rightChild = node
+    end
+    splay!(tree, node)
+    return tree
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,9 +32,10 @@ tests = ["deprecations",
          "robin_dict",
          "ordered_robin_dict",
          "dibit_vector",
-         "red_black_tree",
          "swiss_dict",
-         "avl_tree"
+         "avl_tree",
+         "red_black_tree", 
+         "splay_tree"
         ]
 
 if length(ARGS) > 0

--- a/test/test_splay_tree.jl
+++ b/test/test_splay_tree.jl
@@ -1,0 +1,134 @@
+@testset "SplayTree" begin
+    @testset "inserting values" begin
+        t = SplayTree{Int}()
+        for i in 1:100
+            insert!(t, i)
+        end
+
+        @test length(t) == 100
+
+        for i in 1:100
+            @test haskey(t, i)
+        end
+
+        for i = 101:200
+            @test !haskey(t, i)
+        end
+    end
+
+    @testset "deleting values" begin
+        t = SplayTree{Int}()
+        for i in 1:100
+            insert!(t, i)
+        end
+        for i in 1:2:100
+            delete!(t, i)
+        end
+
+        @test length(t) == 50
+        
+        for i in 1:100
+            if iseven(i)
+                @test haskey(t, i)
+            else
+                @test !haskey(t, i)
+            end
+        end
+
+        for i in 1:2:100
+            insert!(t, i)
+        end
+
+        @test length(t) == 100
+    end
+
+    @testset "handling different cases of delete!" begin
+        t2 = SplayTree()
+        for i in 1:100000
+            insert!(t2, i)
+        end
+
+        @test length(t2) == 100000
+        
+        nums = rand(1:100000, 8599)
+        visited = Set()
+        for num in nums 
+            if !(num in visited)
+                delete!(t2, num)
+                push!(visited, num) 
+            end
+        end
+
+        for i in visited
+            @test !haskey(t2, i)
+        end
+        @test (length(t2) + length(visited)) == 100000
+    end
+
+    @testset "handling different cases of insert!" begin
+        nums = rand(1:100000, 1000)
+        t3 = SplayTree()
+        uniq_nums = Set(nums)
+        for num in nums
+            insert!(t3, num)
+        end
+        @test length(t3) == length(uniq_nums)
+    end
+
+    @testset "in" begin
+        t4 = SplayTree{Char}()
+        push!(t4, 'a')
+        push!(t4, 'b')
+        @test length(t4) == 2
+        @test in('a', t4)
+        @test !in('c', t4)
+    end
+
+    @testset "search_node" begin 
+        t5 = SplayTree()
+        for i in 1:32
+            push!(t5, i)
+        end
+        n1 = search_node(t5, 21)
+        @test n1.data == 21
+        n2 = search_node(t5, 35)
+        @test n2.data == 32
+        n3 = search_node(t5, 0)
+        @test n3.data == 1
+    end 
+
+    @testset "getindex" begin 
+        t6 = SplayTree{Int}()
+        for i in 1:10
+            push!(t6, i)
+        end
+        for i in 1:10
+            @test t6[i] == i
+        end
+        @test_throws BoundsError getindex(t6, 0)
+        @test_throws BoundsError getindex(t6, 11)
+    end
+
+    @testset "key conversion in push!" begin
+        t7 = SplayTree{Int}()
+        push!(t7, Int8(1))
+        @test length(t7) == 1
+        @test haskey(t7, 1)
+    end
+
+    @testset "maximum_node" begin
+        t8 = SplayTree()
+        @test maximum_node(t8.root) == nothing
+        for i in 1:32
+            push!(t8, i)
+        end
+        m1 = maximum_node(t8.root)
+        @test m1.data == 32
+        node = t8.root
+        while node.rightChild != nothing
+            m = maximum_node(node.rightChild)
+            @test m == m1
+            node = node.rightChild
+        end
+    end
+end

--- a/test/test_splay_tree.jl
+++ b/test/test_splay_tree.jl
@@ -1,8 +1,8 @@
 @testset "SplayTree" begin
-    @testset "inserting values" begin
+    @testset "pushing values" begin
         t = SplayTree{Int}()
         for i in 1:100
-            insert!(t, i)
+            push!(t, i)
         end
 
         @test length(t) == 100
@@ -19,7 +19,7 @@
     @testset "deleting values" begin
         t = SplayTree{Int}()
         for i in 1:100
-            insert!(t, i)
+            push!(t, i)
         end
         for i in 1:2:100
             delete!(t, i)
@@ -36,7 +36,7 @@
         end
 
         for i in 1:2:100
-            insert!(t, i)
+            push!(t, i)
         end
 
         @test length(t) == 100
@@ -45,7 +45,7 @@
     @testset "handling different cases of delete!" begin
         t2 = SplayTree()
         for i in 1:100000
-            insert!(t2, i)
+            push!(t2, i)
         end
 
         @test length(t2) == 100000
@@ -65,12 +65,12 @@
         @test (length(t2) + length(visited)) == 100000
     end
 
-    @testset "handling different cases of insert!" begin
+    @testset "handling different cases of push!" begin
         nums = rand(1:100000, 1000)
         t3 = SplayTree()
         uniq_nums = Set(nums)
         for num in nums
-            insert!(t3, num)
+            push!(t3, num)
         end
         @test length(t3) == length(uniq_nums)
     end

--- a/test/test_splay_tree.jl
+++ b/test/test_splay_tree.jl
@@ -105,8 +105,8 @@
         for i in 1:10
             @test t6[i] == i
         end
-        @test_throws BoundsError getindex(t6, 0)
-        @test_throws BoundsError getindex(t6, 11)
+        @test_throws KeyError getindex(t6, 0)
+        @test_throws KeyError getindex(t6, 11)
     end
 
     @testset "key conversion in push!" begin


### PR DESCRIPTION
Part of GSoC'20 implementation.

SplayTree has no additional memory footprint as compared to Red-Black Tree or AVL Tree. It offers `O(log n)` amortized time complexity for the operations `search`, `insert` and `delete` 

TO-DO

- [x] writes tests