### PR TITLE
Performance improvements to BinaryMinMaxHeap

### DIFF
--- a/test/test_minmax_heap.jl
+++ b/test/test_minmax_heap.jl
@@ -162,11 +162,11 @@ using Base.Order: Forward, Reverse
     end
 
     @testset "children_and_grandchildren tests" begin
-        @test children_and_grandchildren(1, 1) == Int[]
-        @test children_and_grandchildren(2, 1) == [2]
-        @test children_and_grandchildren(3, 1) == [2, 3]
-        @test children_and_grandchildren(7, 1) == [2, 4, 5, 3, 6, 7]
-        @test children_and_grandchildren(10, 2) == [4, 8, 9, 5, 10]
+        @test collect(children_and_grandchildren(1, 1)) == Int[]
+        @test collect(children_and_grandchildren(2, 1)) == [2]
+        @test collect(children_and_grandchildren(3, 1)) == [2, 3]
+        @test collect(children_and_grandchildren(7, 1)) == [2, 4, 5, 3, 6, 7]
+        @test collect(children_and_grandchildren(10, 2)) == [4, 8, 9, 5, 10]
     end
 
     @testset "throw errors tests" begin


### PR DESCRIPTION
Hi there! I was recently working on a project making heavy use of the min-max heap and found some performance improvements (primarily ditching allocating a particular array in `children_and_grandchildren`). You can checkout a benchmark below. Note, this does make a change to the return type of an internal method. Thanks for the great package and I'm happy to make any necessary changes!

## Benchmark

```julia
using DataStructures, Random

function test(
    h::DataStructures.BinayMinMaxHeap;
    maxlen = 10000,
    percent_push = 0.5,
    percent_pop_min = 0.5,
    max_consecutive = 100,
    numtests = 1_000_000,
)
    Random.seed!(12345)
    for _ in 1:numtests
        # push!
        if rand() <= percent_push
            num_to_push = rand(1:max_consecutive)
            for _ in 1:num_to_push
                length(h) == maxlen && break
                push!(h, rand(Int64))
            end
        # popmin!
        elseif rand() <= percent_pop_min
            num_to_pop = rand(1:max_consecutive)
            for _ in 1:num_to_pop
                isempty(h) && break
                DataStructures.popmin!(h)
            end
        # popmax!
        else
            num_to_pop = rand(1:max_consecutive)
            for _ in 1:num_to_pop
                isempty(h) && break
                DataStructures.popmax!(h)
            end
        end
    end
    return nothing
end

h = DataStructures.BinaryMinMaxHeap{Int64}()
@time test(h)
empty!(h)
@time test(h)
hash(h.valtree)
```

Before:
```
18.386442 seconds (390.30 M allocations: 25.079 GiB, 4.70% gc time, 1.14% compilation time)
18.100581 seconds (389.74 M allocations: 25.047 GiB, 4.53% gc time)
0x0f5972b24cef30f2
```

After:
```
4.455606 seconds (1.31 M allocations: 70.637 MiB, 0.45% gc time, 6.42% compilation time)
4.166581 seconds (4 allocations: 152 bytes)
0x0f5972b24cef30f2
```