### PR TITLE
Another fix for MutableLinkedList append!

### DIFF
--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -151,6 +151,9 @@ function Base.setindex!(l::MutableLinkedList{T}, data, idx::Int) where T
 end
 
 function Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T
+    if isempty(l2)
+        return l1
+    end
     l1.node.prev.next = l2.node.next # l1's last's next is now l2's first
     l1.node.prev = l2.node.prev.next # l1's last node is now l2's last node
     l2.node.prev.next = l1.node # l2's last's next is now l1.node

--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -152,6 +152,7 @@ end
 
 function Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T
     l1.node.prev.next = l2.node.next # l1's last's next is now l2's first
+    l1.node.prev = l2.node.prev.next # l1's last node is now l2's last node
     l2.node.prev.next = l1.node # l2's last's next is now l1.node
     l1.len += length(l2)
     return l1

--- a/test/test_mutable_list.jl
+++ b/test/test_mutable_list.jl
@@ -99,6 +99,7 @@
                     append!(l, l2)
                     @test l == MutableLinkedList{Int}(1:2n...)
                     @test collect(l) == collect(MutableLinkedList{Int}(1:2n...))
+                    @test last(l) == 2n
                     l3 = MutableLinkedList{Int}(1:n...)
                     append!(l3, n+1:2n...)
                     @test l3 == MutableLinkedList{Int}(1:2n...)


### PR DESCRIPTION
The previous implementation of `append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T})` failed to update the reference for the last node of l1. This resulted in bugs, e.g.
```jl
julia> l1, l2 = MutableLinkedList{Int}(1, 2), MutableLinkedList{Int}(3, 4)
(MutableLinkedList{Int64}(1, 2), MutableLinkedList{Int64}(3, 4))

julia> append!(l1, l2) 
MutableLinkedList{Int64}(1, 2, 3, 4)

julia> last(l1) 
2 # should be 4
```
