### PR TITLE
do not drop repeat keys in Accumulate(::Pairs...)

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -14,7 +14,13 @@ end
 
 Accumulator{T, V}() where {T, V} = Accumulator{T, V}(Dict{T, V}())
 Accumulator(map::AbstractDict) = Accumulator(Dict(map))
-Accumulator(ps::Pair...) = Accumulator(Dict(ps))
+function Accumulator(p::Pair, ps::Pair...)
+    a = Accumulator(Dict(p))
+    for (k,v) in ps
+        inc!(a, k, v)
+    end
+    a
+end
 
 counter(T::Type) = Accumulator{T, Int}()
 counter(dct::AbstractDict{T, V}) where {T, V<:Integer} = Accumulator{T, V}(Dict(dct))

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -51,7 +51,7 @@
         @test sum(ct) == 6
     end
 
-    @testset "From Pairs" begin 
+    @testset "From Pairs" begin
         acc = Accumulator("a" => 2, "b" => 3, "c" => 1)
         @test isa(acc,Accumulator{String,Int})
         @test haskey(acc,"a")
@@ -60,6 +60,15 @@
         @test acc["a"] == 2
         @test acc["b"] == 3
         @test acc["c"] == 1
+    end
+
+    @testset "From Pairs with repeats" begin
+        acc = Accumulator("a" => 2, "b" => 3, "b" => 1)
+        @test isa(acc,Accumulator{String,Int})
+        @test haskey(acc,"a")
+        @test haskey(acc,"b")
+        @test acc["a"] == 2
+        @test acc["b"] == 4
     end
 
     @testset "From Vector" begin


### PR DESCRIPTION
Previously the `Accumulator(::Pairs...)` constructor first converted the sequence to a `Dict`, thus dropping repeated keys, which seemed counter what I would expect an accumulator to do (e.g. when used with a generator).