### PR TITLE
Remove redundant docstring

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -106,11 +106,7 @@ Removes and returns the element at the top of the heap `h`.
 """
 Base.pop!(h::BinaryHeap) = heappop!(h.valtree, h.ordering)
 
-"""
-    sizehint!(h::BinaryHeap, n::Integer)
-
-Suggest that heap `h` reserve capacity for at least `n` elements. This can improve performance.
-"""
+# Suggest that heap `h` reserve capacity for at least `n` elements. This can improve performance.
 function Base.sizehint!(h::BinaryHeap, n::Integer)
     sizehint!(h.valtree, n)
     return h


### PR DESCRIPTION
The docstring for `sizehint!(h::BinaryHeap, n::Integer)` adds nothing that isn't already in the documentation for `sizehint!(s, n)`:
```julia
help?> sizehint!
search: sizehint!

  sizehint!(s, n)

  Suggest that collection s reserve capacity for at least n elements. This can improve performance.

  Notes on the performance model
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  For types that support sizehint!,

    1. push! and append! methods generally may (but are not required to) preallocate extra

  storage. For types implemented in Base, they typically do, using a heuristic optimized for a general use case.

    2. sizehint! may control this preallocation. Again, it typically does this for types in

  Base.

    3. empty! is nearly costless (and O(1)) for types that support this kind of preallocation.

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  sizehint!(h::BinaryHeap, n::Integer)

  Suggest that heap h reserve capacity for at least n elements. This can improve performance.
```