### PR TITLE
Circ buff new constructor

### DIFF
--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -13,9 +13,9 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     length::Int
     buffer::Vector{T}
 
-    function CircularBuffer{T}(vec,capacity::Int) where {T}
-        capacity >= length(vec) || throw(BoundsError()) # prevent overflow
-        new{T}(capacity,1,length(vec),copyto!(Vector{T}(undef,capacity),convert(Vector{T},vec)))
+    function CircularBuffer{T}(iter, capacity::Int) where {T}
+        vec = copyto!(Vector{T}(undef,capacity), vec)
+        new{T}(capacity, 1, length(vec),vec)
     end
 
 end

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -14,11 +14,16 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     length::Int
     buffer::Vector{T}
 
+    function CircularBuffer{T}(f,len,buf) where {T}
+        f <= length(buf) || throw(ArgumentError("Value of 'first' must be inbounds of buffer"))
+        len <= length(buf) || throw(ArgumentError("Value of 'length' must be <= length of buffer"))
+        return new{T}(length(buf), f, len, buf)
+    end
 end
 
 function CircularBuffer{T}(iter, capacity::Int) where {T}
     vec = copyto!(Vector{T}(undef,capacity), iter)
-    CircularBuffer{T}(capacity, 1, length(vec),vec)
+    CircularBuffer{T}(1, length(iter),vec)
 end
 
 CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
@@ -29,7 +34,7 @@ CircularBuffer(iter,capacity::Int) =  CircularBuffer{eltype(iter)}(iter,capacity
 
 function CircularBuffer{T}(iter) where {T}
   vec = reshape(collect(T,iter),:) 
-  CircularBuffer{T}(length(vec), 1, length(vec), vec)
+  CircularBuffer{T}(1, length(vec), vec)
 end
 
 CircularBuffer(iter) = CircularBuffer{eltype(iter)}(iter)

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,11 +1,11 @@
 """
-    CircularBuffer{T}(n)
+    CircularBuffer{T}(v,n)
 
 The CircularBuffer type implements a circular buffer of fixed capacity
 where new items are pushed to the back of the list, overwriting values
 in a circular fashion.
 
-Allocate a buffer of elements of type `T` with maximum capacity `n`.
+Allocate a buffer of elements of type `T`  containing items `v` with maximum capacity `n`.
 """
 mutable struct CircularBuffer{T} <: AbstractVector{T}
     capacity::Int

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -14,7 +14,7 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     buffer::Vector{T}
 
     function CircularBuffer{T}(iter, capacity::Int) where {T}
-        vec = copyto!(Vector{T}(undef,capacity), vec)
+        vec = copyto!(Vector{T}(undef,capacity), iter)
         new{T}(capacity, 1, length(vec),vec)
     end
 
@@ -24,7 +24,8 @@ CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
 
 CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(T[],capacity)
 
-CircularBuffer(vec,capacity::Int) =  CircularBuffer{eltype(vec)}(vec,capacity)
+CircularBuffer(iter,capacity::Int) =  CircularBuffer{eltype(iter)}(iter,capacity)
+
 
 
 """

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -14,11 +14,11 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     length::Int
     buffer::Vector{T}
 
-    function CircularBuffer{T}(iter, capacity::Int) where {T}
-        vec = copyto!(Vector{T}(undef,capacity), iter)
-        new{T}(capacity, 1, length(vec),vec)
-    end
+end
 
+function CircularBuffer{T}(iter, capacity::Int) where {T}
+    vec = copyto!(Vector{T}(undef,capacity), iter)
+    CircularBuffer{T}(capacity, 1, length(vec),vec)
 end
 
 CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
@@ -27,9 +27,9 @@ CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(T[],capacity)
 
 CircularBuffer(iter,capacity::Int) =  CircularBuffer{eltype(iter)}(iter,capacity)
 
-function CircularBuffer{T}(iter)
-  vec = collect(T,iter)  
-  CircularBuffer{T}(vec,length(vec))
+function CircularBuffer{T}(iter) where {T}
+  vec = reshape(collect(T,iter),:) 
+  CircularBuffer{T}(length(vec), 1, length(vec), vec)
 end
 
 CircularBuffer(iter) = CircularBuffer{eltype(iter)}(iter)

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -13,10 +13,19 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
     length::Int
     buffer::Vector{T}
 
-    CircularBuffer{T}(capacity::Int) where {T} = new{T}(capacity, 1, 0, Vector{T}(undef, capacity))
+    function CircularBuffer{T}(vec,capacity::Int) where {T}
+        capacity >= length(vec) || throw(BoundsError()) # prevent overflow
+        new{T}(capacity,1,length(vec),copyto!(Vector{T}(undef,capacity),convert(Vector{T},vec)))
+    end
+
 end
 
-CircularBuffer(capacity) = CircularBuffer{Any}(capacity)
+CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
+
+CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}([],capacity)
+
+CircularBuffer(vec,capacity::Int) =  CircularBuffer{eltype(vec)}(vec,capacity)
+
 
 """
     empty!(cb::CircularBuffer)

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -26,7 +26,12 @@ CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(T[],capacity)
 
 CircularBuffer(iter,capacity::Int) =  CircularBuffer{eltype(iter)}(iter,capacity)
 
+function CircularBuffer{T}(iter)
+  vec = collect(T,iter)  
+  CircularBuffer{T}(vec,length(vec))
+end
 
+CircularBuffer(iter) = CircularBuffer{eltype(iter)}(iter)
 
 """
     empty!(cb::CircularBuffer)

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -22,7 +22,7 @@ end
 
 CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
 
-CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}([],capacity)
+CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(T[],capacity)
 
 CircularBuffer(vec,capacity::Int) =  CircularBuffer{eltype(vec)}(vec,capacity)
 

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -1,11 +1,12 @@
 """
-    CircularBuffer{T}(v,n)
+    CircularBuffer{T}(v,n::Int)
 
 The CircularBuffer type implements a circular buffer of fixed capacity
 where new items are pushed to the back of the list, overwriting values
 in a circular fashion.
 
 Allocate a buffer of elements of type `T`  containing items `v` with maximum capacity `n`.
+If no capacity is provided the capacity is the number of elements in `v`
 """
 mutable struct CircularBuffer{T} <: AbstractVector{T}
     capacity::Int

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -51,6 +51,10 @@
     end
 
     @testset "other constructors" begin
+        @testset "internal constructor" begin
+            @test_throws ArgumentError CircularBuffer{Int64}(6,0,Vector{Int64}(undef,5))
+            @test_throws ArgumentError CircularBuffer{Int64}(1,6,Vector{Int64}(undef,5))
+        end
         @testset "capacity only" begin
             cb = CircularBuffer(10)
             @test length(cb) == 0

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -60,22 +60,29 @@
             @test length(cb) == 0
             @test typeof(cb) <: CircularBuffer{Any}
         end
-        @testset "from vec inferred type" begin
+        @testset "from vec inferred type with capacity" begin
             cb = CircularBuffer(1:5,10)
             @test length(cb) == 5
             @test typeof(cb) == CircularBuffer{Int}
         end
-        @testset "from vec given type" begin
+        @testset "from vec given type with capacity" begin
             cb = CircularBuffer{Float64}(1:5,10)
             @test length(cb) == 5
             @test typeof(cb) == CircularBuffer{Float64}
             @test collect(cb) == [1.0,2.0,3.0,4.0,5.0]
         end
-        @testset "inferred capacity" begin
+        @testset "inferred capacity given type" begin
             cb = CircularBuffer{Float64}(1:5)
             @test length(cb) == 5
             @test typeof(cb) == CircularBuffer{Float64}
             @test collect(cb) == [1.0,2.0,3.0,4.0,5.0]
+            @test capacity(cb) == 5
+        end
+        @testset "inferred capacity inferred type" begin
+            cb = CircularBuffer(1:5)
+            @test length(cb) == 5
+            @test typeof(cb) == CircularBuffer{Int}
+            @test collect(cb) == [1,2,3,4,5]
             @test capacity(cb) == 5
         end
 

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -50,10 +50,24 @@
         end
     end
 
-    @testset "other constructor" begin
-        cb = CircularBuffer(10)
-        @test length(cb) == 0
-        @test typeof(cb) <: CircularBuffer{Any}
+    @testset "other constructors" begin
+        @testset "capacity only" begin
+            cb = CircularBuffer(10)
+            @test length(cb) == 0
+            @test typeof(cb) <: CircularBuffer{Any}
+        end
+        @testset "from vec inferred type" begin
+            cb = CircularBuffer(1:5,10)
+            @test length(cb) == 5
+            @test typeof(cb) == CircularBuffer{Int}
+        end
+        @testset "from vec given type" begin
+            cb = CircularBuffer{Float64}(1:5,10)
+            @test length(cb) == 5
+            @test typeof(cb) == CircularBuffer{Float64}
+            @test collect(cb) == [1.0,2.0,3.0,4.0,5.0]
+        end
+
     end
 
     @testset "pushfirst" begin

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -67,6 +67,13 @@
             @test typeof(cb) == CircularBuffer{Float64}
             @test collect(cb) == [1.0,2.0,3.0,4.0,5.0]
         end
+        @testset "inferred capacity" begin
+            cb = CircularBuffer{Float64}(1:5)
+            @test length(cb) == 5
+            @test typeof(cb) == CircularBuffer{Float64}
+            @test collect(cb) == [1.0,2.0,3.0,4.0,5.0]
+            @test capacity(cb) == 5
+        end
 
     end
 


### PR DESCRIPTION
Adds constructors to Circular Buffer allowing a vector or other iterable to be in the buffer once initialized. Capacity is still required to be provided by the user and errors if the given capacity is less than the length of the given iterable. If no type parameter is given the eltype of the provided iterable is used. If one is provided the provided iterable is converted to that type (if possible, errors otherwise).

Existing constructors have changed slightly via new type restrictions.

Allows:
`CircularBuffer(1:5,10)`
`CircularBuffer{Float64}([1,2],100)`
`CircularBuffer((1,2.0,"hi"),20)`