### PR TITLE
Improve LinkedList `Base.map` performance by not having to reverse the list

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -79,7 +79,9 @@ function Base.map(f::Base.Callable, l::Cons{T}) where T
         push!(stack, head(l))
         l::Cons{T} = tail(l)::Cons{T}
     end
-    l2 = list(f(head(l)))  # Note this might have a different eltype than T
+    # Note the new list might have a different eltype than T
+    first = f(head(l))
+    l2 = cons(first, nil(typeof(first) <: T ? T : typeof(first)))
     for i in reverse(1:length(stack))
         l2 = cons(f(stack[i]), l2)
     end


### PR DESCRIPTION
I was curious about the Linked List implementation so I did a bit of profiling it, and I was surprised to see that `map()` was constructing a list twice:
<img width="1270" alt="Screen Shot 2021-10-16 at 10 58 41 AM" src="https://user-images.githubusercontent.com/1582097/137593377-11e8938d-4bbd-4098-acd1-81ae8d5308ab.png">
<img width="899" alt="Screen Shot 2021-10-16 at 10 58 54 AM" src="https://user-images.githubusercontent.com/1582097/137593389-b2fb3739-3bc1-4349-abd2-18a278e2e258.png">

So I first implemented it as the tail recursive map for linked lists (in fa11333), which improved things quite a bit:
Before:
```julia
julia> @Btime DataStructures.map(x->x*2, $(list((1:1000)...)));
  148.476 μs (6469 allocations: 163.55 KiB)
```
After:
```julia
julia> @Btime DataStructures.map(x->x*2, $(list((1:1000)...)));
  29.705 μs (1745 allocations: 42.89 KiB)
```
But that has this silly (if adorable) recursive call stack, which can of course StackOverflow (I had forgotten that julia [doesn't have Tail Call Optimization](https://discourse.julialang.org/t/tail-call-optimization-and-function-barrier-based-accumulation-in-loops/25831/12)):
<img width="1274" alt="Screen Shot 2021-10-16 at 10 58 12 AM" src="https://user-images.githubusercontent.com/1582097/137593426-85dfccc2-e139-4386-b16f-bb407e79e44a.png">
<img width="801" alt="Screen Shot 2021-10-16 at 10 58 48 AM" src="https://user-images.githubusercontent.com/1582097/137593452-f87c3f96-17fa-4a0a-a9dc-026305de6cef.png">

So I rewrote it into an iterative function, and magically that actually made it even faster still. I'm not exactly sure why, but i'll take it. :)

Before:
```julia
julia> @Btime DataStructures.map(x->x*2, $(list((1:1000)...)));
  29.705 μs (1745 allocations: 42.89 KiB)
```
After:
```julia
julia> @Btime DataStructures.map(x->x*2, $(list((1:1000)...)));
  13.139 μs (1011 allocations: 47.65 KiB)
```
<img width="1280" alt="Screen Shot 2021-10-16 at 11 37 21 AM" src="https://user-images.githubusercontent.com/1582097/137593528-bc355704-b1b7-4379-8586-b7e3e5002685.png">
<img width="1044" alt="Screen Shot 2021-10-16 at 11 46 00 AM" src="https://user-images.githubusercontent.com/1582097/137593799-c88f5853-4be5-4390-9c29-fe22b5d0b687.png">

Also, this let's us maintain the property that was added in PR #27, to allow `map()` to create a list with a different eltype.

----------------

(Note: All measurements taken on julia 1.6.3; visualizations with PProf.jl)