### PR TITLE
Fix #678 BoundsError in MutableBinaryHeap delete! with 3 elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.5"
+version = "0.18.6"
 
 
 [deps]

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -113,7 +113,7 @@ function _binary_heap_pop!(ord::Ordering,
     if nd_id == lastindex(nodes)
         pop!(nodes)
     else
-        # otherwise we need to swap the node-to-remove with the last node
+        # move the last node to the position of the node-to-remove
         @inbounds nodes[nd_id] = new_rt = nodes[end]
         pop!(nodes)
         @inbounds nodemap[new_rt.handle] = nd_id

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -108,11 +108,12 @@ function _binary_heap_pop!(ord::Ordering,
     v = rt.value
     @inbounds nodemap[rt.handle] = 0
 
-    if length(nodes) == 1
-        # clear
-        empty!(nodes)
+    # if node-to-remove is at end, we can just pop it
+    # the same applies to 1-element heaps that are empty after removing the last element
+    if nd_id == lastindex(nodes)
+        pop!(nodes)
     else
-        # move the last node to the position of the removed node
+        # otherwise we need to swap the node-to-remove with the last node
         @inbounds nodes[nd_id] = new_rt = nodes[end]
         pop!(nodes)
         @inbounds nodemap[new_rt.handle] = nd_id

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -266,6 +266,15 @@ end
         @test isequal(heap_values(h), [1])
     end
 
+    @testset "test delete! at end of 3-element heap" begin
+        h = MutableBinaryMinHeap{Int}()
+        push!(h, 1)
+        push!(h, 2)
+        handle = push!(h, 3)
+        delete!(h, handle)
+        @test isequal(heap_values(h), [1, 2])
+    end
+
     @testset "test update! and top_with_handle" begin
         for (hf,m) = [(MutableBinaryMinHeap,-2.0), (MutableBinaryMaxHeap,2.0)]
             xs = rand(100)


### PR DESCRIPTION
Added test where a 3-element MutableBinaryMinHeap is created and last
element is deleted. This test failed as reported in #678.
This test failure was fixed by not swapping and bubbling when the last
element in a heap is deleted.

Please review and hit me with all problems you see. 