### PR TITLE
type default argument in SortedSet constructor

### DIFF
--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -18,7 +18,7 @@ array) and ordering object `o`. The ordering object defaults to
 mutable struct SortedSet{K, Ord <: Ordering} <: AbstractSet{K}
     bt::BalancedTree23{K,Nothing,Ord}
 
-    function SortedSet{K,Ord}(o::Ord=Forward, iter=[]) where {K,Ord<:Ordering}
+    function SortedSet{K,Ord}(o::Ord=Forward, iter=K[]) where {K,Ord<:Ordering}
         sorted_set = new{K,Ord}(BalancedTree23{K,Nothing,Ord}(o))
 
         for item in iter

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -18,7 +18,7 @@ array) and ordering object `o`. The ordering object defaults to
 mutable struct SortedSet{K, Ord <: Ordering} <: AbstractSet{K}
     bt::BalancedTree23{K,Nothing,Ord}
 
-    function SortedSet{K,Ord}(o::Ord=Forward, iter=K[]) where {K,Ord<:Ordering}
+    function SortedSet{K,Ord}(o::Ord=Forward, iter=Tuple{}()) where {K,Ord<:Ordering}
         sorted_set = new{K,Ord}(BalancedTree23{K,Nothing,Ord}(o))
 
         for item in iter


### PR DESCRIPTION
to avoid false positive by JET.@report_opt
```
using DataStructures
using JET

struct FP
  a::Int
end
Ordering = Lt( (fp1::FP, fp2::FP) -> fp1.a < fp2.a)
@report_opt SortedSet{FP}(Ordering )
═════ 1 possible error found ═════
┌ @ /home/wsl/.julia/packages/DataStructures/nBjdy/src/sorted_set.jl:71 Core.apply_type(DataStructures.SortedSet, _, _)(o)
│┌ @ /home/wsl/.julia/packages/DataStructures/nBjdy/src/sorted_set.jl:22 #self#(o, Base.vect())
││┌ @ /home/wsl/.julia/packages/DataStructures/nBjdy/src/sorted_set.jl:130 DataStructures.convert(FP, %23)
│││ runtime dispatch detected: DataStructures.convert(FP, %23::Any)
││└────────────────────────────────────────────────────────────────────────
```