### PR TITLE
Minor cleanups & performance enhancement

### DIFF
--- a/test/test_priority_queue.jl
+++ b/test/test_priority_queue.jl
@@ -196,6 +196,9 @@ import Base.Order.Reverse
             while !isempty(pq)
                 @test 10 != dequeue!(pq)
             end
+
+            pq = PriorityQueue(1.0 => 1)
+            @test dequeue!(pq, 1.0f0) isa Float64
         end
 
         @testset "dequeuing pair" begin


### PR DESCRIPTION
There are no large consequences here, just mostly janitorial. There is one functional change represented by the new test, that `dequeue!(pq, key)` is now guaranteed to return something of `keytype(pq)` (rather than just `key` directly). I *think* that's the right thing to do, but it probably already happens for the large majority of uses even without this precaution.