### PR TITLE
Add (`keys()` and) `values()` interfaces for (mutable) binary heaps

### DIFF
--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -23,6 +23,8 @@ extract_all!(h)      # removes all elements and returns sorted array
 
 extract_all_rev!(h)  # removes all elements and returns reverse sorted array
 
+values(h)            # returns the elements of the heap in an arbitrary order
+
 sizehint!(h, n)      # reserve capacity for at least `n` elements
 ```
 
@@ -40,6 +42,8 @@ update!(h, i, v)           # updates the value of an element (referred to by the
 delete!(h, i)              # deletes the node with handle i from the heap
 
 v, i = top_with_handle(h)  # returns the top value of a heap and its handle
+
+ks = keys(h)               # returns the handles associated with the heap in an arbitrary order
 ```
 
 Currently, both min/max versions of binary heap (type `BinaryHeap`) and

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -25,7 +25,7 @@ module DataStructures
     export FenwickTree, length, inc!, dec!, incdec!, prefixsum
 
     export AbstractHeap, compare, extract_all!, extract_all_rev!
-    export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest, drain, drain!
+    export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
     export MutableBinaryHeap, MutableBinaryMinHeap, MutableBinaryMaxHeap
     export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -25,7 +25,7 @@ module DataStructures
     export FenwickTree, length, inc!, dec!, incdec!, prefixsum
 
     export AbstractHeap, compare, extract_all!, extract_all_rev!
-    export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest
+    export BinaryHeap, BinaryMinHeap, BinaryMaxHeap, nlargest, nsmallest, drain, drain!
     export MutableBinaryHeap, MutableBinaryMinHeap, MutableBinaryMaxHeap
     export heapify!, heapify, heappop!, heappush!, isheap
     export BinaryMinMaxHeap, popmin!, popmax!, popall!

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -106,6 +106,20 @@ Removes and returns the element at the top of the heap `h`.
 """
 Base.pop!(h::BinaryHeap) = heappop!(h.valtree, h.ordering)
 
+"""
+    drain(h::BinaryHeap)
+
+Returns the elements of the heap in an arbitrary order.
+"""
+drain(h::BinaryHeap) = h.valtree
+
+"""
+    drain!(h::BinaryHeap)
+
+Removes and returns the elements of the heap in an arbitrary order.
+"""
+drain!(h::BinaryHeap) = [pop!(h.valtree) for _ in 1:length(h)]
+
 # Suggest that heap `h` reserve capacity for at least `n` elements. This can improve performance.
 function Base.sizehint!(h::BinaryHeap, n::Integer)
     sizehint!(h.valtree, n)

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -107,18 +107,11 @@ Removes and returns the element at the top of the heap `h`.
 Base.pop!(h::BinaryHeap) = heappop!(h.valtree, h.ordering)
 
 """
-    drain(h::BinaryHeap)
+    values(h::BinaryHeap)
 
 Returns the elements of the heap in an arbitrary order.
 """
-drain(h::BinaryHeap) = h.valtree
-
-"""
-    drain!(h::BinaryHeap)
-
-Removes and returns the elements of the heap in an arbitrary order.
-"""
-drain!(h::BinaryHeap) = [pop!(h.valtree) for _ in 1:length(h)]
+Base.values(h::BinaryHeap) = h.valtree
 
 # Suggest that heap `h` reserve capacity for at least `n` elements. This can improve performance.
 function Base.sizehint!(h::BinaryHeap, n::Integer)

--- a/src/heaps/minmax_heap.jl
+++ b/src/heaps/minmax_heap.jl
@@ -232,25 +232,14 @@ Remove up to the `k` largest values from the heap.
     return [popmax!(h) for _ in 1:min(length(h), k)]
 end
 
+
 """
-    drain(h::BinaryMinMaxHeap)
+    values(h::BinaryMinMaxHeap)
 
 Returns the elements of the heap in an arbitrary order.
 """
-drain(h::BinaryMinMaxHeap) = h.valtree
+Base.values(h::BinaryMinMaxHeap) = h.valtree
 
-"""
-    drain!(h::BinaryMinMaxHeap)
-
-Removes and returns the elements of the heap in an arbitrary order.
-"""
-drain!(h::BinaryMinMaxHeap) = [pop!(h.valtree) for _ in 1:length(h)]
-
-function Base.push!(h::BinaryMinMaxHeap, v)
-    valtree = h.valtree
-    push!(valtree, v)
-    @inbounds _minmax_heap_bubble_up!(valtree, length(valtree))
-end
 
 """
     first(h::BinaryMinMaxHeap)

--- a/src/heaps/minmax_heap.jl
+++ b/src/heaps/minmax_heap.jl
@@ -232,6 +232,11 @@ Remove up to the `k` largest values from the heap.
     return [popmax!(h) for _ in 1:min(length(h), k)]
 end
 
+function Base.push!(h::BinaryMinMaxHeap, v)
+    valtree = h.valtree
+    push!(valtree, v)
+    @inbounds _minmax_heap_bubble_up!(valtree, length(valtree))
+end
 
 """
     values(h::BinaryMinMaxHeap)

--- a/src/heaps/minmax_heap.jl
+++ b/src/heaps/minmax_heap.jl
@@ -232,6 +232,19 @@ Remove up to the `k` largest values from the heap.
     return [popmax!(h) for _ in 1:min(length(h), k)]
 end
 
+"""
+    drain(h::BinaryMinMaxHeap)
+
+Returns the elements of the heap in an arbitrary order.
+"""
+drain(h::BinaryMinMaxHeap) = h.valtree
+
+"""
+    drain!(h::BinaryMinMaxHeap)
+
+Removes and returns the elements of the heap in an arbitrary order.
+"""
+drain!(h::BinaryMinMaxHeap) = [pop!(h.valtree) for _ in 1:length(h)]
 
 function Base.push!(h::BinaryMinMaxHeap, v)
     valtree = h.valtree

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -247,6 +247,20 @@ end
 Base.pop!(h::MutableBinaryHeap{T}) where {T} = _binary_heap_pop!(h.ordering, h.nodes, h.node_map)
 
 """
+    keys(h::MutableBinaryHeap)
+
+Returns the handles of the heap in an arbitrary order.
+"""
+Base.keys(h::MutableBinaryHeap) = h.node_map
+
+"""
+    values(h::MutableBinaryHeap)
+
+Returns an iterator over the elements of the heap in an arbitrary order.
+"""
+Base.values(h::MutableBinaryHeap) = (h.nodes[i].value for i in h.node_map)
+
+"""
     update!{T}(h::MutableBinaryHeap{T}, i::Int, v::T)
 
 Replace the element at index `i` in heap `h` with `v`.

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -89,6 +89,11 @@
             @test reverse(sort(vs)) == extract_all_rev!(BinaryMinHeap(vs))
         end
 
+        @testset "drain" begin
+            @test sort(vs) == sort(drain(BinaryMinHeap(vs)))
+            @test sort(vs) == sort(drain!(BinaryMinHeap(vs)))
+        end
+
         @testset "push!" begin
             @testset "push! hmin" begin
                 hmin = BinaryMinHeap{Int}()

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -89,9 +89,8 @@
             @test reverse(sort(vs)) == extract_all_rev!(BinaryMinHeap(vs))
         end
 
-        @testset "drain" begin
-            @test sort(vs) == sort(drain(BinaryMinHeap(vs)))
-            @test sort(vs) == sort(drain!(BinaryMinHeap(vs)))
+        @testset "values" begin
+            @test sort(vs) == sort(values(BinaryMinHeap(vs)))
         end
 
         @testset "push!" begin

--- a/test/test_minmax_heap.jl
+++ b/test/test_minmax_heap.jl
@@ -114,6 +114,13 @@ using Base.Order: Forward, Reverse
         end
     end
 
+    @testset "drain" begin
+        vs = [10, 4, 6, 1, 16, 2, 20, 17, 13, 5]
+
+        @test sort(vs) == sort(drain(BinaryMinMaxHeap{Int}(vs)))
+        @test sort(vs) == sort(drain!(BinaryMinMaxHeap{Int}(vs)))
+    end
+
     @testset "empty!" begin
         h = BinaryMinMaxHeap([1, 4, 3, 10, 2])
         ret = empty!(h)

--- a/test/test_minmax_heap.jl
+++ b/test/test_minmax_heap.jl
@@ -114,11 +114,10 @@ using Base.Order: Forward, Reverse
         end
     end
 
-    @testset "drain" begin
+    @testset "values" begin
         vs = [10, 4, 6, 1, 16, 2, 20, 17, 13, 5]
 
-        @test sort(vs) == sort(drain(BinaryMinMaxHeap{Int}(vs)))
-        @test sort(vs) == sort(drain!(BinaryMinMaxHeap{Int}(vs)))
+        @test sort(vs) == sort(values(BinaryMinMaxHeap{Int}(vs)))
     end
 
     @testset "empty!" begin

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -113,6 +113,8 @@ end
         @test isequal(list_values(h), vs)
         @test isequal(heap_values(h), [16, 14, 10, 8, 7, 3, 9, 1, 4, 2])
         @test sizehint!(h, 100) === h
+        @test sort(vs) == sort(collect(values(h)))
+        @test 1:length(h) == sort(keys(h))
     end
 
     @testset "make mutable binary custom ordering heap" begin


### PR DESCRIPTION
Occasionally we need to iterate through *all* of the elements of a heap but don't care about the order. In this situation, using `extract_all!(h)` is wasteful because it costs `O(n log n)` to return the elements in sorted order (and also mutates the heap). In DataStructures.jl, accessing `h.valtree` directly is more efficient at `O(n)`; however, this field is not documented.

This PR adds the more Julian interface `Base.values(h) = h.valtree` for `BinaryHeap`s and `BinaryMinMaxHeaps`.

````julia
julia> using DataStructures

julia> h = BinaryMaxHeap(rand(5))
BinaryMaxHeap{Float64}(Base.Order.ReverseOrdering{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering()), [0.9829465592187847, 0.8428991971652844, 0.7707265509429536, 0.47963097130235544, 0.17748799914754054])

julia> values(h)
5-element Vector{Float64}:
 0.9829465592187847
 0.8428991971652844
 0.7707265509429536
 0.47963097130235544
 0.17748799914754054

julia> h = BinaryMinMaxHeap(rand(5))
BinaryMinMaxHeap{Float64}([0.025268923626285966, 0.8282336623952297, 0.976681573216973, 0.14183939323945371, 0.6669349808193425])

julia> values(h)
5-element Vector{Float64}:
 0.025268923626285966
 0.8282336623952297
 0.976681573216973
 0.14183939323945371
 0.6669349808193425
````

For `MutableBinaryHeaps`, it also adds `Base.keys(h) = h.node_map` and `Base.values(h)` which returns an *iterator* over the values.

````julia
julia> h = MutableBinaryMaxHeap(rand(5))
MutableBinaryHeap(0.9872660968754716, 0.8597302788167083, 0.7713500693829297, 0.600486099809733, 0.7149676391647972)

julia> keys(h)
5-element Vector{Int64}:
 4
 3
 2
 5
 1

julia> values(h)
Base.Generator{Vector{Int64}, DataStructures.var"#3#4"{MutableBinaryMaxHeap{Float64}}}(DataStructures.var"#3#4"{MutableBinaryMaxHeap{Float64}}(MutableBinaryHeap(0.9872660968754716, 0.8597302788167083, 0.7713500693829297, 0.600486099809733, 0.7149676391647972)), [4, 3, 2, 5, 1])

julia> Dict(zip(keys(h), values(h)))
Dict{Int64, Any} with 5 entries:
  5 => 0.714968
  4 => 0.600486
  2 => 0.85973
  3 => 0.77135
  1 => 0.987266
````

I have included unit tests and documentation.

(This is my first time submitting a pull request on GitHub. I have made every effort to follow the contrib guide, but I apologize in advance if I have done anything wrong. The first commit in my fork mentions the names `drain()` and `drain!()`, which are the names used for this operation in Rust, but I renamed them in a subsequent commit to match similar Julia built-ins.)