### PR TITLE
Improve inference for macros leading to (:)

### DIFF
--- a/src/delegate.jl
+++ b/src/delegate.jl
@@ -9,7 +9,7 @@ function unquote(e::QuoteNode)
     return e.value
 end
 
-macro delegate(source, targets)
+macro delegate(source::Expr, targets::Expr)
     typename = esc(source.args[1])
     fieldname = unquote(source.args[2])
     funcnames = targets.args
@@ -25,7 +25,7 @@ macro delegate(source, targets)
     return Expr(:block, fdefs...)
 end
 
-macro delegate_return_parent(source, targets)
+macro delegate_return_parent(source::Expr, targets::Expr)
     typename = esc(source.args[1])
     fieldname = unquote(source.args[2])
     funcnames = targets.args


### PR DESCRIPTION
These type annotations prevent invalidations due to packages that specialize `promote_rule`. The specific call signature, `promote_rule(::Type{Int64}, ::Type{S} where S)`, gets triggered by calls to `(::Colon)(::Int64, ::Real)`. Annotating these inputs as `Expr` allows inference to realize what the `args` field type is, thus allowing `length` to be inferred as returning an `Int`.