### PR TITLE
Concrete type for field of DequeIterator

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -112,7 +112,7 @@ end
 # Iteration
 
 struct DequeIterator{T}
-    q::Deque
+    q::Deque{T}
 end
 
 function Base.iterate(qi::DequeIterator{T}, (cb, i) = (qi.q.head, qi.q.head.front)) where T


### PR DESCRIPTION
Before this PR, accessing the field was type unstable, now it's type stable.