### PR TITLE
Fix MutableBinaryHeap{T} when T is Union/abstract

### DIFF
--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -220,7 +220,7 @@ function Base.push!(h::MutableBinaryHeap{T}, v) where T
     nodemap = h.node_map
     i = length(nodemap) + 1
     nd_id = length(nodes) + 1
-    push!(nodes, MutableBinaryHeapNode(convert(T, v), i))
+    push!(nodes, MutableBinaryHeapNode{T}(convert(T, v), i))
     push!(nodemap, nd_id)
     _heap_bubble_up!(h.ordering, nodes, nodemap, nd_id)
     return i
@@ -260,7 +260,7 @@ function update!(h::MutableBinaryHeap{T}, i::Int, v) where T
     nd_id = nodemap[i]
     v0 = nodes[nd_id].value
     x = convert(T, v)
-    nodes[nd_id] = MutableBinaryHeapNode(x, i)
+    nodes[nd_id] = MutableBinaryHeapNode{T}(x, i)
     if Base.lt(ordering, x, v0)
         _heap_bubble_up!(ordering, nodes, nodemap, nd_id)
     else

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -342,4 +342,14 @@ end
         update!(h, 2, 20)
         @test isequal(heap_values(h), [0.5, 10.1, 3.0, 20.0])
     end
+
+    @testset "T is a Union" begin
+        h = MutableBinaryMinHeap{Union{Int, Float64}}()
+        push!(h, 1)
+        push!(h, 2.0)
+        update!(h, 1, 1.5)
+        update!(h, 2, 3)
+        @test pop!(h) === 1.5
+        @test pop!(h) === 3
+    end
 end # @testset MutableBinheap


### PR DESCRIPTION
Each MutableBinaryHeapNode needs to be fully parameterised or Julia will (rightly) throw a conversion error when trying to add them to MutableBinaryHeap's nodes field.