### PR TITLE
Fix type instabilities in AVL, RB and splay tree

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -57,6 +57,9 @@ module DataStructures
 
     export findkey
 
+    # _getproperty(x::Nothing, f::Symbol) = @assert false
+    _setproperty!(x::Nothing, f::Symbol, v) = @assert false
+
     include("delegate.jl")
 
     include("deque.jl")

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -57,9 +57,6 @@ module DataStructures
 
     export findkey
 
-    # _getproperty(x::Nothing, f::Symbol) = @assert false
-    _setproperty!(x::Nothing, f::Symbol, v) = @assert false
-
     include("delegate.jl")
 
     include("deque.jl")

--- a/src/avl_tree.jl
+++ b/src/avl_tree.jl
@@ -14,21 +14,12 @@ end
 
 AVLTreeNode(d) = AVLTreeNode{Any}(d)
 
-AVLTreeNode_or_null{T} = Union{AVLTreeNode{T}, Nothing}
-
-# _getproperty(x::AVLTreeNode{T}, f::Symbol) where {T} = getfield(x, f)
-# Base.getproperty(x::AVLTreeNode_or_null{T}, f::Symbol) where {T} =
-#     _getproperty(x, f)
-
 _setproperty!(x::AVLTreeNode{T}, f, v) where {T} =
-    # setfield!(x, f, convert(fieldtype(typeof(x), f), v))
     setfield!(x, f, v)
-_setproperty!(x::AVLTreeNode{T}, f, ::Nothing) where {T} =
-    setfield!(x, f, nothing)
-_setproperty!(x::AVLTreeNode{T}, f, v::AVLTreeNode{T}) where {T} =
-    setfield!(x, f, v)
-Base.setproperty!(x::AVLTreeNode_or_null{T}, f::Symbol, v) where {T} =
+Base.setproperty!(x::AVLTreeNode{T}, f::Symbol, v) where {T} =
     _setproperty!(x, f, v)
+
+AVLTreeNode_or_null{T} = Union{AVLTreeNode{T}, Nothing}
 
 mutable struct AVLTree{T}
     root::AVLTreeNode_or_null{T}

--- a/src/avl_tree.jl
+++ b/src/avl_tree.jl
@@ -14,10 +14,8 @@ end
 
 AVLTreeNode(d) = AVLTreeNode{Any}(d)
 
-_setproperty!(x::AVLTreeNode{T}, f, v) where {T} =
-    setfield!(x, f, v)
 Base.setproperty!(x::AVLTreeNode{T}, f::Symbol, v) where {T} =
-    _setproperty!(x, f, v)
+    setfield!(x, f, v)
 
 AVLTreeNode_or_null{T} = Union{AVLTreeNode{T}, Nothing}
 
@@ -45,7 +43,7 @@ end
 
 # computes the height of the subtree, which basically is
 # one added the maximum of the height of the left subtree and right subtree
-compute_height(node::AVLTreeNode) = Int8(1 + max(get_height(node.leftChild), get_height(node.rightChild)))
+compute_height(node::AVLTreeNode) = Int8(1) + max(get_height(node.leftChild), get_height(node.rightChild))
 
 get_subsize(node::AVLTreeNode_or_null) = (node == nothing) ? Int32(0) : node.subsize
 

--- a/src/avl_tree.jl
+++ b/src/avl_tree.jl
@@ -32,7 +32,7 @@ AVLTree() = AVLTree{Any}()
 
 Base.length(tree::AVLTree) = tree.count
 
-get_height(node::Union{AVLTreeNode, Nothing}) = (node == nothing) ? Int32(0) : node.height
+get_height(node::Union{AVLTreeNode, Nothing}) = (node == nothing) ? Int8(0) : node.height
 
 # balance is the difference of height between leftChild and rightChild of a node.
 function get_balance(node::Union{AVLTreeNode, Nothing})

--- a/src/avl_tree.jl
+++ b/src/avl_tree.jl
@@ -191,7 +191,7 @@ function Base.push!(tree::AVLTree{K}, key0) where K
     insert!(tree, key)
 end
 
-function delete_node!(node::AVLTreeNode{K}, key) where K
+function delete_node!(node::AVLTreeNode{K}, key::K) where K
     if key < node.data
         node.leftChild = delete_node!(node.leftChild, key)
     elseif key > node.data

--- a/src/avl_tree.jl
+++ b/src/avl_tree.jl
@@ -16,12 +16,10 @@ AVLTreeNode(d) = AVLTreeNode{Any}(d)
 
 AVLTreeNode_or_null{T} = Union{AVLTreeNode{T}, Nothing}
 
-_getproperty(x::Nothing, f) = @assert false
-_getproperty(x::AVLTreeNode{T}, f) where {T} = getfield(x, f)
-Base.getproperty(x::AVLTreeNode_or_null{T}, f::Symbol) where {T} =
-    _getproperty(x, f)
+# _getproperty(x::AVLTreeNode{T}, f::Symbol) where {T} = getfield(x, f)
+# Base.getproperty(x::AVLTreeNode_or_null{T}, f::Symbol) where {T} =
+#     _getproperty(x, f)
 
-_setproperty!(x::Nothing, f, v) = @assert false
 _setproperty!(x::AVLTreeNode{T}, f, v) where {T} =
     # setfield!(x, f, convert(fieldtype(typeof(x), f), v))
     setfield!(x, f, v)
@@ -30,8 +28,6 @@ _setproperty!(x::AVLTreeNode{T}, f, ::Nothing) where {T} =
 _setproperty!(x::AVLTreeNode{T}, f, v::AVLTreeNode{T}) where {T} =
     setfield!(x, f, v)
 Base.setproperty!(x::AVLTreeNode_or_null{T}, f::Symbol, v) where {T} =
-    _setproperty!(x, f, v)
-Base.setproperty!(x::AVLTreeNode_or_null{T}, f::Symbol, v::AVLTreeNode_or_null{T}) where {T} =
     _setproperty!(x, f, v)
 
 mutable struct AVLTree{T}

--- a/src/red_black_tree.jl
+++ b/src/red_black_tree.jl
@@ -17,10 +17,8 @@ end
 RBTreeNode() = RBTreeNode{Any}()
 RBTreeNode(d) = RBTreeNode{Any}(d)
 
-_setproperty!(x::RBTreeNode{K}, f, v) where {K} =
-    setfield!(x, f, v)
 Base.setproperty!(x::RBTreeNode{K}, f::Symbol, v) where {K} =
-    _setproperty!(x, f, v)
+    setfield!(x, f, v)
 
 function create_null_node(K::Type)
     node = RBTreeNode{K}()

--- a/src/red_black_tree.jl
+++ b/src/red_black_tree.jl
@@ -17,18 +17,9 @@ end
 RBTreeNode() = RBTreeNode{Any}()
 RBTreeNode(d) = RBTreeNode{Any}(d)
 
-# _getproperty(x::RBTreeNode{K}, f) where {K} = getfield(x, f)
-# Base.getproperty(x::Union{Nothing, RBTreeNode{K}}, f::Symbol) where {K} =
-#     _getproperty(x, f)
-
 _setproperty!(x::RBTreeNode{K}, f, v) where {K} =
-    # setfield!(x, f, convert(fieldtype(typeof(x), f), v))
     setfield!(x, f, v)
-_setproperty!(x::RBTreeNode{K}, f, ::Nothing) where {K} =
-    setfield!(x, f, nothing)
-_setproperty!(x::RBTreeNode{K}, f, v::RBTreeNode{K}) where {K} =
-    setfield!(x, f, v)
-Base.setproperty!(x::Union{Nothing, RBTreeNode{K}}, f::Symbol, v) where {K} =
+Base.setproperty!(x::RBTreeNode{K}, f::Symbol, v) where {K} =
     _setproperty!(x, f, v)
 
 function create_null_node(K::Type)

--- a/src/red_black_tree.jl
+++ b/src/red_black_tree.jl
@@ -17,6 +17,20 @@ end
 RBTreeNode() = RBTreeNode{Any}()
 RBTreeNode(d) = RBTreeNode{Any}(d)
 
+# _getproperty(x::RBTreeNode{K}, f) where {K} = getfield(x, f)
+# Base.getproperty(x::Union{Nothing, RBTreeNode{K}}, f::Symbol) where {K} =
+#     _getproperty(x, f)
+
+_setproperty!(x::RBTreeNode{K}, f, v) where {K} =
+    # setfield!(x, f, convert(fieldtype(typeof(x), f), v))
+    setfield!(x, f, v)
+_setproperty!(x::RBTreeNode{K}, f, ::Nothing) where {K} =
+    setfield!(x, f, nothing)
+_setproperty!(x::RBTreeNode{K}, f, v::RBTreeNode{K}) where {K} =
+    setfield!(x, f, v)
+Base.setproperty!(x::Union{Nothing, RBTreeNode{K}}, f::Symbol, v) where {K} =
+    _setproperty!(x, f, v)
+
 function create_null_node(K::Type)
     node = RBTreeNode{K}()
     node.color = false

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -11,12 +11,15 @@ end
 SplayTreeNode(d) = SplayTreeNode{Any}(d)
 SplayTreeNode() = SplayTreeNode{Any}()
 
+Base.setproperty!(x::SplayTreeNode{K}, f::Symbol, v) where {K} =
+    setfield!(x, f, v)
+
 mutable struct SplayTree{K}
     root::Union{SplayTreeNode{K}, Nothing}
     count::Int
 
     SplayTree{K}() where K = new{K}(nothing, 0)
-end 
+end
 
 Base.length(tree::SplayTree) = tree.count
 
@@ -41,7 +44,7 @@ function left_rotate!(tree::SplayTree, node_x::SplayTreeNode)
         node_y.leftChild = node_x
     end
     node_x.parent = node_y
-end    
+end
 
 function right_rotate!(tree::SplayTree, node_x::SplayTreeNode)
     node_y = node_x.leftChild
@@ -59,7 +62,7 @@ function right_rotate!(tree::SplayTree, node_x::SplayTreeNode)
     end
     node_y.rightChild = node_x
     node_x.parent = node_y
-end 
+end
 
 # The splaying operation moves node_x to the root of the tree using the series of rotations.
 function splay!(tree::SplayTree, node_x::SplayTreeNode)
@@ -71,7 +74,7 @@ function splay!(tree::SplayTree, node_x::SplayTreeNode)
             if node_x == parent.leftChild
                 # zig rotation
                 right_rotate!(tree, node_x.parent)
-            else 
+            else
                 # zag rotation
                 left_rotate!(tree, node_x.parent)
             end
@@ -104,7 +107,7 @@ function maximum_node(node::Union{SplayTreeNode, Nothing})
     return node
 end
 
-# Join operations joins two trees S and T 
+# Join operations joins two trees S and T
 # All the items in S are smaller than the items in T.
 # This is a two-step process.
 # In the first step, splay the largest node in S. This moves the largest node to the root node.
@@ -157,10 +160,10 @@ function Base.delete!(tree::SplayTree{K}, d::K) where K
     x = search_node(tree, d)
     (x == nothing) && return tree
     t = nothing
-    s = nothing 
-    
+    s = nothing
+
     splay!(tree, x)
-    
+
     if x.rightChild !== nothing
         t = x.rightChild
         t.parent = nothing
@@ -211,7 +214,7 @@ function Base.push!(tree::SplayTree{K}, d0) where K
     return tree
 end
 
-function Base.getindex(tree::SplayTree{K}, ind) where K 
+function Base.getindex(tree::SplayTree{K}, ind) where K
     @boundscheck (1 <= ind <= tree.count) || throw(KeyError("$ind should be in between 1 and $(tree.count)"))
     function traverse_tree_inorder(node::Union{SplayTreeNode, Nothing})
         if (node != nothing)
@@ -222,6 +225,6 @@ function Base.getindex(tree::SplayTree{K}, ind) where K
             return K[]
         end
     end
-    arr = traverse_tree_inorder(tree.root) 
+    arr = traverse_tree_inorder(tree.root)
     return @inbounds arr[ind]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ tests = ["deprecations",
          "dibit_vector",
          "swiss_dict",
          "avl_tree",
-         "red_black_tree", 
+         "red_black_tree",
          "splay_tree"
         ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,9 @@ using Serialization
 
 import DataStructures: IntSet
 
-@test [] == detect_ambiguities(Base, Core, DataStructures)
+# These fail due to setproperty! specializations for AVL and RB tree.
+# @test [] == detect_ambiguities(Core, DataStructures)
+# @test [] == detect_ambiguities(Base, DataStructures)
 
 tests = ["deprecations",
          "int_set",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,8 @@ using Serialization
 
 import DataStructures: IntSet
 
-# These fail due to setproperty! specializations for AVL and RB tree.
-# @test [] == detect_ambiguities(Core, DataStructures)
-# @test [] == detect_ambiguities(Base, DataStructures)
+@test [] == detect_ambiguities(Core, DataStructures)
+@test [] == detect_ambiguities(Base, DataStructures)
 
 tests = ["deprecations",
          "int_set",

--- a/test/test_avl_tree.jl
+++ b/test/test_avl_tree.jl
@@ -26,7 +26,7 @@
         end
 
         @test length(t) == 50
-        
+
         for i in 1:100
             if iseven(i)
                 @test haskey(t, i)
@@ -43,19 +43,19 @@
     end
 
     @testset "handling different cases of delete!" begin
-        t2 = AVLTree()
+        t2 = AVLTree{Int}()
         for i in 1:100000
             insert!(t2, i)
         end
 
         @test length(t2) == 100000
-        
+
         nums = rand(1:100000, 8599)
         visited = Set()
-        for num in nums 
+        for num in nums
             if !(num in visited)
                 delete!(t2, num)
-                push!(visited, num) 
+                push!(visited, num)
             end
         end
 
@@ -67,7 +67,7 @@
 
     @testset "handling different cases of insert!" begin
         nums = rand(1:100000, 1000)
-        t3 = AVLTree()
+        t3 = AVLTree{Int}()
         uniq_nums = Set(nums)
         for num in uniq_nums
             insert!(t3, num)
@@ -84,20 +84,20 @@
         @test !in('c', t4)
     end
 
-    @testset "search_node" begin 
-        t5 = AVLTree()
+    @testset "search_node" begin
+        t5 = AVLTree{Int}()
         for i in 1:32
             push!(t5, i)
         end
         n1 = search_node(t5, 21)
         @test n1.data == 21
         n2 = search_node(t5, 35)
-        @test n2.data == 32 
+        @test n2.data == 32
         n3 = search_node(t5, 0)
         @test n3.data == 1
-    end 
+    end
 
-    @testset "getindex" begin 
+    @testset "getindex" begin
         t6 = AVLTree{Int}()
         for i in 1:10
             push!(t6, i)
@@ -117,7 +117,7 @@
     end
 
     @testset "minimum_node" begin
-        t8 = AVLTree()
+        t8 = AVLTree{Int}()
         @test minimum_node(t8.root) == nothing
         for i in 1:32
             push!(t8, i)
@@ -132,7 +132,7 @@
         end
     end
 
-    @testset "rank" begin 
+    @testset "rank" begin
         t9 = AVLTree{Int}()
         for i in 1:20
             push!(t9, i)


### PR DESCRIPTION
Improves benchmark results for
https://github.com/JuliaCollections/DataStructures.jl/issues/762

v0.18.10

100000 elements
  DataStructures.AVLTree                   6.061 s (7102520 allocations: 114.48 MiB)
1000 elements
  DataStructures.AVLTree                   36.800 ms (28637 allocations: 509.97 KiB)
10 elements
  DataStructures.AVLTree                   134.361 μs (102 allocations: 2.23 KiB)

v0.19.0-DEV

100000 elements
  DataStructures.AVLTree                   6.113 s (7102520 allocations: 114.48 MiB)
1000 elements
  DataStructures.AVLTree                   36.298 ms (28637 allocations: 509.97 KiB)
10 elements
  DataStructures.AVLTree                   130.629 μs (102 allocations: 2.23 KiB)

Now:

100000 elements
  DataStructures.AVLTree                   213.450 ms (200002 allocations: 9.16 MiB)
1000 elements
  DataStructures.AVLTree                   1.408 ms (2002 allocations: 93.80 KiB)
10 elements
  DataStructures.AVLTree                   7.814 μs (22 allocations: 1008 bytes)