### PR TITLE
Correct peek docstring

### DIFF
--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -119,7 +119,7 @@ Base.haskey(pq::PriorityQueue, key) = haskey(pq.index, key)
 """
     peek(pq)
 
-Return the lowest priority key from a priority queue without removing that
+Return the lowest priority key and value from a priority queue without removing that
 key from the queue.
 """
 Base.peek(pq::PriorityQueue) = pq.xs[1]


### PR DESCRIPTION
The docstring just stated that the key was returned, which is wrong and also disagrees with the [docs](http://juliacollections.github.io/DataStructures.jl/stable/priority-queue/)