### PR TITLE
Add setsize to disjoint set

### DIFF
--- a/docs/src/disjoint_sets.md
+++ b/docs/src/disjoint_sets.md
@@ -16,6 +16,7 @@ find_root!(a, 3)          # finds the root element of the subset that contains 3
 in_same_set(a, x, y)     # determines whether x and y are in the same set
 elem = push!(a)          # adds a single element in a new set; returns the new element
                          # (this operation is often called MakeSet)
+setsize(a, x)            # finds the size of the set that x is in
 ```
 
 One may also use other element types:

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -24,7 +24,7 @@ module DataStructures
     export capacity, num_blocks, top_with_handle, sizehint!
 
     export Accumulator, counter, reset!, inc!, dec!
-    export IntDisjointSet, DisjointSet, num_groups, find_root!, in_same_set, root_union!
+    export IntDisjointSet, DisjointSet, num_groups, find_root!, in_same_set, root_union!, setsize
     export FenwickTree, length, inc!, dec!, incdec!, prefixsum
 
     export AbstractHeap, compare, extract_all!, extract_all_rev!


### PR DESCRIPTION
This addresses #297.  I've saw that there was progress on it in #298, but that seems stale now.

I believe that having the `size` attribute makes the `rank` attribute a little redundant, as we can modify the code to use union by size instead of union by rank.  I'll wait for your opinion on it though before implementing that.

The Julia Formatter [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) made some formatting changes, in particular to the test file.  I didn't intend to do that and can reverse those changes if you wish