### PR TITLE
Fix MutableLinkedList append! w/ test

### DIFF
--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -151,8 +151,8 @@ function Base.setindex!(l::MutableLinkedList{T}, data, idx::Int) where T
 end
 
 function Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T
-    l1.node.prev.next = l2.node.next
-    l2.node.next.prev = l1.node.prev
+    l1.node.prev.next = l2.node.next # l1's last's next is now l2's first
+    l2.node.prev.next = l1.node # l2's last's next is now l1.node
     l1.len += length(l2)
     return l1
 end

--- a/test/test_mutable_list.jl
+++ b/test/test_mutable_list.jl
@@ -98,9 +98,11 @@
                     l2 = MutableLinkedList{Int}(n+1:2n...)
                     append!(l, l2)
                     @test l == MutableLinkedList{Int}(1:2n...)
+                    @test collect(l) == collect(MutableLinkedList{Int}(1:2n...))
                     l3 = MutableLinkedList{Int}(1:n...)
                     append!(l3, n+1:2n...)
                     @test l3 == MutableLinkedList{Int}(1:2n...)
+                    @test collect(l3) == collect(MutableLinkedList{Int}(1:2n...))
                 end
 
                 @testset "delete" begin


### PR DESCRIPTION
Fixes #725 

The logic for making the end of the appended list point to the original list's terminal node was wrong.