### PR TITLE
Deprecate `reverse_iter` to `Iterators.reverse`

### DIFF
--- a/docs/src/stack_and_queue.md
+++ b/docs/src/stack_and_queue.md
@@ -1,4 +1,3 @@
-
 # Stack and Queue
 
 The `Stack` and `Queue` types are a light-weight wrapper of a deque
@@ -7,17 +6,17 @@ type, which respectively provide interfaces for LIFO and FIFO access.
 Usage of Stack:
 
 ```julia
-s = Stack{Int}()            # create a stack
-isempty(s)                  # check whether the stack is empty
-length(s)                   # get the number of elements
-eltype(s)                   # get the type of elements
-push!(s, 1)                 # push back a item
-first(s)                    # get an item from the top of stack
-pop!(s)                     # get and remove a first item
-empty!(s)                   # make a stack empty
-iterate(s::Stack)           # Get a LIFO iterator of a stack
-reverse_iter(s::Stack{T})   # Get a FILO iterator of a stack
-s1 == s2                    # check whether the two stacks are same
+s = Stack{Int}()                # create a stack
+isempty(s)                      # check whether the stack is empty
+length(s)                       # get the number of elements
+eltype(s)                       # get the type of elements
+push!(s, 1)                     # push back a item
+first(s)                        # get an item from the top of stack
+pop!(s)                         # get and remove a first item
+empty!(s)                       # make a stack empty
+iterate(s::Stack)               # Get a LIFO iterator of a stack
+Iterators.reverse(s::Stack{T})  # Get a FILO iterator of a stack
+s1 == s2                        # check whether the two stacks are same
 ```
 
 Usage of Queue:

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -1,6 +1,6 @@
 module DataStructures
 
-    using Base: HasEltype, HasLength, IteratorEltype, IteratorSize, SizeUnknown,
+    using Base: Iterators, HasEltype, HasLength, IteratorEltype, IteratorSize, SizeUnknown,
                 lt, Ordering, ForwardOrdering, Forward, ReverseOrdering, Reverse, Lt,
                 isbitsunion, isiterable, dict_with_eltype, KeySet, Callable, _tablesz,
                 findnextnot, unsafe_getindex, unsafe_setindex!, peek
@@ -15,7 +15,7 @@ module DataStructures
     export complement, complement!
 
     export Deque, Stack, Queue, CircularDeque
-    export enqueue!, dequeue!, dequeue_pair!, update!, reverse_iter
+    export enqueue!, dequeue!, dequeue_pair!, update!
     export capacity, num_blocks, top_with_handle, sizehint!
 
     export Accumulator, counter, reset!, inc!, dec!

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -2,3 +2,4 @@
 @deprecate path(t::Trie, str::AbstractString) partial_path(t::Trie, str::AbstractString)
 @deprecate find_root find_root!
 @deprecate top first
+@deprecate reverse_iter Iterators.reverse

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -115,6 +115,8 @@ struct DequeIterator{T}
     q::Deque
 end
 
+Base.last(qi::DequeIterator) = last(qi.q)
+
 function Base.iterate(qi::DequeIterator{T}, (cb, i) = (qi.q.head, qi.q.head.front)) where T
     i > cb.back && return nothing
     x = cb.data[i]
@@ -130,11 +132,7 @@ end
 
 # Backwards deque iteration
 
-struct ReverseDequeIterator{T}
-    q::Deque
-end
-
-function Base.iterate(qi::ReverseDequeIterator{T}, (cb, i) = (qi.q.rear, qi.q.rear.back)) where T
+function Base.iterate(qi::Iterators.Reverse{<:Deque}, (cb, i) = (qi.itr.rear, qi.itr.rear.back))
     i < cb.front && return nothing
     x = cb.data[i]
 
@@ -148,12 +146,9 @@ function Base.iterate(qi::ReverseDequeIterator{T}, (cb, i) = (qi.q.rear, qi.q.re
     return (x, (cb, i))
 end
 
-reverse_iter(q::Deque{T}) where {T} = ReverseDequeIterator{T}(q)
-
 Base.iterate(q::Deque{T}, s...) where {T} = iterate(DequeIterator{T}(q), s...)
 
 Base.length(qi::DequeIterator{T}) where {T} = qi.q.len
-Base.length(qi::ReverseDequeIterator{T}) where {T} = qi.q.len
 
 Base.collect(q::Deque{T}) where {T} = T[x for x in q]
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -42,6 +42,6 @@ Base.empty!(s::Queue) = (empty!(s.store); s)
 
 Base.iterate(q::Queue, s...) = iterate(q.store, s...)
 
-reverse_iter(q::Queue) = reverse_iter(q.store)
+Iterators.reverse(q::Queue) = Iterators.reverse(q.store)
 
 Base.:(==)(x::Queue, y::Queue) = x.store == y.store

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -41,6 +41,7 @@ Base.eltype(::Type{Stack{T}}) where T = T
 Get the top item from the stack. Sometimes called peek.
 """
 Base.first(s::Stack) = last(s.store)
+Base.last(s::Stack) = first(s.store)
 
 function Base.push!(s::Stack, x)
     push!(s.store, x)
@@ -51,13 +52,8 @@ Base.pop!(s::Stack) = pop!(s.store)
 
 Base.empty!(s::Stack) = (empty!(s.store); s)
 
-Base.iterate(st::Stack, s...) = iterate(reverse_iter(st.store), s...)
+Base.iterate(st::Stack, s...) = iterate(Iterators.reverse(st.store), s...)
 
-"""
-    reverse_iterate(s::Stack)
-
-Get a FILO iterator of a stack
-"""
-reverse_iter(s::Stack{T}) where {T} = DequeIterator{T}(s.store)
+Iterators.reverse(s::Stack{T}) where {T} = DequeIterator{T}(s.store)
 
 Base.:(==)(x::Stack, y::Stack) = x.store == y.store

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -20,3 +20,24 @@ end
     hh = BinaryMinHeap{Float64}([1,2,3])
     @test top(hh) == 1
 end
+
+function test_reverse_iter(it::T) where T
+    arr = [i for i in it]
+    index = length(arr)
+    for i in reverse_iter(it)
+        @test arr[index] == i
+        index -= 1
+    end
+
+    @test reverse(arr) == [i for i in reverse_iter(it)]
+end
+@testset "reverse_iter" begin
+    @testset "Queue" begin
+        q = Queue{Int}(); enqueue!(q, 1); enqueue!(q, 2)
+        test_reverse_iter(q)
+    end
+    @testset "Stack" begin
+        s = Stack{Int}(); push!(s, 1); push!(s, 2)
+        test_reverse_iter(s)
+    end
+end

--- a/test/test_queue.jl
+++ b/test/test_queue.jl
@@ -93,14 +93,17 @@
 
         @testset "reverse iterator" begin
             index = length(arr)
-            for i in reverse_iter(q)
+            for i in Iterators.reverse(q)
                 @test(arr[index] == i)
                 index -= 1
             end
         end
 
         @test arr == [i for i in q]
-        @test reverse(arr) == [i for i in reverse_iter(q)]
+        @test reverse(arr) == [i for i in Iterators.reverse(q)]
+        @test first(Iterators.reverse(q)) === last(q)
+        @test last(Iterators.reverse(q)) === first(q)
+        @test length(Iterators.reverse(q)) === length(q)
     end
 
 end # @testset Queue

--- a/test/test_stack.jl
+++ b/test/test_stack.jl
@@ -87,14 +87,17 @@
 
         @testset "reverse iterator" begin
             index = 1
-            for i in reverse_iter(stk)
+            for i in Iterators.reverse(stk)
                 @test(arr[index] == i)
                 index += 1
             end
         end
 
-        @test arr == [i for i in reverse_iter(stk)]
+        @test arr == [i for i in Iterators.reverse(stk)]
         @test reverse(arr) == [i for i in stk]
+        @test first(Iterators.reverse(stk)) === last(stk)
+        @test last(Iterators.reverse(stk)) === first(stk)
+        @test length(Iterators.reverse(stk)) === length(stk)
     end
 
 end # @testset Stack


### PR DESCRIPTION
- trying out replacing `reverse_iter` with `Iterators.reverse` (not `reverse` since we don't promise to make a copy) -- thoughts?
- in the spirit of "No exported functions that could be just done with overloads of Base" (#479) 
- as commented in #479, I don't _think_ the `Iterators.reverse(::T) -> Iterators.Reverse{T}` is promised by the Iterators API, since it's not documented or tested for in Base (i.e. the changes of this PR don't break that API). 