### PR TITLE
List performance improvent by Union-typed tail

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -7,7 +7,7 @@ end
 
 mutable struct Cons{T} <: LinkedList{T}
     head::T
-    tail::LinkedList{T}
+    tail::Union{Nil{T}, Cons{T}}
 end
 
 cons(h, t::LinkedList{T}) where {T} = Cons{T}(h, t)


### PR DESCRIPTION
Just found this non-breaking alternative to #681 with similar (somewhat worse, but still 10x+ iteration) performance.

```
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using DataStructures
       println("Creation:")
       @btime nil()
       @btime list(1)
       @btime list(1,2,3,4,5,6,7)
       const lshort = list(1,2,3,4,5,6,7)
       @btime list([i for i=1:1000]...)
       const llong = list([i for i=1:1000]...)
       println("Iteration:")
       @btime sum(lshort)
       @btime sum(llong)
       println("Reverse:")
       @btime reverse(lshort)
       @btime reverse(llong)
       println("Map:")
       @btime map(x->2x, lshort)
       @btime map(x->2x, llong)
       println("Copy:")
       @btime copy(lshort)
       @btime copy(llong);
Creation:
  3.405 ns (1 allocation: 8 bytes)
  8.175 ns (2 allocations: 40 bytes)
  29.328 ns (8 allocations: 232 bytes)
  15.242 μs (1492 allocations: 54.77 KiB)
Iteration:
  3.910 ns (0 allocations: 0 bytes)
  1.363 μs (0 allocations: 0 bytes)
Reverse:
  33.955 ns (8 allocations: 232 bytes)
  3.955 μs (1001 allocations: 31.26 KiB)
Map:
  68.279 ns (16 allocations: 464 bytes)
  8.354 μs (2002 allocations: 62.52 KiB)
Copy:
  64.018 ns (16 allocations: 464 bytes)
  8.082 μs (2002 allocations: 62.52 KiB)
```
