### PR TITLE
remove eltype definition from SortedDict and SortedSet

### DIFF
--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -81,7 +81,8 @@ function SortedDict(o::Ordering, kv)
     else
         throw(ArgumentError("In SortedDict(o,kv), kv should contain either pairs or 2-tuples"))
     end
-    SortedDict{eltype(c2).parameters[1], eltype(c2).parameters[2], typeof(o)}(o, c2)
+    SortedDict{
+                (c2).parameters[1], eltype(c2).parameters[2], typeof(o)}(o, c2)
 end
 SortedDict{K,D}(iter, o::Ordering=Forward) where {K, D} =
     SortedDict{K,D,typeof(o)}(o, iter)
@@ -231,11 +232,8 @@ end
 
 
 @inline Base.eltype(m::SortedDict{K,D,Ord}) where {K,D,Ord <: Ordering} =  Pair{K,D}
-@inline Base.eltype(::Type{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} =  Pair{K,D}
 @inline Base.keytype(m::SortedDict{K,D,Ord}) where {K,D,Ord <: Ordering} = K
-@inline Base.keytype(::Type{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} = K
 @inline Base.valtype(m::SortedDict{K,D,Ord}) where {K,D,Ord <: Ordering} = D
-@inline Base.valtype(::Type{SortedDict{K,D,Ord}}) where {K,D,Ord <: Ordering} = D
 
 """
     Base.in(p::Pair, sd::SortedDict)

--- a/src/sorted_dict.jl
+++ b/src/sorted_dict.jl
@@ -81,8 +81,7 @@ function SortedDict(o::Ordering, kv)
     else
         throw(ArgumentError("In SortedDict(o,kv), kv should contain either pairs or 2-tuples"))
     end
-    SortedDict{
-                (c2).parameters[1], eltype(c2).parameters[2], typeof(o)}(o, c2)
+    SortedDict{eltype(c2).parameters[1], eltype(c2).parameters[2], typeof(o)}(o, c2)
 end
 SortedDict{K,D}(iter, o::Ordering=Forward) where {K, D} =
     SortedDict{K,D,typeof(o)}(o, iter)

--- a/src/sorted_set.jl
+++ b/src/sorted_set.jl
@@ -164,7 +164,6 @@ convertible to `eltype(m)`.  Time: O(*c* log *n*)
     return exactfound
 end
 
-@inline Base.eltype(::Type{SortedSet{K,Ord}}) where {K,Ord <: Ordering} = K
 @inline Base.keytype(m::SortedSet{K,Ord}) where {K,Ord <: Ordering} = K
 @inline Base.keytype(::Type{SortedSet{K,Ord}}) where {K,Ord <: Ordering} = K
 


### PR DESCRIPTION
Like #854 but with `eltype` removed also for `SortedSet`.

Do we need to do the same for `keytype` of `SortedSet`, which is not normally defined for `AbstractSet`?

xref: https://github.com/JuliaCollections/DataStructures.jl/pull/854#issuecomment-1656749953