### PR TITLE
Add Queue `show` method to hide backing Deque

### DIFF
--- a/src/queue.jl
+++ b/src/queue.jl
@@ -45,3 +45,9 @@ Base.iterate(q::Queue, s...) = iterate(q.store, s...)
 Iterators.reverse(q::Queue) = Iterators.reverse(q.store)
 
 Base.:(==)(x::Queue, y::Queue) = x.store == y.store
+
+# Showing
+
+function Base.show(io::IO, s::Queue)
+   print(io,"Queue [$(collect(s.store))]")
+end


### PR DESCRIPTION
I was looking over the Queue method per #479 and while I didn't find any issues I noticed that during printing at the REPL the backing Deque is printed inside. Decided to try to write a small show method to hide the backing type to pretty it up.