### PR TITLE
Add recursive `DefaultDict` example

### DIFF
--- a/docs/src/default_dict.md
+++ b/docs/src/default_dict.md
@@ -104,3 +104,17 @@ dd["a"]
 dd["b"]["a"] = 1
 dd["a"]
 ```
+
+To create a `DefaultDict` which recursively calls itself you can write:
+```@repl
+rdict(args...) = DefaultDict(rdict, Dict{Any,Any}(args...))
+dd = rdict()
+dd["a"]["b"]["c"]
+```
+
+It's also possible to create a recursive `DefaultDict` where the key is restricted:
+```@repl
+rdict(args...) = DefaultDict{String,Any,typeof(rdict)}(rdict, Dict{String,Any}(args...))
+dd = rdict()
+dd["a"]["b"]["c"]
+```


### PR DESCRIPTION
Seems like a useful example to include. Alternatively I could see a `DefaultDictRec` being introduced which could be an abstraction on this idea and would allow for dynamically setting the type parameters.