### PR TITLE
Fix docs: switch "disjoint set" to "disjoint sets" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package implements a variety of data structures, including
 -   Priority Queue
 -   Fenwick Tree
 -   Accumulators and Counters (i.e. Multisets / Bags)
--   Disjoint-Set
+-   Disjoint-Sets
 -   Binary Heap
 -   Mutable Binary Heap
 -   Ordered Dicts and Sets

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
         "priority-queue.md",
         "fenwick.md",
         "accumulators.md",
-        "disjoint_set.md",
+        "disjoint_sets.md",
         "heaps.md",
         "ordered_containers.md",
         "default_dict.md",

--- a/docs/src/disjoint_sets.md
+++ b/docs/src/disjoint_sets.md
@@ -1,15 +1,15 @@
-# Disjoint-Set
+# Disjoint-Sets
 
 Some algorithms, such as finding connected components in undirected
 graph and Kruskal's method of finding minimum spanning tree, require a
 data structure that can efficiently represent a collection of disjoint
 subsets. A widely used data structure for this purpose is the *Disjoint
-set forest*.
+set forest* (disjoint sets).
 
 Usage:
 
 ```julia
-a = IntDisjointSet(10)  # creates a forest comprised of 10 singletons
+a = IntDisjointSets(10)  # creates a forest comprised of 10 singletons
 union!(a, 3, 5)          # merges the sets that contain 3 and 5 into one and returns the root of the new set
 root_union!(a, x, y)     # merges the sets that have root x and y into one and returns the root of the new set
 find_root!(a, 3)          # finds the root element of the subset that contains 3
@@ -21,14 +21,14 @@ elem = push!(a)          # adds a single element in a new set; returns the new e
 One may also use other element types:
 
 ```julia
-a = DisjointSet{AbstractString}(["a", "b", "c", "d"])
+a = DisjointSets{AbstractString}(["a", "b", "c", "d"])
 union!(a, "a", "b")
 in_same_set(a, "c", "d")
 push!(a, "f")
 ```
 
-Note that the internal implementation of `IntDisjointSet` is based on
-vectors, and is very efficient. `DisjointSet{T}` is a wrapper of
-`IntDisjointSet`, which uses a dictionary to map input elements to an
-internal index. Note for `DisjointSet`, `union!`, `root_union!` and
+Note that the internal implementation of `IntDisjointSets` is based on
+vectors, and is very efficient. `DisjointSets{T}` is a wrapper of
+`IntDisjointSets`, which uses a dictionary to map input elements to an
+internal index. Note for `DisjointSets`, `union!`, `root_union!` and
 `find_root!` return the index of the root.


### PR DESCRIPTION
This is a docs-only PR to change occurrences of "disjoint set" to "disjoint sets" in the docs. Should close #740.

This also happens to fix a slight bug that the table of contents didn't show the page for Disjoint Sets, since the name of link was changed (but the name of the actual doc file was not yet changed).