### PR TITLE
fix: check key values, not `get` return for haskey(k, orderedrobindict)

### DIFF
--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -305,8 +305,8 @@ julia> haskey(D, 'c')
 false
 ```
 """
-Base.haskey(h::OrderedRobinDict, key) = key in h.keys
-Base.in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedRobinDict{K}} = key in v.dict.keys
+Base.haskey(h::OrderedRobinDict, key) = (get(h.dict, key, -1) > 0)
+Base.in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedRobinDict{K}} = (get(v.dict.dict, key, -1) >= 0)
 
 """(get(h.dict, key, -2) > 0)
     getkey(collection, key, default)

--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -308,7 +308,7 @@ false
 Base.haskey(h::OrderedRobinDict, key) = (get(h.dict, key, -1) > 0)
 Base.in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedRobinDict{K}} = (get(v.dict.dict, key, -1) >= 0)
 
-"""(get(h.dict, key, -2) > 0)
+"""
     getkey(collection, key, default)
 
 Return the key matching argument `key` if one exists in `collection`, otherwise return `default`.

--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -305,10 +305,10 @@ julia> haskey(D, 'c')
 false
 ```
 """
-Base.haskey(h::OrderedRobinDict, key) = (get(h.dict, key, -2) > 0)
-Base.in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedRobinDict{K}} = (get(v.dict, key, -1) >= 0)
+Base.haskey(h::OrderedRobinDict, key) = key in h.keys
+Base.in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedRobinDict{K}} = key in v.dict.keys
 
-"""
+"""(get(h.dict, key, -2) > 0)
     getkey(collection, key, default)
 
 Return the key matching argument `key` if one exists in `collection`, otherwise return `default`.

--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -132,7 +132,7 @@ function Base.setindex!(h::OrderedRobinDict{K, V}, v0, key0) where {K,V}
     else
         @assert haskey(h, key0)
         @inbounds orig_v = h.vals[index]
-        (orig_v != v0) && (@inbounds h.vals[index] = v0)
+        !isequal(orig_v, v0) && (@inbounds h.vals[index] = v0)
     end
 
     check_for_rehash(h) && rehash!(h)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,8 @@ import DataStructures: IntSet
 @test [] == detect_ambiguities(Core, DataStructures)
 @test [] == detect_ambiguities(Base, DataStructures)
 
-tests = ["deprecations",
+tests = [
+         "deprecations",
          "int_set",
          "sparse_int_set",
          "deque",

--- a/test/test_ordered_robin_dict.jl
+++ b/test/test_ordered_robin_dict.jl
@@ -139,6 +139,8 @@
         @test h["a","b"] == h[("a","b")] == 4
         h["a","b","c"] = 4
         @test h["a","b","c"] == h[("a","b","c")] == 4
+        h["b"] = missing
+        @test 5 == (h["b"] = 5)
     end
 
     @testset "KeyError" begin

--- a/test/test_ordered_robin_dict.jl
+++ b/test/test_ordered_robin_dict.jl
@@ -31,10 +31,10 @@
 
         # access, modification
         for c in 'a':'z'
-            d[c] = c - 'a' + 1
+            d[c] = c - 'a' - 2
         end
 
-        @test (d['a'] += 1) == 2
+        @test (d['a'] += 1) == -1
         @test 'a' in keys(d)
         @test haskey(d, 'a')
         @test get(d, 'B', 0) == 0
@@ -42,11 +42,11 @@
         @test getkey(d, 'B', nothing) == nothing
         @test !('B' in keys(d))
         @test !haskey(d, 'B')
-        @test pop!(d, 'a') == 2
+        @test pop!(d, 'a') == -1
 
         @test collect(keys(d)) == collect('b':'z')
-        @test collect(values(d)) == collect(2:26)
-        @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
+        @test collect(values(d)) == collect(-1:23)
+        @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', -1:23)]
     end
 
     @testset "convert" begin

--- a/test/test_ordered_robin_dict.jl
+++ b/test/test_ordered_robin_dict.jl
@@ -31,10 +31,10 @@
 
         # access, modification
         for c in 'a':'z'
-            d[c] = c - 'a' - 2
+            d[c] = c - 'a' + 1
         end
 
-        @test (d['a'] += 1) == -1
+        @test (d['a'] += 1) == 2
         @test 'a' in keys(d)
         @test haskey(d, 'a')
         @test get(d, 'B', 0) == 0
@@ -42,11 +42,11 @@
         @test getkey(d, 'B', nothing) == nothing
         @test !('B' in keys(d))
         @test !haskey(d, 'B')
-        @test pop!(d, 'a') == -1
+        @test pop!(d, 'a') == 2
 
         @test collect(keys(d)) == collect('b':'z')
-        @test collect(values(d)) == collect(-1:23)
-        @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', -1:23)]
+        @test collect(values(d)) == collect(2:26)
+        @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
     end
 
     @testset "convert" begin
@@ -76,6 +76,13 @@
         od60[14]=15
 
         @test od60[14] == 15
+    end
+
+    @testset "Fixes issue 857" begin
+        h = OrderedRobinDict{Any,Any}([("a", missing), ("b", -2)])
+        @test 5 == (h["a"] = 5)
+        @test "b" in keys(h)
+        @test haskey(h,"b")
     end
 
 
@@ -139,8 +146,6 @@
         @test h["a","b"] == h[("a","b")] == 4
         h["a","b","c"] = 4
         @test h["a","b","c"] == h[("a","b","c")] == 4
-        h["b"] = missing
-        @test 5 == (h["b"] = 5)
     end
 
     @testset "KeyError" begin


### PR DESCRIPTION
Resolves #857 

I am not sure if checking if the key appears in the key vector property is the right way to go. Open to another solution!