### PR TITLE
Remove `mutable` from LinkedList structs.

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -2,10 +2,9 @@ abstract type LinkedList{T} end
 
 Base.eltype(::Type{<:LinkedList{T}}) where T = T
 
-mutable struct Nil{T} <: LinkedList{T}
-end
+struct Nil{T} <: LinkedList{T} end
 
-mutable struct Cons{T} <: LinkedList{T}
+struct Cons{T} <: LinkedList{T}
     head::T
     tail::LinkedList{T}
 end


### PR DESCRIPTION
These types have always been meant to be treated as immutable structs,
but I think they were created long enough ago (https://github.com/JuliaCollections/DataStructures.jl/commit/5873750e976aa572b58d74da764478ec8c69e96f) that
 there wasn't an immutable/mutable distinction? o.O

And they were converted from `type` to `mutable struct` in an automatic
conversion via femtocleaner, here: https://github.com/JuliaCollections/DataStructures.jl/pull/321

In any case, these are clearly meant to be treated as immutable structs
and if they were created today they wouldn't be marked mutable, so this
fixes that.

There's no real performance impact, since you of course have to heap
allocate all the inner nodes anyway, but one can imagine that maybe
someone maintains hundreds or thousands of very small lists, and getting
to save that one extra allocation for the `head` maybe helps some. :)

This is mainly a theoretical cleanup.