### PR TITLE
Rename enqueue! and dequeue! to push! and popfirst!

### DIFF
--- a/src/queue.jl
+++ b/src/queue.jl
@@ -4,6 +4,27 @@
     Queue{T}([blksize::Integer=1024])
 
 Create a `Queue` object containing elements of type `T`.
+
+# Examples
+```jldoctest
+julia> q = Queue{Int}()
+Queue{Int64}(Deque [Int64[]])
+
+julia> push!(q, 1)
+Queue{Int64}(Deque [[1]])
+
+julia> x = first(q)
+1
+
+julia> length(q)
+1
+
+julia> x = popfirst!(q)
+1
+
+julia> length(q)
+0
+```
 """
 mutable struct Queue{T}
     store::Deque{T}
@@ -20,21 +41,21 @@ Base.first(s::Queue) = first(s.store)
 Base.last(s::Queue) = last(s.store)
 
 """
-    enqueue!(s::Queue, x)
+    push!(s::Queue, x)
 
 Inserts the value `x` to the end of the queue `s`.
 """
-function enqueue!(s::Queue, x)
+function Base.push!(s::Queue, x)
     push!(s.store, x)
     return s
 end
 
 """
-    dequeue!(s::Queue)
+    popfirst!(s::Queue)
 
 Removes an element from the front of the queue `s` and returns it.
 """
-dequeue!(s::Queue) = popfirst!(s.store)
+Base.popfirst!(s::Queue) = popfirst!(s.store)
 
 Base.empty!(s::Queue) = (empty!(s.store); s)
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -11,13 +11,13 @@ Stack{Int64}(Deque [Int64[]])
 julia> push!(s, 1) # push back a item
 Stack{Int64}(Deque [[1]])
 
-julia> x = top(s) # get a first item
+julia> x = first(s) # get a first item
 1
 
 julia> length(s)
 1
 
-julia> x = pop!(s) # get and remove a first item
+julia> x = popfirst!(s) # get and remove a first item
 1
 
 julia> length(s)
@@ -49,6 +49,7 @@ function Base.push!(s::Stack, x)
 end
 
 Base.pop!(s::Stack) = pop!(s.store)
+Base.popfirst!(s::Stack) = pop!(s.store)
 
 Base.empty!(s::Stack) = (empty!(s.store); s)
 

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -33,7 +33,7 @@ function test_reverse_iter(it::T) where T
 end
 @testset "reverse_iter" begin
     @testset "Queue" begin
-        q = Queue{Int}(); enqueue!(q, 1); enqueue!(q, 2)
+        q = Queue{Int}(); push!(q, 1); push!(q, 2)
         test_reverse_iter(q)
     end
     @testset "Stack" begin

--- a/test/test_queue.jl
+++ b/test/test_queue.jl
@@ -18,10 +18,10 @@
         @test isempty(s)
         @test_throws ArgumentError first(s)
         @test_throws ArgumentError last(s)
-        @test_throws ArgumentError dequeue!(s)
+        @test_throws ArgumentError popfirst!(s)
 
         for i = 1 : n
-            enqueue!(s, i)
+            push!(s, i)
             @test first(s) == 1
             @test last(s) == i
             @test !isempty(s)
@@ -29,7 +29,7 @@
         end
 
         for i = 1 : n
-            x = dequeue!(s)
+            x = popfirst!(s)
             @test x == i
             if i < n
                 @test first(s) == i + 1
@@ -48,24 +48,24 @@
         s = Queue{Int}()
 
         @test s == t
-        enqueue!(s, 10)
+        push!(s, 10)
         @test s != t
-        enqueue!(t, 10)
+        push!(t, 10)
         @test s == t
-        enqueue!(t, 20)
+        push!(t, 20)
         @test s != t
 
         @testset "different types" begin
             r = Queue{Float32}()
-            enqueue!(r, 10)
+            push!(r, 10)
             @test s == r
         end
     end
 
     @testset "emptyness" begin
         s = Queue{Int}()
-        enqueue!(s, 1)
-        enqueue!(s, 3)
+        push!(s, 1)
+        push!(s, 3)
         @test !isempty(s)
         empty!(s)
         @test isempty(s)
@@ -79,7 +79,7 @@
         arr = Int64[]
 
         for i = 1:n
-            enqueue!(q,i)
+            push!(q,i)
             push!(arr,i)
         end
 


### PR DESCRIPTION
This is currently annoying me, so I figured I would send a patch.

I also added `popfirst!` to `Stack` so that the core interface is consistent
between the two structures.

Fixes #296.