### PR TITLE
Use Base.Ordering with heaps

### DIFF
--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -95,7 +95,10 @@ array without sorting the entire array first:
 ```julia
 nlargest(3, [0,21,-12,68,-25,14]) # => [68,21,14]
 nsmallest(3, [0,21,-12,68,-25,14]) # => [-25,-12,0]
+nlargest(3, [0,21,-12,68,-25,14], by=abs) # => [68,-25,21]
 ```
 
-`nlargest(n, a)` is equivalent to `sort(a, lt = >)[1:min(n, end)]`, and
-`nsmallest(n, a)` is equivalent to `sort(a, lt = <)[1:min(n, end)]`.
+Both functions support the same `lt`, `by`, and `order` keyword arguments as
+`sort` to define how elements are ordered.
+`nsmallest(n, a; kw...)` is equivalent to `sort(a; kw...)[1:min(n, end)]`, and
+`nlargest(n, a; kw...)` is equivalent to `sort(a; rev=true, kw...)[1:min(n, end)]`.

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -118,23 +118,33 @@ function nextreme(order::Ordering, n::Int, arr::AbstractVector{T}) where {T}
 end
 
 """
-    nlargest(n, arr)
+    nlargest(n, arr; kw...)
 
 Return the `n` largest elements of the array `arr`.
 
-Equivalent to `sort(arr, lt = >)[1:min(n, end)]`
+Equivalent to `sort(arr; kw...)[1:min(n, end)]`
 """
-function nlargest(n::Int, arr::AbstractVector{T}) where T
-    return nextreme(LessThan(), n, arr)
+function nlargest(n::Int, arr::AbstractVector{T};
+    lt=isless, by=identity, order::Ordering=Forward) where T
+    nlargest(n, arr, ord(lt, by, nothing, order))
+end
+
+function nlargest(n::Int, arr::AbstractVector{T}, order::Ordering) where T
+    return nextreme(ReverseOrdering(order), n, arr)
 end
 
 """
-    nsmallest(n, arr)
+    nsmallest(n, arr; kw...)
 
 Return the `n` smallest elements of the array `arr`.
 
-Equivalent to `sort(arr, lt = <)[1:min(n, end)]`
+Equivalent to `sort(arr; rev=true, kw...)[1:min(n, end)]`
 """
-function nsmallest(n::Int, arr::AbstractVector{T}) where T
-    return nextreme(GreaterThan(), n, arr)
+function nsmallest(n::Int, arr::AbstractVector{T};
+    lt=isless, by=identity, order::Ordering=Forward) where T
+    nsmallest(n, arr, ord(lt, by, nothing, order))
+end
+
+function nsmallest(n::Int, arr::AbstractVector{T}, order::Ordering) where T
+    return nextreme(order, n, arr)
 end

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -46,6 +46,10 @@
 #
 ###########################################################
 
+
+import Base.Order: Ordering, lt, Forward, Reverse, ord
+
+
 # HT: handle type
 # VT: value type
 
@@ -54,17 +58,6 @@ abstract type AbstractHeap{VT} end
 abstract type AbstractMutableHeap{VT,HT} <: AbstractHeap{VT} end
 
 abstract type AbstractMinMaxHeap{VT} <: AbstractHeap{VT} end
-
-# comparer
-
-struct LessThan
-end
-
-struct GreaterThan
-end
-
-compare(c::LessThan, x, y) = x < y
-compare(c::GreaterThan, x, y) = x > y
 
 # heap implementations
 
@@ -97,14 +90,15 @@ end
 
 # Array functions using heaps
 
-function nextreme(comp::Comp, n::Int, arr::AbstractVector{T}) where {T, Comp}
+function nextreme(order::Ordering, n::Int, arr::AbstractVector{T}) where {T}
     if n <= 0
         return T[] # sort(arr)[1:n] returns [] for n <= 0
     elseif n >= length(arr)
-        return sort(arr, lt = (x, y) -> compare(comp, y, x))
+        return sort(arr, order=order)
     end
 
-    buffer = BinaryHeap{T,Comp}()
+    # We want the top of the heap to be the "largest" element according to the order
+    buffer = BinaryHeap{T}(ReverseOrdering(order))
 
     for i = 1 : n
         @inbounds xi = arr[i]
@@ -113,7 +107,7 @@ function nextreme(comp::Comp, n::Int, arr::AbstractVector{T}) where {T, Comp}
 
     for i = n + 1 : length(arr)
         @inbounds xi = arr[i]
-        if compare(comp, top(buffer), xi)
+        if lt(order, xi, top(buffer))
             # This could use a pushpop method
             pop!(buffer)
             push!(buffer, xi)

--- a/src/heaps/arrays_as_heaps.jl
+++ b/src/heaps/arrays_as_heaps.jl
@@ -1,7 +1,5 @@
 # This contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-import Base.Order: Forward, Ordering, lt
-
 
 # Heap operations on flat arrays
 # ------------------------------

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -116,6 +116,13 @@ end
 
 BinaryHeap(order::Ordering, xs::AbstractVector{T}) where T = BinaryHeap{T}(order, xs)
 
+function BinaryHeap{T}(xs::AbstractVector{T};
+    lt=isless, by=identity, rev::Union{Bool, Nothing}=nothing, order::Ordering=Forward) where T
+    BinaryHeap{T}(ord(lt, by, rev, order), xs)
+end
+BinaryHeap(xs::AbstractVector{T}; kw...) where T = BinaryHeap{T}(xs; kw...)
+BinaryHeap{T}(; kw...) where T = BinaryHeap{T}(Vector{T}(); kw...)
+
 const BinaryMinHeap{T} = BinaryHeap{T, typeof(Forward)}
 const BinaryMaxHeap{T} = BinaryHeap{T, typeof(Reverse)}
 

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -11,8 +11,8 @@ end
 #
 #################################################
 
-function _heap_bubble_up!(comp::Comp,
-    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int) where {Comp, T}
+function _heap_bubble_up!(order::Ordering,
+    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int) where {T}
 
     @inbounds nd = nodes[nd_id]
     v::T = nd.value
@@ -24,7 +24,7 @@ function _heap_bubble_up!(comp::Comp,
         p = i >> 1
         @inbounds nd_p = nodes[p]
 
-        if compare(comp, v, nd_p.value)
+        if lt(order, v, nd_p.value)
             # move parent downward
             @inbounds nodes[i] = nd_p
             @inbounds nodemap[nd_p.handle] = i
@@ -40,8 +40,8 @@ function _heap_bubble_up!(comp::Comp,
     end
 end
 
-function _heap_bubble_down!(comp::Comp,
-    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int) where {Comp, T}
+function _heap_bubble_down!(order::Ordering,
+    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int) where {T}
 
     @inbounds nd = nodes[nd_id]
     v::T = nd.value
@@ -62,9 +62,9 @@ function _heap_bubble_down!(comp::Comp,
             @inbounds nd_l = nodes[il]
             @inbounds nd_r = nodes[ir]
 
-            if compare(comp, nd_r.value, nd_l.value)
+            if lt(order, nd_r.value, nd_l.value)
                 # consider right child
-                if compare(comp, nd_r.value, v)
+                if lt(order, nd_r.value, v)
                     @inbounds nodes[i] = nd_r
                     @inbounds nodemap[nd_r.handle] = i
                     i = ir
@@ -73,7 +73,7 @@ function _heap_bubble_down!(comp::Comp,
                 end
             else
                 # consider left child
-                if compare(comp, nd_l.value, v)
+                if lt(order, nd_l.value, v)
                     @inbounds nodes[i] = nd_l
                     @inbounds nodemap[nd_l.handle] = i
                     i = il
@@ -84,7 +84,7 @@ function _heap_bubble_down!(comp::Comp,
 
         else  # contains only left child
             nd_l = nodes[il]
-            if compare(comp, nd_l.value, v)
+            if lt(order, nd_l.value, v)
                 @inbounds nodes[i] = nd_l
                 @inbounds nodemap[nd_l.handle] = i
                 i = il
@@ -100,8 +100,8 @@ function _heap_bubble_down!(comp::Comp,
     end
 end
 
-function _binary_heap_pop!(comp::Comp,
-    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int=1) where {Comp,T}
+function _binary_heap_pop!(order::Ordering,
+    nodes::Vector{MutableBinaryHeapNode{T}}, nodemap::Vector{Int}, nd_id::Int=1) where {T}
 
     # extract node
     rt = nodes[nd_id]
@@ -118,17 +118,17 @@ function _binary_heap_pop!(comp::Comp,
         @inbounds nodemap[new_rt.handle] = nd_id
 
         if length(nodes) > 1
-            if compare(comp, new_rt.value, v)
-                _heap_bubble_up!(comp, nodes, nodemap, nd_id)
+            if lt(order, new_rt.value, v)
+                _heap_bubble_up!(order, nodes, nodemap, nd_id)
             else
-                _heap_bubble_down!(comp, nodes, nodemap, nd_id)
+                _heap_bubble_down!(order, nodes, nodemap, nd_id)
             end
         end
     end
     return v
 end
 
-function _make_mutable_binary_heap(comp::Comp, ty::Type{T}, values) where {Comp,T}
+function _make_mutable_binary_heap(order::Ordering, ty::Type{T}, values) where {T}
     # make a static binary index tree from a list of values
 
     n = length(values)
@@ -143,7 +143,7 @@ function _make_mutable_binary_heap(comp::Comp, ty::Type{T}, values) where {Comp,
     end
 
     for i = 1 : n
-        _heap_bubble_up!(comp, nodes, nodemap, i)
+        _heap_bubble_up!(order, nodes, nodemap, i)
     end
     return nodes, nodemap
 end
@@ -155,26 +155,32 @@ end
 #
 #################################################
 
-mutable struct MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
-    comparer::Comp
+mutable struct MutableBinaryHeap{VT, O<:Ordering} <: AbstractMutableHeap{VT,Int}
+    order::O
     nodes::Vector{MutableBinaryHeapNode{VT}}
     node_map::Vector{Int}
 
-    function MutableBinaryHeap{VT, Comp}() where {VT, Comp}
+    function MutableBinaryHeap{VT}(order::O) where {VT, O<:Ordering}
         nodes = Vector{MutableBinaryHeapNode{VT}}()
         node_map = Vector{Int}()
-        new{VT, Comp}(Comp(), nodes, node_map)
+        new{VT, O}(order, nodes, node_map)
     end
 
-    function MutableBinaryHeap{VT, Comp}(xs::AbstractVector{VT}) where {VT, Comp}
-        nodes, node_map = _make_mutable_binary_heap(Comp(), VT, xs)
-        new{VT, Comp}(Comp(), nodes, node_map)
+    function MutableBinaryHeap{VT}(order::O, xs::AbstractVector{VT}) where {VT, O<:Ordering}
+        nodes, node_map = _make_mutable_binary_heap(order, VT, xs)
+        new{VT, O}(order, nodes, node_map)
     end
 end
 
-const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, LessThan}
-const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, GreaterThan}
+MutableBinaryHeap(order::Ordering, xs::AbstractVector{T}) where T = MutableBinaryHeap{T}(order, xs)
 
+const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, typeof(Forward)}
+const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, typeof(Reverse)}
+
+MutableBinaryMinHeap{T}() where T = MutableBinaryHeap{T}(Forward)
+MutableBinaryMaxHeap{T}() where T = MutableBinaryHeap{T}(Reverse)
+MutableBinaryMinHeap{T}(xs::AbstractVector{T}) where T = MutableBinaryHeap{T}(Forward, xs)
+MutableBinaryMaxHeap{T}(xs::AbstractVector{T}) where T = MutableBinaryHeap{T}(Reverse, xs)
 MutableBinaryMinHeap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap{T}(xs)
 MutableBinaryMaxHeap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap{T}(xs)
 
@@ -217,7 +223,7 @@ function push!(h::MutableBinaryHeap{T}, v) where T
     nd_id = length(nodes) + 1
     push!(nodes, MutableBinaryHeapNode(convert(T, v), i))
     push!(nodemap, nd_id)
-    _heap_bubble_up!(h.comparer, nodes, nodemap, nd_id)
+    _heap_bubble_up!(h.order, nodes, nodemap, nd_id)
     return i
 end
 
@@ -239,7 +245,7 @@ function top_with_handle(h::MutableBinaryHeap)
     return el.value, el.handle
 end
 
-pop!(h::MutableBinaryHeap{T}) where {T} = _binary_heap_pop!(h.comparer, h.nodes, h.node_map)
+pop!(h::MutableBinaryHeap{T}) where {T} = _binary_heap_pop!(h.order, h.nodes, h.node_map)
 
 """
     update!{T}(h::MutableBinaryHeap{T}, i::Int, v::T)
@@ -250,16 +256,16 @@ This is equivalent to `h[i]=v`.
 function update!(h::MutableBinaryHeap{T}, i::Int, v) where T
     nodes = h.nodes
     nodemap = h.node_map
-    comp = h.comparer
+    order = h.order
 
     nd_id = nodemap[i]
     v0 = nodes[nd_id].value
     x = convert(T, v)
     nodes[nd_id] = MutableBinaryHeapNode(x, i)
-    if compare(comp, x, v0)
-        _heap_bubble_up!(comp, nodes, nodemap, nd_id)
+    if lt(order, x, v0)
+        _heap_bubble_up!(order, nodes, nodemap, nd_id)
     else
-        _heap_bubble_down!(comp, nodes, nodemap, nd_id)
+        _heap_bubble_down!(order, nodes, nodemap, nd_id)
     end
 end
 
@@ -270,7 +276,7 @@ Deletes the element with handle `i` from heap `h` .
 """
 function delete!(h::MutableBinaryHeap{T}, i::Int) where T
      nd_id = h.node_map[i]
-    _binary_heap_pop!(h.comparer, h.nodes, h.node_map, nd_id)
+    _binary_heap_pop!(h.order, h.nodes, h.node_map, nd_id)
     return h
 end
 

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -174,6 +174,13 @@ end
 
 MutableBinaryHeap(order::Ordering, xs::AbstractVector{T}) where T = MutableBinaryHeap{T}(order, xs)
 
+function MutableBinaryHeap{T}(xs::AbstractVector{T};
+    lt=isless, by=identity, rev::Union{Bool, Nothing}=nothing, order::Ordering=Forward) where T
+    BinaryHeap{T}(ord(lt, by, rev, order), xs)
+end
+MutableBinaryHeap(xs::AbstractVector{T}; kw...) where T = MutableBinaryHeap{T}(xs; kw...)
+MutableBinaryHeap{T}(; kw...) where T = MutableBinaryHeap{T}(Vector{T}(); kw...)
+
 const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, typeof(Forward)}
 const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, typeof(Reverse)}
 

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -4,6 +4,8 @@
 
     @testset "make heap" begin
         vs = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7]
+        vs2 = collect(enumerate(vs))
+        order = Base.Order.By(last)
 
         @testset "make min heap" begin
             h = BinaryMinHeap(vs)
@@ -22,6 +24,16 @@
             @test !isempty(h)
             @test top(h) == 16
             @test isequal(h.valtree, [16, 14, 10, 8, 7, 3, 9, 1, 4, 2])
+            @test sizehint!(h, 100) === h
+        end
+
+        @testset "make custom order heap" begin
+            h = BinaryHeap(order, vs2)
+
+            @test length(h) == 10
+            @test !isempty(h)
+            @test top(h) == (2, 1)
+            @test isequal(h.valtree, [(2, 1), (4, 2), (3, 3), (1, 4), (10, 7), (6, 9), (7, 10), (8, 14), (9, 8), (5, 16)])
             @test sizehint!(h, 100) === h
         end
 
@@ -54,7 +66,6 @@
                     @test isequal(extract_all!(hmin), [1, 2, 3, 4, 7, 8, 9, 10, 14, 16])
                     @test isempty(hmin)
                 end
-
             end
 
             @testset "push! hmax" begin
@@ -84,6 +95,36 @@
                 @testset "pop! hmax" begin
                     @test isequal(extract_all!(hmax), [16, 14, 10, 9, 8, 7, 4, 3, 2, 1])
                     @test isempty(hmax)
+                end
+            end
+
+            @testset "push! custom order" begin
+                heap = BinaryHeap{Tuple{Int,Int}}(order)
+                @test length(heap) == 0
+                @test isempty(heap)
+
+                ss = Any[
+                    [(1, 4)],
+                    [(2, 1), (1, 4)],
+                    [(2, 1), (1, 4), (3, 3)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10), (8, 14)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10), (8, 14), (9, 8)],
+                    [(2, 1), (4, 2), (3, 3), (1, 4), (10, 7), (6, 9), (7, 10), (8, 14), (9, 8), (5, 16)]]
+
+                for i = 1 : length(vs2)
+                    push!(heap, vs2[i])
+                    @test length(heap) == i
+                    @test !isempty(heap)
+                    @test isequal(heap.valtree, ss[i])
+                end
+
+                @testset "pop! custom order" begin
+                    @test isequal(extract_all!(heap), sort(vs2, order=order))
+                    @test isempty(heap)
                 end
             end
         end

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -162,9 +162,19 @@
             102,-56,-17,-41,25,-30,-84,26,-84,48,49,-5,-38,28,
             114,-54,96,-55,67,74,127,-61,124,11,-7,93,-51,110,
             -106,-84,-90,-18,-12,-116,21,115,50]
+        # Remove elements which will compare equal otherwise the return value
+        # is ambiguous
+        ss2 = collect(enumerate(unique(ss)))
+
         for n = -1:length(ss) + 1
             @test sort(ss, lt = >)[1:min(n, end)] == nlargest(n, ss)
             @test sort(ss, lt = <)[1:min(n, end)] == nsmallest(n, ss)
+
+            r = 1:min(n, length(ss2))
+            @test sort(ss2, by=last)[r] == nsmallest(n, ss2, by=last)
+            @test sort(ss2, by=last, rev=true)[r] == nlargest(n, ss2, by=last)
+            @test sort(ss2, lt=(a, b) -> a[2] < b[2])[r] == nsmallest(n, ss2, by=last)
+            @test sort(ss2, lt=(a, b) -> a[2] > b[2])[r] == nlargest(n, ss2, by=last)
         end
     end
 

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -1,8 +1,10 @@
 # Test of binary heaps
 
+using Base.Order: lt
+
 # auxiliary functions
 
-function heap_values(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
+function heap_values(h::MutableBinaryHeap{VT}) where {VT}
     n = length(h)
     nodes = h.nodes
     @assert length(nodes) == n
@@ -13,7 +15,7 @@ function heap_values(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
     vs
 end
 
-function list_values(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
+function list_values(h::MutableBinaryHeap{VT}) where {VT}
     n = length(h)
     nodes = h.nodes
     nodemap = h.node_map
@@ -27,8 +29,7 @@ function list_values(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
     vs
 end
 
-function verify_heap(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
-    comp = h.comparer
+function verify_heap(h::MutableBinaryHeap{VT}) where {VT}
     nodes = h.nodes
     n = length(h)
     m = div(n,2)
@@ -36,13 +37,13 @@ function verify_heap(h::MutableBinaryHeap{VT,Comp}) where {VT,Comp}
         v = nodes[i].value
         lc = i * 2
         if lc <= n
-            if compare(comp, nodes[lc].value, v)
+            if lt(h.order, nodes[lc].value, v)
                 return false
             end
         end
         rc = lc + 1
         if rc <= n
-            if compare(comp, nodes[rc].value, v)
+            if lt(h.order, nodes[rc].value, v)
                 return false
             end
         end


### PR DESCRIPTION
Note: this is basically a duplicate of #547, which still seems active. I wrote all this before finding that one, so I'm submitting it anyways just in case any of it is still useful.

Changes made:

* `comp::Comp` arguments and fields replaced with `order::Base.Ordering` everywhere
  * Heaps now support arbitrary orderings
  * `LessThan` and `GreaterThan` singleton types and `compare` function replaced with `Base.Forward`, `Base.Reverse`, and `Base.Order.lt`.
* Heap constructors now take an `Ordering` as a constructor argument rather than a type parameter, because in general we can't get an instance from just the type (exception follows)
* Min/max type aliases are now `const BinaryMinHeap{T} = BinaryHeap{T, typeof(Forward)}` and `const BinaryMaxHeap{T} = BinaryHeap{T, typeof(Reverse)}`, and similarly for mutable version
  * These required adding additional constructors to `BinaryHeap`/`MutableBinaryHeap` for these two special cases where the order is a singleton: `BinaryHeap{T, typeof(Forward)}(...) = BinaryHeap{T}(Forward, ...)` etc
* `BinaryHeap`, `MutableBinaryHeap`, `nsmallest`, and `nlargest` now have methods with the `lt`, `by`, and `rev` keyword arguments like in `sort`, which is more user-friendly than requiring an `Ordering` instance.

This introduces similar breaking changes as in #547 in that `isless` is now used for comparison by default instead of `<`, which may yield different results where `NaN`s are involved (although, I would say that the previous behavior was undefined).
I haven't updated or run the benchmark script yet so I don't know if there are any performance regressions.
