### PR TITLE
inbounds optimizations for CircularDeque and CircularBuffer

### DIFF
--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -39,7 +39,7 @@ Get the item at the front of the queue.
 """
 @inline function first(D::CircularDeque)
     @boundscheck D.n > 0 || throw(BoundsError())
-    return D.buffer[D.first]
+    return @inbounds D.buffer[D.first]
 end
 
 """
@@ -49,7 +49,7 @@ Get the item from the back of the queue.
 """
 @inline function last(D::CircularDeque)
     @boundscheck D.n > 0 || throw(BoundsError())
-    return D.buffer[D.last]
+    return @inbounds D.buffer[D.last]
 end
 
 @inline function Base.push!(D::CircularDeque, v)
@@ -61,7 +61,7 @@ end
     return D
 end
 
-@inline function Base.pop!(D::CircularDeque)
+@inline Base.@propagate_inbounds function Base.pop!(D::CircularDeque)
     v = last(D)
     D.n -= 1
     tmp = D.last - 1
@@ -88,7 +88,7 @@ end
 
 Remove the element at the front.
 """
-@inline function popfirst!(D::CircularDeque)
+@inline Base.@propagate_inbounds function popfirst!(D::CircularDeque)
     v = first(D)
     D.n -= 1
     tmp = D.first + 1

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -69,10 +69,10 @@ end
 Remove the element at the back.
 """
 @inline function Base.pop!(cb::CircularBuffer)
-    (cb.length == 0) && throw(ArgumentError("array must be non-empty"))
+    @boundscheck (cb.length == 0) && throw(ArgumentError("array must be non-empty"))
     i = _buffer_index(cb, cb.length)
     cb.length -= 1
-    return cb.buffer[i]
+    return @inbounds cb.buffer[i]
 end
 
 """
@@ -87,7 +87,7 @@ Add an element to the back and overwrite front if full.
     else
         cb.length += 1
     end
-    cb.buffer[_buffer_index(cb, cb.length)] = data
+    @inbounds cb.buffer[_buffer_index(cb, cb.length)] = data
     return cb
 end
 
@@ -97,13 +97,11 @@ end
 Remove the element from the front of the `CircularBuffer`.
 """
 function popfirst!(cb::CircularBuffer)
-    if cb.length == 0
-        throw(ArgumentError("array must be non-empty"))
-    end
+    @boundscheck (cb.length == 0) && throw(ArgumentError("array must be non-empty"))
     i = cb.first
     cb.first = (cb.first + 1 > cb.capacity ? 1 : cb.first + 1)
     cb.length -= 1
-    return cb.buffer[i]
+    return @inbounds cb.buffer[i]
 end
 
 """
@@ -118,7 +116,7 @@ function pushfirst!(cb::CircularBuffer, data)
     if length(cb) < cb.capacity
         cb.length += 1
     end
-    cb.buffer[cb.first] = data
+    @inbounds cb.buffer[cb.first] = data
     return cb
 end
 


### PR DESCRIPTION
Fills a few inbounds optimization gaps in ```CircularDeque``` and ```CircularBuffer``` implementations, adding missing propagation and eliminating redundant checks.

Benchmarked with
```Julia
using DataStructures
using BenchmarkTools
function pushpop(xs)
    @inbounds push!(xs, 1)
    @inbounds popfirst!(xs)
    @inbounds pushfirst!(xs, 1)
    @inbounds pop!(xs)
end
function pushpop_checked(xs)
    push!(xs, 1)
    popfirst!(xs)
    pushfirst!(xs, 1)
    pop!(xs)
end
@btime pushpop($(CircularDeque{Int}(10)))
@btime pushpop_checked($(CircularDeque{Int}(10)))
@btime pushpop($(CircularBuffer{Int}(10)))
@btime pushpop_checked($(CircularBuffer{Int}(10)))
```

| Test         | Container        | Before | After |
|-----------|-----------------|-------:|------:|
| pushpop | CircularDeque |  7.6ns | 2.3ns |
| pushpop_checked | CircularDeque |  7.7ns | 6.3ns |
| pushpop | CircularBuffer |  7.3ns | 3.5ns |
| pushpop_checked | CircularBuffer |  7.4ns | 6.6ns |

Similar to #586 and #588