### PR TITLE
Use custom orderings with heaps and nlargest/nsmallest

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.2"
+version = "0.18.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.3"
+version = "0.18.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -33,13 +33,13 @@ provides the following interface:
 ```julia
 # Let `h` be a heap, `i` be a handle, and `v` be a value.
 
-i = push!(h, v)              # adds a value to the heap and and returns a handle to v
+i = push!(h, v)            # adds a value to the heap and and returns a handle to v
 
-update!(h, i, v)             # updates the value of an element (referred to by the handle i)
+update!(h, i, v)           # updates the value of an element (referred to by the handle i)
 
-delete!(h, i)               # deletes the node with handle i from the heap
+delete!(h, i)              # deletes the node with handle i from the heap
 
-v, i = top_with_handle(h)    # returns the top value of a heap and its handle
+v, i = top_with_handle(h)  # returns the top value of a heap and its handle
 ```
 
 Currently, both min/max versions of binary heap (type `BinaryHeap`) and
@@ -49,16 +49,16 @@ Examples of constructing a heap:
 
 ```julia
 h = BinaryMinHeap{Int}()
-h = BinaryMaxHeap{Int}()          # create an empty min/max binary heap of integers
+h = BinaryMaxHeap{Int}()             # create an empty min/max binary heap of integers
 
 h = BinaryMinHeap([1,4,3,2])
-h = BinaryMaxHeap([1,4,3,2])      # create a min/max heap from a vector
+h = BinaryMaxHeap([1,4,3,2])         # create a min/max heap from a vector
 
 h = MutableBinaryMinHeap{Int}()
-h = MutableBinaryMaxHeap{Int}()   # create an empty mutable min/max heap
+h = MutableBinaryMaxHeap{Int}()      # create an empty mutable min/max heap
 
 h = MutableBinaryMinHeap([1,4,3,2])
-h = MutableBinaryMaxHeap([1,4,3,2])    # create a mutable min/max heap from a vector
+h = MutableBinaryMaxHeap([1,4,3,2])  # create a mutable min/max heap from a vector
 ```
 
 ## Using alternate orderings
@@ -119,7 +119,7 @@ This package includes an implementation of a binary min-max heap (`BinaryMinMaxH
 
 Examples:
 ```julia
-h = BinaryMinMaxHeap{Int}()          # create an empty min-max heap with integer values
+h = BinaryMinMaxHeap{Int}()        # create an empty min-max heap with integer values
 
 h = BinaryMinMaxHeap([1, 2, 3, 4]) # create a min-max heap from a vector
 ```

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -129,37 +129,45 @@ function nextreme(ord::Base.Ordering, n::Int, arr::AbstractVector{T}) where T
 end
 
 """
-    nlargest(n, arr)
+    nlargest(n, arr; kw...)
 
 Return the `n` largest elements of the array `arr`.
 
 Equivalent to:
-    sort(arr, order = Base.Reverse)[1:min(n, end)]
+    sort(arr, kw..., rev=true)[1:min(n, end)]
 
 Note that if `arr` contains floats and is free of NaN values,
-then the following alternative may be used to achieve 2x performance.
+then the following alternative may be used to achieve 2x performance:
+
     DataStructures.nextreme(DataStructures.FasterReverse(), n, arr)
+
 This faster version is equivalent to:
+
     sort(arr, lt = >)[1:min(n, end)]
 """
-function nlargest(n::Int, arr::AbstractVector)
-    return nextreme(Base.Reverse, n, arr)
+function nlargest(n::Int, arr::AbstractVector; lt=isless, by=identity)
+    order = Base.ReverseOrdering(Base.ord(lt, by, nothing))
+    return nextreme(order, n, arr)
 end
 
 """
-    nsmallest(n, arr)
+    nsmallest(n, arr; kw...)
 
 Return the `n` smallest elements of the array `arr`.
 
 Equivalent to:
-    sort(arr, order = Base.Forward)[1:min(n, end)]
+    sort(arr; kw...)[1:min(n, end)]
 
 Note that if `arr` contains floats and is free of NaN values,
-then the following alternative may be used to achieve 2x performance.
+then the following alternative may be used to achieve 2x performance:
+
     DataStructures.nextreme(DataStructures.FasterForward(), n, arr)
+
 This faster version is equivalent to:
+
     sort(arr, lt = <)[1:min(n, end)]
 """
-function nsmallest(n::Int, arr::AbstractVector)
-    return nextreme(Base.Forward, n, arr)
+function nsmallest(n::Int, arr::AbstractVector; lt=isless, by=identity)
+    order = Base.ord(lt, by, nothing)
+    return nextreme(order, n, arr)
 end

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -34,21 +34,29 @@ mutable struct BinaryHeap{T, O <: Base.Ordering} <: AbstractHeap{T}
     ordering::O
     valtree::Vector{T}
 
-    function BinaryHeap{T, O}() where {T,O}
-        new{T,O}(O(), Vector{T}())
+    function BinaryHeap{T}(ordering::Base.Ordering) where T
+        new{T, typeof(ordering)}(ordering, Vector{T}())
     end
 
-    function BinaryHeap{T, O}(xs) where {T,O}
-        ordering = O()
+    function BinaryHeap{T}(ordering::Base.Ordering, xs::AbstractVector) where T
         valtree = heapify(xs, ordering)
-        new{T,O}(ordering, valtree)
+        new{T, typeof(ordering)}(ordering, valtree)
     end
 end
 
+BinaryHeap(ordering::Base.Ordering, xs::AbstractVector{T}) where T = BinaryHeap{T}(ordering, xs)
+
+# Constructors using singleton order types as type parameters rather than arguments
+BinaryHeap{T, O}() where {T, O<:Base.Ordering} = BinaryHeap{T}(O())
+BinaryHeap{T, O}(xs::AbstractVector) where {T, O<:Base.Ordering} = BinaryHeap{T}(O(), xs)
+
+# Forward/reverse ordering type aliases
 const BinaryMinHeap{T} = BinaryHeap{T, Base.ForwardOrdering}
 const BinaryMaxHeap{T} = BinaryHeap{T, Base.ReverseOrdering}
+
 BinaryMinHeap(xs::AbstractVector{T}) where T = BinaryMinHeap{T}(xs)
 BinaryMaxHeap(xs::AbstractVector{T}) where T = BinaryMaxHeap{T}(xs)
+
 
 #################################################
 #

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -160,25 +160,31 @@ mutable struct MutableBinaryHeap{T, O <: Base.Ordering} <: AbstractMutableHeap{T
     nodes::Vector{MutableBinaryHeapNode{T}}
     node_map::Vector{Int}
 
-    function MutableBinaryHeap{T, O}() where {T, O}
-        ordering = O()
+    function MutableBinaryHeap{T}(ordering::Base.Ordering) where T
         nodes = Vector{MutableBinaryHeapNode{T}}()
         node_map = Vector{Int}()
-        new{T, O}(ordering, nodes, node_map)
+        new{T, typeof(ordering)}(ordering, nodes, node_map)
     end
 
-    function MutableBinaryHeap{T, O}(xs::AbstractVector{T}) where {T, O}
-        ordering = O()
+    function MutableBinaryHeap{T}(ordering::Base.Ordering, xs::AbstractVector) where T
         nodes, node_map = _make_mutable_binary_heap(ordering, T, xs)
-        new{T, O}(ordering, nodes, node_map)
+        new{T, typeof(ordering)}(ordering, nodes, node_map)
     end
 end
 
+MutableBinaryHeap(ordering::Base.Ordering, xs::AbstractVector{T}) where T = MutableBinaryHeap{T}(ordering, xs)
+
+# Constructors using singleton order types as type parameters rather than arguments
+MutableBinaryHeap{T, O}() where {T, O<:Base.Ordering} = MutableBinaryHeap{T}(O())
+MutableBinaryHeap{T, O}(xs::AbstractVector) where {T, O<:Base.Ordering} = MutableBinaryHeap{T}(O(), xs)
+
+# Forward/reverse ordering type aliases
 const MutableBinaryMinHeap{T} = MutableBinaryHeap{T, Base.ForwardOrdering}
 const MutableBinaryMaxHeap{T} = MutableBinaryHeap{T, Base.ReverseOrdering}
 
 MutableBinaryMinHeap(xs::AbstractVector{T}) where T = MutableBinaryMinHeap{T}(xs)
 MutableBinaryMaxHeap(xs::AbstractVector{T}) where T = MutableBinaryMaxHeap{T}(xs)
+
 
 function Base.show(io::IO, h::MutableBinaryHeap)
     print(io, "MutableBinaryHeap(")

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -208,9 +208,17 @@
             102,-56,-17,-41,25,-30,-84,26,-84,48,49,-5,-38,28,
             114,-54,96,-55,67,74,127,-61,124,11,-7,93,-51,110,
             -106,-84,-90,-18,-12,-116,21,115,50]
+        square = x -> x^2
+
         for n = -1:length(ss) + 1
-            @test sort(ss, lt = >)[1:min(n, end)] == nlargest(n, ss)
-            @test sort(ss, lt = <)[1:min(n, end)] == nsmallest(n, ss)
+            r = 1:min(n, length(ss))
+
+            @test nlargest(n, ss) == sort(ss, rev=true)[r]
+            @test nsmallest(n, ss) == sort(ss)[r]
+
+            @test nlargest(n, ss, by=square) == sort(ss, by=square, rev=true)[r]
+            @test nsmallest(n, ss, by=square) == sort(ss, by=square)[r]
+
             @test nlargest(n, ss) == DataStructures.nextreme(DataStructures.FasterReverse(), n, ss)
             @test nsmallest(n, ss) == DataStructures.nextreme(DataStructures.FasterForward(), n, ss)
         end

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -53,6 +53,8 @@ end
 @testset "MutableBinheap" begin
 
     vs = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7]
+    vs2 = collect(enumerate(vs))
+    ordering = Base.Order.By(last)
 
     @testset "construct heap" begin
         MutableBinaryHeap{Int, Base.ForwardOrdering}()
@@ -68,6 +70,10 @@ end
         MutableBinaryMaxHeap{Int}()
         MutableBinaryMaxHeap{Int}(vs)
         MutableBinaryMaxHeap(vs)
+
+        MutableBinaryHeap{eltype(vs2)}(ordering)
+        MutableBinaryHeap{eltype(vs2)}(ordering, vs2)
+        MutableBinaryHeap(ordering, vs2)
 
         @test true
     end
@@ -100,6 +106,17 @@ end
         @test first(h) == 16
         @test isequal(list_values(h), vs)
         @test isequal(heap_values(h), [16, 14, 10, 8, 7, 3, 9, 1, 4, 2])
+        @test sizehint!(h, 100) === h
+    end
+
+    @testset "make mutable binary custom ordering heap" begin
+        h = MutableBinaryHeap(ordering, vs2)
+
+        @test length(h) == 10
+        @test !isempty(h)
+        @test first(h) == (2, 1)
+        @test isequal(list_values(h), vs2)
+        @test isequal(heap_values(h), [(2, 1), (4, 2), (3, 3), (1, 4), (10, 7), (6, 9), (7, 10), (8, 14), (9, 8), (5, 16)])
         @test sizehint!(h, 100) === h
     end
 
@@ -163,7 +180,37 @@ end
         # test pop!
         @test isequal(extract_all!(hmax), [16, 14, 10, 9, 8, 7, 4, 3, 2, 1])
         @test isempty(hmax)
+    end
 
+    @testset "Custom ordering push! / pop!" begin
+        heap = MutableBinaryHeap{Tuple{Int,Int}}(ordering)
+        @test length(heap) == 0
+        @test isempty(heap)
+
+        # test push!
+        ss = Any[
+            [(1, 4)],
+            [(2, 1), (1, 4)],
+            [(2, 1), (1, 4), (3, 3)],
+            [(2, 1), (4, 2), (3, 3), (1, 4)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10), (8, 14)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (5, 16), (6, 9), (7, 10), (8, 14), (9, 8)],
+            [(2, 1), (4, 2), (3, 3), (1, 4), (10, 7), (6, 9), (7, 10), (8, 14), (9, 8), (5, 16)]]
+        for i = 1 : length(vs2)
+            ia = push!(heap, vs2[i])
+            @test ia == i
+            @test length(heap) == i
+            @test !isempty(heap)
+            @test isequal(list_values(heap), vs2[1:i])
+            @test isequal(heap_values(heap), ss[i])
+        end
+
+        # test pop!
+        @test isequal(extract_all!(heap), sort(vs2, order=ordering))
+        @test isempty(heap)
     end
 
     @testset "hybrid push! and pop!" begin


### PR DESCRIPTION
* Added constructors to `BinaryHeap` and `MutableBinaryHeap` that take a `Base.Ordering` instance as the first argument. Previously the only way to use a specific ordering was as a type parameter, which only works if the ordering type is a singleton/has a constructor with no arguments.
* Modified `nlargest` and `nsmallest` signatures to take `by` and `lt` arguments as in `sort`. This shouldn't incur a performance penalty as I'm pretty sure Julia can fully specialize on keyword arguments, and the default argument values should statically resolve to calling `nextreme` with either `Base.Forward` or `Base.Reverse`.
* Updated docs page with instructions on how to use these features.