### PR TITLE
10x+ LinkedList performance by eliminating Nil and the abstract tail in Cons

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -30,8 +30,7 @@ module DataStructures
 
     export Trie, subtrie, keys_with_prefix, partial_path
 
-    export LinkedList, Nil, Cons, nil, cons, head, tail, list, filter, cat,
-           reverse
+    export LinkedList, Cons, nil, cons, head, tail, list, filter, cat, reverse
     export MutableLinkedList
     export SortedDict, SortedMultiDict, SortedSet
     export SDToken, SDSemiToken, SMDToken, SMDSemiToken


### PR DESCRIPTION
The `tail` field in `Cons` was not concrete, which made iteration slow. This PR changes the type of `tail` from `LinkedList{T}` to `Cons{T}`, and uses an unitialized `Cons` in the place of `Nil`.

I haven't found benchmarks, so I used the following to measure the gain. Creation performance is the same, iteration is 70-100x faster, other operations closer to 10x.

```
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using DataStructures
       println("Creation:")
       @btime nil()
       @btime list(1)
       @btime list(1,2,3,4,5,6,7)
       const lshort = list(1,2,3,4,5,6,7)
       @btime list([i for i=1:1000]...)
       const llong = list([i for i=1:1000]...)
       println("Iteration:")
       @btime sum(lshort)
       @btime sum(llong)
       println("Reverse:")
       @btime reverse(lshort)
       @btime reverse(llong)
       println("Map:")
       @btime map(x->2x, lshort)
       @btime map(x->2x, llong)
       println("Copy:")
       @btime copy(lshort)
       @btime copy(llong);
Creation:
  3.814 ns (1 allocation: 32 bytes)
  9.071 ns (2 allocations: 64 bytes)
  30.337 ns (8 allocations: 256 bytes)
  15.398 μs (1492 allocations: 54.80 KiB)
Iteration:
  3.412 ns (0 allocations: 0 bytes)
  898.029 ns (0 allocations: 0 bytes)
Reverse:
  32.967 ns (8 allocations: 256 bytes)
  4.193 μs (1001 allocations: 31.28 KiB)
Map:
  62.038 ns (16 allocations: 512 bytes)
  7.761 μs (2002 allocations: 62.56 KiB)
Copy:
  61.569 ns (16 allocations: 512 bytes)
  7.843 μs (2002 allocations: 62.56 KiB)
```

On the current master:
```
Creation:
  3.588 ns (1 allocation: 8 bytes)
  8.146 ns (2 allocations: 40 bytes)
  28.937 ns (8 allocations: 232 bytes)
  15.431 μs (1492 allocations: 54.77 KiB)
Iteration:
  438.298 ns (7 allocations: 224 bytes)
  64.385 μs (1978 allocations: 46.53 KiB)
Reverse:
  467.740 ns (15 allocations: 456 bytes)
  67.213 μs (2979 allocations: 77.79 KiB)
Map:
  944.696 ns (29 allocations: 880 bytes)
  145.330 μs (6469 allocations: 163.55 KiB)
Copy:
  932.111 ns (30 allocations: 912 bytes)
  134.162 μs (5958 allocations: 155.58 KiB)
```

Unfortunatley, `Nil` was exported, so this is breaking. There is an `isnil()` function now, but I am not sure if it needs to be exported. 
