### PR TITLE
setindex! returns priority queue

### DIFF
--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -247,7 +247,7 @@ function Base.setindex!(pq::PriorityQueue{K, V}, value, key) where {K,V}
     else
         push!(pq, key=>value)
     end
-    return value
+    return pq
 end
 
 """


### PR DESCRIPTION
To follow the abstract dictionary API, `setindex!` shall return the priority queue when applied to such objects. This also fixes pushing of multiple items with `push!` on a priority queue.