### PR TITLE
Fixed type-instability in Deque iterator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.7"
+version = "0.18.8"
 
 
 [deps]

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -112,7 +112,7 @@ end
 # Iteration
 
 struct DequeIterator{T}
-    q::Deque
+    q::Deque{T}
 end
 
 Base.last(qi::DequeIterator) = last(qi.q)

--- a/test/bench_deque.jl
+++ b/test/bench_deque.jl
@@ -62,3 +62,15 @@ t2 = @elapsed traverse(q)
 println("traverse 10^7 integers:")
 @printf("    Vector:   elapsed = %8.4fs\n", t1)
 @printf("    Deque:    elapsed = %8.4fs\n", t2)
+
+# sum
+
+sum(v)
+t1 = @elapsed sum(v)
+
+sum(q)
+t2 = @elapsed sum(q)
+
+println("sum 10^7 integers:")
+@printf("    Vector:   elapsed = %8.4fs\n", t1)
+@printf("    Deque:    elapsed = %8.4fs\n", t2)


### PR DESCRIPTION
As reported in at least issue https://github.com/JuliaCollections/DataStructures.jl/issues/619, iterating over `Deque` was type unstable. This also therefore extends to `Queue` and `Stack` which are based on `Deque`. Running your benchmark (and a new `sum` benchmark) gives the following 75x speed-up of iteration.
Before:
```
traverse 10^7 integers:
    Vector:   elapsed =   0.0000s
    Deque:    elapsed =   0.3877s
sum 10^7 integers:
    Vector:   elapsed =   0.0044s
    Deque:    elapsed =   0.5728s
```
After:
```
traverse 10^7 integers:
    Vector:   elapsed =   0.0000s
    Deque:    elapsed =   0.0051s
sum 10^7 integers:
    Vector:   elapsed =   0.0036s
    Deque:    elapsed =   0.0085s
```