### PR TITLE
Update ordered_containers.md

### DIFF
--- a/docs/src/ordered_containers.md
+++ b/docs/src/ordered_containers.md
@@ -12,7 +12,7 @@ for c in 'a':'e'
 end
 collect(d) # => [('a',1),('b',2),('c',3),('d',4),('e',5)]
 
-s = OrderedSet(π,e,γ,catalan,φ)
+s = OrderedSet([π,e,γ,catalan,φ])
 collect(s) # => [π = 3.1415926535897...,
            #     e = 2.7182818284590...,
            #     γ = 0.5772156649015...,
@@ -21,7 +21,18 @@ collect(s) # => [π = 3.1415926535897...,
 ```
 
 All standard `Dict` functions are available for `OrderedDicts`, and
-all `Set` operations are available for `OrderedSets`.
+all `Set` operations are available for `OrderedSets`. A point to be careful about is that equality does not respect order. That is, 
+```julia
+A1 = OrderedSet(["a", "b"])
+A2 = OrderedSet(["b", "a"])
+A1 == A2 # true
+collect(A1) == collect(A2) # false
+
+B1 = OrderedDict("a" => 1, "b" => 2)
+B2 = OrderedDict("b" => 2, "a" => 1)
+B1 == B2 # true
+collect(B1) == collect(B2) # false
+```
 
 Note that to create an `OrderedSet` of a particular type, you must specify
 the type in curly-braces:
@@ -30,3 +41,4 @@ the type in curly-braces:
 # create an OrderedSet of Strings
 strs = OrderedSet{AbstractString}()
 ```
+


### PR DESCRIPTION
1) Fixed incorrect example code in `OrderedSet` (Note that this code doesn't run as the various irrational numbers are not defined.)

2) Added clarification on equality. The behaviour was raised as a point of confusion in a Slack thread. I just documented the current existing behaviour.