### PR TITLE
Fix typo in RBTree docstring

### DIFF
--- a/src/red_black_tree.jl
+++ b/src/red_black_tree.jl
@@ -231,7 +231,7 @@ function Base.insert!(tree::RBTree{K}, d::K) where K
 end
 
 """
-    insert!(tree, key)
+    push!(tree, key)
 
 Inserts `key` in the `tree` if it is not present.
 """


### PR DESCRIPTION
Somehow missed in #638.