### PR TITLE
Add `top` alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ after_success:
 # Documenter auto-deploy
 # https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#.travis.yml-Configuration-1
 jobs:
+  allow_failures:
+    - julia: nightly
   include:
     - name: "Benchmark"
       julia: 1.2

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.2"
+version = "0.18.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ platform:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia_version: latest
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -112,5 +112,4 @@ module DataStructures
     include("splay_tree.jl")
 
     include("deprecations.jl")
-@deprecate top(x) = first(h)
 end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -25,7 +25,7 @@ module DataStructures
     export AbstractHeap, compare, extract_all!, extract_all_rev!
     export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
     export MutableBinaryHeap, MutableBinaryMinHeap, MutableBinaryMaxHeap
-    export heapify!, heapify, heappop!, heappush!, isheap, top
+    export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!
 
     export Trie, subtrie, keys_with_prefix, partial_path
@@ -112,5 +112,5 @@ module DataStructures
     include("splay_tree.jl")
 
     include("deprecations.jl")
-    @deprecate top(h::BinaryHeap) = first(h)
+@deprecate top(x) = first(h)
 end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -25,7 +25,7 @@ module DataStructures
     export AbstractHeap, compare, extract_all!, extract_all_rev!
     export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
     export MutableBinaryHeap, MutableBinaryMinHeap, MutableBinaryMaxHeap
-    export heapify!, heapify, heappop!, heappush!, isheap
+    export heapify!, heapify, heappop!, heappush!, isheap, top
     export BinaryMinMaxHeap, popmin!, popmax!, popall!
 
     export Trie, subtrie, keys_with_prefix, partial_path
@@ -112,4 +112,5 @@ module DataStructures
     include("splay_tree.jl")
 
     include("deprecations.jl")
+    const top = first
 end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -112,5 +112,5 @@ module DataStructures
     include("splay_tree.jl")
 
     include("deprecations.jl")
-    const top = first
+    @deprecate top(h::BinaryHeap) = first(h)
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,4 @@
 # 0.18 deprecations. Remove before releasing 0.19
 @deprecate path(t::Trie, str::AbstractString) partial_path(t::Trie, str::AbstractString)
 @deprecate find_root find_root!
+@deprecate top first

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -15,3 +15,8 @@
     @test collect(path(t, "ro")) == [t0, t1, t2]
     @test collect(path(t, "roa")) == [t0, t1, t2]
 end
+
+@testset "top" begin
+    hh = BinaryMinHeap{Float64}([1,2,3])
+    @test top(hh) == 1
+end


### PR DESCRIPTION
Removing the `top` function broke a lot of code in the SciML ecosystem.