### PR TITLE
Rename DisjointSet and resolve errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package implements a variety of data structures, including
 -   Priority Queue
 -   Fenwick Tree
 -   Accumulators and Counters (i.e. Multisets / Bags)
--   Disjoint Sets
+-   Disjoint-Set
 -   Binary Heap
 -   Mutable Binary Heap
 -   Ordered Dicts and Sets

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
         "priority-queue.md",
         "fenwick.md",
         "accumulators.md",
-        "disjoint_sets.md",
+        "disjoint_set.md",
         "heaps.md",
         "ordered_containers.md",
         "default_dict.md",

--- a/docs/src/disjoint_set.md
+++ b/docs/src/disjoint_set.md
@@ -1,0 +1,34 @@
+# Disjoint-Set
+
+Some algorithms, such as finding connected components in undirected
+graph and Kruskal's method of finding minimum spanning tree, require a
+data structure that can efficiently represent a collection of disjoint
+subsets. A widely used data structure for this purpose is the *Disjoint
+set forest*.
+
+Usage:
+
+```julia
+a = IntDisjointSet(10)  # creates a forest comprised of 10 singletons
+union!(a, 3, 5)          # merges the sets that contain 3 and 5 into one and returns the root of the new set
+root_union!(a, x, y)     # merges the sets that have root x and y into one and returns the root of the new set
+find_root(a, 3)          # finds the root element of the subset that contains 3
+in_same_set(a, x, y)     # determines whether x and y are in the same set
+elem = push!(a)          # adds a single element in a new set; returns the new element
+                         # (this operation is often called MakeSet)
+```
+
+One may also use other element types:
+
+```julia
+a = DisjointSet{AbstractString}(["a", "b", "c", "d"])
+union!(a, "a", "b")
+in_same_set(a, "c", "d")
+push!(a, "f")
+```
+
+Note that the internal implementation of `IntDisjointSet` is based on
+vectors, and is very efficient. `DisjointSet{T}` is a wrapper of
+`IntDisjointSet`, which uses a dictionary to map input elements to an
+internal index. Note for `DisjointSet`, `union!`, `root_union!` and
+`find_root` return the index of the root.

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -19,7 +19,7 @@ module DataStructures
     export capacity, num_blocks, top_with_handle, sizehint!
 
     export Accumulator, counter, reset!, inc!, dec!
-    export IntDisjointSets, DisjointSets, num_groups, find_root!, in_same_set, root_union!
+    export IntDisjointSet, DisjointSet, num_groups, find_root!, in_same_set, root_union!
     export FenwickTree, length, inc!, dec!, incdec!, prefixsum
 
     export AbstractHeap, compare, extract_all!, extract_all_rev!

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -3,3 +3,7 @@
 @deprecate find_root find_root!
 @deprecate top first
 @deprecate reverse_iter Iterators.reverse
+# Deprecations from #700
+Base.@deprecate_binding DisjointSets DisjointSet
+Base.@deprecate_binding IntDisjointSets IntDisjointSet
+@deprecate DisjointSets(xs...) DisjointSet(xs)

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -223,6 +223,7 @@ Make a new subset with an automatically chosen new element x.
 Returns the new element.
 """
 function Base.push!(s::DisjointSet{T}, x::T) where T
+    haskey(s.intmap, x) && return x
     id = push!(s.internal)
     s.intmap[x] = id
     push!(s.revmap, x) # Note, this assumes invariant: length(s.revmap) == id

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -1,4 +1,4 @@
-# Disjoint sets
+# Disjoint-Set
 
 ############################################################
 #
@@ -8,41 +8,38 @@
 #   instead of dictionary (for efficiency)
 #
 #   Disjoint sets over other key types can be implemented
-#   based on an IntDisjointSets through a map from the key
+#   based on an IntDisjointSet through a map from the key
 #   to an integer index
 #
 ############################################################
 
-_intdisjointsets_bounds_err_msg(T) = "the maximum number of elements in IntDisjointSets{$T} is $(typemax(T))"
+_intdisjointset_bounds_err_msg(T) = "the maximum number of elements in IntDisjointSet{$T} is $(typemax(T))"
 
 """
-    IntDisjointSets{T<:Integer}(n::Integer)
+    IntDisjointSet{T<:Integer}(n::Integer)
 
 A forest of disjoint sets of integers, which is a data structure
 (also called a union–find data structure or merge–find set)
 that tracks a set of elements partitioned
 into a number of disjoint (non-overlapping) subsets.
 """
-mutable struct IntDisjointSets{T<:Integer}
+mutable struct IntDisjointSet{T<:Integer}
     parents::Vector{T}
     ranks::Vector{T}
     ngroups::T
-
-    # creates a disjoint set comprised of n singletons
-    # IntDisjointSets(n::T) where {T<:Integer} = new(collect(Base.OneTo(n)), zeros(T, n), n)
 end
 
-IntDisjointSets(n::T) where {T<:Integer} = IntDisjointSets{T}(collect(Base.OneTo(n)), zeros(T, n), n)
-IntDisjointSets{T}(n::Integer) where {T<:Integer} = IntDisjointSets{T}(collect(Base.OneTo(T(n))), zeros(T, T(n)), T(n))
-Base.length(s::IntDisjointSets) = length(s.parents)
+IntDisjointSet(n::T) where {T<:Integer} = IntDisjointSet{T}(collect(Base.OneTo(n)), zeros(T, n), n)
+IntDisjointSet{T}(n::Integer) where {T<:Integer} = IntDisjointSet{T}(collect(Base.OneTo(T(n))), zeros(T, T(n)), T(n))
+Base.length(s::IntDisjointSet) = length(s.parents)
 
 """
-    num_groups(s::IntDisjointSets)
+    num_groups(s::IntDisjointSet)
 
 Get a number of groups.
 """
-num_groups(s::IntDisjointSets) = s.ngroups
-Base.eltype(::Type{IntDisjointSets{T}}) where {T<:Integer} = T
+num_groups(s::IntDisjointSet) = s.ngroups
+Base.eltype(::Type{IntDisjointSet{T}}) where {T<:Integer} = T
 
 # find the root element of the subset that contains x
 # path compression is implemented here
@@ -64,27 +61,27 @@ function _find_root_impl!(parents::Vector{T}, x::Integer) where {T<:Integer}
 end
 
 """
-    find_root!(s::IntDisjointSets{T}, x::T)
+    find_root!(s::IntDisjointSet{T}, x::T)
 
 Find the root element of the subset that contains an member x.
 Path compression is implemented here.
 """
-find_root!(s::IntDisjointSets{T}, x::T) where {T<:Integer} = find_root_impl!(s.parents, x)
+find_root!(s::IntDisjointSet{T}, x::T) where {T<:Integer} = find_root_impl!(s.parents, x)
 
 """
-    in_same_set(s::IntDisjointSets{T}, x::T, y::T)
+    in_same_set(s::IntDisjointSet{T}, x::T, y::T)
 
 Returns `true` if `x` and `y` belong to the same subset in `s` and `false` otherwise.
 """
-in_same_set(s::IntDisjointSets{T}, x::T, y::T) where {T<:Integer} = find_root!(s, x) == find_root!(s, y)
+in_same_set(s::IntDisjointSet{T}, x::T, y::T) where {T<:Integer} = find_root!(s, x) == find_root!(s, y)
 
 """
-    union!(s::IntDisjointSets{T}, x::T, y::T)
+    union!(s::IntDisjointSet{T}, x::T, y::T)
 
 Merge the subset containing x and that containing y into one
 and return the root of the new set.
 """
-function Base.union!(s::IntDisjointSets{T}, x::T, y::T) where {T<:Integer}
+function Base.union!(s::IntDisjointSet{T}, x::T, y::T) where {T<:Integer}
     parents = s.parents
     xroot = find_root_impl!(parents, x)
     yroot = find_root_impl!(parents, y)
@@ -92,13 +89,13 @@ function Base.union!(s::IntDisjointSets{T}, x::T, y::T) where {T<:Integer}
 end
 
 """
-    root_union!(s::IntDisjointSets{T}, x::T, y::T)
+    root_union!(s::IntDisjointSet{T}, x::T, y::T)
 
 Form a new set that is the union of the two sets whose root elements are
 x and y and return the root of the new set.
 Assume x ≠ y (unsafe).
 """
-function root_union!(s::IntDisjointSets{T}, x::T, y::T) where {T<:Integer}
+function root_union!(s::IntDisjointSet{T}, x::T, y::T) where {T<:Integer}
     parents = s.parents
     rks = s.ranks
     @inbounds xrank = rks[x]
@@ -115,15 +112,15 @@ function root_union!(s::IntDisjointSets{T}, x::T, y::T) where {T<:Integer}
 end
 
 """
-    push!(s::IntDisjointSets{T})
+    push!(s::IntDisjointSet{T})
 
 Make a new subset with an automatically chosen new element x.
 Returns the new element. Throw an `ArgumentError` if the
 capacity of the set would be exceeded.
 """
-function Base.push!(s::IntDisjointSets{T}) where {T<:Integer}
+function Base.push!(s::IntDisjointSet{T}) where {T<:Integer}
     l = length(s)
-    l < typemax(T) || throw(ArgumentError(_intdisjointsets_bounds_err_msg(T)))
+    l < typemax(T) || throw(ArgumentError(_intdisjointset_bounds_err_msg(T)))
     x = l + one(T)
     push!(s.parents, x)
     push!(s.ranks, zero(T))
@@ -132,20 +129,20 @@ function Base.push!(s::IntDisjointSets{T}) where {T<:Integer}
 end
 
 """
-    DisjointSets{T}(xs)
+    DisjointSet{T}(xs)
 
 A forest of disjoint sets of arbitrary value type T.
 
-It is a wrapper of IntDisjointSets{Int}, which uses a
+It is a wrapper of IntDisjointSet{Int}, which uses a
 dictionary to map the input value to an internal index.
 """
-mutable struct DisjointSets{T} <: AbstractSet{T}
+mutable struct DisjointSet{T} <: AbstractSet{T}
     intmap::Dict{T,Int}
     revmap::Vector{T}
-    internal::IntDisjointSets{Int}
+    internal::IntDisjointSet{Int}
 
-    DisjointSets{T}() where T = new{T}(Dict{T,Int}(), Vector{T}(), IntDisjointSets(0))
-    function DisjointSets{T}(xs) where T    # xs must be iterable
+    DisjointSet{T}() where T = new{T}(Dict{T,Int}(), Vector{T}(), IntDisjointSet(0))
+    function DisjointSet{T}(xs) where T    # xs must be iterable
         imap = Dict{T,Int}()
         rmap = Vector{T}()
         n = length(xs)
@@ -156,80 +153,78 @@ mutable struct DisjointSets{T} <: AbstractSet{T}
             imap[x] = (id += 1)
             push!(rmap,x)
         end
-        new{T}(imap, rmap, IntDisjointSets(n))
+        new{T}(imap, rmap, IntDisjointSet(n))
     end
 end
 
-DisjointSets() = DisjointSets{Any}()
-DisjointSets(xs::T...) where T = DisjointSets{T}(xs)
-DisjointSets{T}(xs::T...) where T = DisjointSets{T}(xs)
-DisjointSets(xs) = _DisjointSets(xs, Base.IteratorEltype(xs))
-_DisjointSets(xs, ::Base.HasEltype) = DisjointSets{eltype(xs)}(xs)
-function _DisjointSets(xs, ::Base.EltypeUnknown)
+DisjointSet() = DisjointSet{Any}()
+DisjointSet(xs) = _DisjointSet(xs, Base.IteratorEltype(xs))
+_DisjointSet(xs, ::Base.HasEltype) = DisjointSet{eltype(xs)}(xs)
+function _DisjointSet(xs, ::Base.EltypeUnknown)
     T = Base.@default_eltype(xs)
-    (isconcretetype(T) || T === Union{}) || return Base.grow_to!(DisjointSets{T}(), xs)
-    return DisjointSets{T}(xs)
+    (isconcretetype(T) || T === Union{}) || return Base.grow_to!(DisjointSet{T}(), xs)
+    return DisjointSet{T}(xs)
 end
 
-Base.iterate(s::DisjointSets) = iterate(s.revmap)
-Base.iterate(s::DisjointSets, i) = iterate(s.revmap, i)
+Base.iterate(s::DisjointSet) = iterate(s.revmap)
+Base.iterate(s::DisjointSet, i) = iterate(s.revmap, i)
 
-Base.length(s::DisjointSets) = length(s.internal)
+Base.length(s::DisjointSet) = length(s.internal)
 
 """
-    num_groups(s::DisjointSets)
+    num_groups(s::DisjointSet)
 
 Get a number of groups.
 """
-num_groups(s::DisjointSets) = num_groups(s.internal)
-Base.eltype(::Type{DisjointSets{T}}) where T = T
-Base.empty(s::DisjointSets{T}, ::Type{U}=T) where {T,U} = DisjointSets{U}()
-function Base.sizehint!(s::DisjointSets, n::Integer)
+num_groups(s::DisjointSet) = num_groups(s.internal)
+Base.eltype(::Type{DisjointSet{T}}) where T = T
+Base.empty(s::DisjointSet{T}, ::Type{U}=T) where {T,U} = DisjointSet{U}()
+function Base.sizehint!(s::DisjointSet, n::Integer)
     sizehint!(s.intmap, n)
     sizehint!(s.revmap, n)
     return s
 end
 
 """
-    find_root!{T}(s::DisjointSets{T}, x::T)
+    find_root!{T}(s::DisjointSet{T}, x::T)
 
 Finds the root element of the subset in `s` which has the element `x` as a member.
 """
-find_root!(s::DisjointSets{T}, x::T) where {T} = s.revmap[find_root!(s.internal, s.intmap[x])]
+find_root!(s::DisjointSet{T}, x::T) where {T} = s.revmap[find_root!(s.internal, s.intmap[x])]
 
 """
-    in_same_set(s::DisjointSets{T}, x::T, y::T)
+    in_same_set(s::DisjointSet{T}, x::T, y::T)
 
 Returns `true` if `x` and `y` belong to the same subset in `s` and `false` otherwise.
 """
-in_same_set(s::DisjointSets{T}, x::T, y::T) where {T} = in_same_set(s.internal, s.intmap[x], s.intmap[y])
+in_same_set(s::DisjointSet{T}, x::T, y::T) where {T} = in_same_set(s.internal, s.intmap[x], s.intmap[y])
 
 """
-    union!(s::DisjointSets{T}, x::T, y::T)
+    union!(s::DisjointSet{T}, x::T, y::T)
 
 Merge the subset containing x and that containing y into one
 and return the root of the new set.
 """
-Base.union!(s::DisjointSets{T}, x::T, y::T) where {T} = s.revmap[union!(s.internal, s.intmap[x], s.intmap[y])]
+Base.union!(s::DisjointSet{T}, x::T, y::T) where {T} = s.revmap[union!(s.internal, s.intmap[x], s.intmap[y])]
 
 """
-    root_union!(s::DisjointSets{T}, x::T, y::T)
+    root_union!(s::DisjointSet{T}, x::T, y::T)
 
 Form a new set that is the union of the two sets whose root elements are
 x and y and return the root of the new set.
 Assume x ≠ y (unsafe).
 """
-root_union!(s::DisjointSets{T}, x::T, y::T) where {T} = s.revmap[root_union!(s.internal, s.intmap[x], s.intmap[y])]
+root_union!(s::DisjointSet{T}, x::T, y::T) where {T} = s.revmap[root_union!(s.internal, s.intmap[x], s.intmap[y])]
 
 """
-    push!(s::DisjointSets{T}, x::T)
+    push!(s::DisjointSet{T}, x::T)
 
 Make a new subset with an automatically chosen new element x.
 Returns the new element.
 """
-function Base.push!(s::DisjointSets{T}, x::T) where T
+function Base.push!(s::DisjointSet{T}, x::T) where T
     id = push!(s.internal)
     s.intmap[x] = id
-    push!(s.revmap,x) # Note, this assumes invariant: length(s.revmap) == id
+    push!(s.revmap, x) # Note, this assumes invariant: length(s.revmap) == id
     return x
 end

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -162,4 +162,9 @@
         end
     end
 
+    @testset "Test deprecations from #700" begin
+        @test DisjointSets(1:10) isa DisjointSet
+        @test IntDisjointSets(10) isa IntDisjointSet
+        @test DisjointSets(1:10...) == DisjointSet(1:10)
+    end
 end # @testset DisjointSet

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -1,10 +1,10 @@
 @testset "DisjointSet" begin
 
-    @testset "IntDisjointSets" begin
+    @testset "IntDisjointSet" begin
         for T in [Int, UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64]
             @testset "eltype = $(T)" begin
-                s = IntDisjointSets(T(10))
-                s2 = IntDisjointSets{T}(10)
+                s = IntDisjointSet(T(10))
+                s2 = IntDisjointSet{T}(10)
 
                 @testset "basic tests" begin
                     @test length(s) == 10
@@ -36,7 +36,7 @@
                 end
 
                 @testset "more tests" begin
-                    # We cannot support arbitrary indexing and still use @inbounds with IntDisjointSets
+                    # We cannot support arbitrary indexing and still use @inbounds with IntDisjointSet
                     # (and it's not useful anyway)
                     @test_throws MethodError push!(s, T(22))
 
@@ -59,27 +59,28 @@
         end
     end
 
-    @testset "IntDisjointSets overflow" begin
+    @testset "IntDisjointSet overflow" begin
         for T in [UInt8, Int8]
-            s = IntDisjointSets(T(typemax(T)-1))
+            s = IntDisjointSet(T(typemax(T)-1))
             push!(s)
             @test_throws ArgumentError push!(s)
         end
     end
 
-    @testset "DisjointSets" begin
-        # DisjointSets supports arbitrary indices
-        s = DisjointSets{Int}(1:10)
+    @testset "DisjointSet" begin
+        # DisjointSet supports arbitrary indices
+        s = DisjointSet{Int}(1:10)
 
         @testset "constructor" begin
-            @test DisjointSets() isa DisjointSets{Any}
-            @test DisjointSets{Int}(1:10) isa DisjointSets{Int}
-            @test DisjointSets{Float64}(1.0:10.0...) isa DisjointSets{Float64}
-            @test DisjointSets(collect(1:10)) isa DisjointSets{Int}
-            @test DisjointSets(collect(1.0:10.0)...) isa DisjointSets{Float64}
-            @test DisjointSets(x*im for x = 1:10) isa DisjointSets{Complex{Int}}
+            @test DisjointSet() isa DisjointSet{Any}
+            @test DisjointSet{Int}(1:10) isa DisjointSet{Int}
+            @test DisjointSet(collect(1:10)) isa DisjointSet{Int}
+            @test DisjointSet(x*im for x = 1:10) isa DisjointSet{Complex{Int}}
             g = (x % 2 == 0 ? x+1//x : x*im for x = 1:10)
-            @test DisjointSets(g) isa DisjointSets{Number}
+            @test DisjointSet(g) isa DisjointSet{Number}
+            @test DisjointSet(Any[1,2,3]) isa DisjointSet
+            @test DisjointSet{Any}(Any[1,2,3]) isa DisjointSet{Any}
+            @test DisjointSet{Int}(Any[1,2,3]) isa DisjointSet{Int}
         end
 
         @testset "basic tests" begin
@@ -88,10 +89,10 @@
             @test eltype(s) == Int
             @test eltype(typeof(s)) == Int
             @test length(empty(s)) == num_groups(empty(s)) == 0
-            @test empty(s) isa DisjointSets{eltype(s)}
+            @test empty(s) isa DisjointSet{eltype(s)}
             @test collect(s) == collect(1:10)
             g = (x % 2 == 0 ? x+1//x : x*im for x = 1:10)
-            s1 = DisjointSets(g)
+            s1 = DisjointSet(g)
             @test length(s1) == 10
             @test sizehint!(s1, 100) === s1
 
@@ -139,7 +140,7 @@
 
         @testset "Some tests using non-integer disjoint sets" begin
             elems = ["a", "b", "c", "d"]
-            a = DisjointSets{AbstractString}(elems)
+            a = DisjointSet{AbstractString}(elems)
             @test collect(a) == ["a", "b", "c", "d"]
             union!(a, "a", "b")
             @test in_same_set(a,"a","b")

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -166,5 +166,6 @@
         @test DisjointSets(1:10) isa DisjointSet
         @test IntDisjointSets(10) isa IntDisjointSet
         @test DisjointSets(1:10...) == DisjointSet(1:10)
+        @test typeof(DisjointSet(1:10)) <: DisjointSets
     end
 end # @testset DisjointSet


### PR DESCRIPTION
Addresses #694 and resolves error when pushing a repeated element to a `DisjointSet`:

```julia
julia> ds = DisjointSets('a':'e')
DisjointSets{Char} with 5 elements:
  'a'
  'b'
  'c'
  'd'
  'e'

julia> ds.intmap
Dict{Char,Int64} with 5 entries:
  'a' => 1
  'c' => 3
  'd' => 4
  'e' => 5
  'b' => 2

julia> ds.internal
IntDisjointSets{Int64}([1, 2, 3, 4, 5], [0, 0, 0, 0, 0], 5)

julia> push!(ds, 'b')
'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)

julia> ds.intmap
Dict{Char,Int64} with 5 entries:
  'a' => 1
  'c' => 3
  'd' => 4
  'e' => 5
  'b' => 6

julia> ds.internal
IntDisjointSets{Int64}([1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0], 6)
```

