### PR TITLE
Add num_groups for DisjointSets to documentation

### DIFF
--- a/docs/src/disjoint_sets.md
+++ b/docs/src/disjoint_sets.md
@@ -12,10 +12,11 @@ Usage:
 a = IntDisjointSets(10)  # creates a forest comprised of 10 singletons
 union!(a, 3, 5)          # merges the sets that contain 3 and 5 into one and returns the root of the new set
 root_union!(a, x, y)     # merges the sets that have root x and y into one and returns the root of the new set
-find_root!(a, 3)          # finds the root element of the subset that contains 3
+find_root!(a, 3)         # finds the root element of the subset that contains 3
 in_same_set(a, x, y)     # determines whether x and y are in the same set
 elem = push!(a)          # adds a single element in a new set; returns the new element
                          # (this operation is often called MakeSet)
+num_groups(a)            # returns the number of sets
 ```
 
 One may also use other element types:


### PR DESCRIPTION
I was doing Advent of Code and had trouble finding this function, so I think it should be in the documentation. As an aside, not sure if it should say "return the number of _groups_" or the number of _sets_. 