### PR TITLE
Fix for MutableLinkedList append!

### DIFF
--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -153,7 +153,13 @@ end
 function Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T
     l1.node.prev.next = l2.node.next # l1's last's next is now l2's first
     l2.node.prev.next = l1.node # l2's last's next is now l1.node
+    l2.node.next.prev = l1.node.prev # l2's first's prev is now l1's last
+    l1.node.prev      = l2.node.prev # l1's first's prev is now l2's last
     l1.len += length(l2)
+    # make l2 empty
+    l2.node.prev = l2.node
+    l2.node.next = l2.node
+    l2.len = 0
     return l1
 end
 

--- a/test/test_mutable_list.jl
+++ b/test/test_mutable_list.jl
@@ -97,7 +97,8 @@
                 @testset "append" begin
                     l2 = MutableLinkedList{Int}(n+1:2n...)
                     append!(l, l2)
-                    @test l == MutableLinkedList{Int}(1:2n...)
+                    @test l  == MutableLinkedList{Int}(1:2n...)
+                    @test l2 == MutableLinkedList{Int}()
                     @test collect(l) == collect(MutableLinkedList{Int}(1:2n...))
                     l3 = MutableLinkedList{Int}(1:n...)
                     append!(l3, n+1:2n...)


### PR DESCRIPTION
See https://github.com/JuliaCollections/DataStructures.jl/issues/739 for example of the segfault that I'm seeing

- Updates `Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T` so that the resulting object doesn't print endlessly to the screen, and that `collect` doesn't segfault the julia session
   - adds more lines to update node `next` and `prev` pointers
- Adds a test in the append section so that the second argument is checked for being empty

with these changes, I'm seeing this work without segfaulting
```julia
(@v1.9) pkg> activate .
  Activating project at `~/repos/DataStructures.jl`

julia> using DataStructures

julia> l1, l2 = MutableLinkedList{Int}(1,2), MutableLinkedList{Int}(3,4)
(MutableLinkedList{Int64}(1, 2), MutableLinkedList{Int64}(3, 4))

julia> append!(l1, l2)
MutableLinkedList{Int64}(1, 2, 3, 4)

julia> collect(l1)
4-element Vector{Int64}:
 1
 2
 3
 4

julia> l2
MutableLinkedList{Int64}()
```