### PR TITLE
Use Julia 1.6 as new minimum

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,8 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-Compat = "3.0.0, 4"
 OrderedCollections = "1.1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -5,14 +5,8 @@ module DataStructures
                 isbitsunion, isiterable, dict_with_eltype, KeySet, Callable, _tablesz,
                 findnextnot, unsafe_getindex, unsafe_setindex!, peek
 
-   
-
     import Base.insert!
-    # Exports for old version of julia where Base doesn't export this
-    export peek
-    export popat!
 
-    using Compat # Provides Base.Order.ReverseOrdering(). May remove this line with julia 1.4
     using OrderedCollections
     using OrderedCollections: isordered
     export OrderedDict, OrderedSet, LittleDict
@@ -36,12 +30,11 @@ module DataStructures
 
     export Trie, subtrie, keys_with_prefix, partial_path, find_prefixes
 
-    export LinkedList, Nil, Cons, nil, cons, head, tail, list, filter, cat,
-           reverse
+    export LinkedList, Nil, Cons, nil, cons, head, tail, list
     export MutableLinkedList
     export SortedDict, SortedMultiDict, SortedSet
-    export SDToken, SDSemiToken, SMDToken, SMDSemiToken
-    export SetToken, SetSemiToken
+    export SMDSemiToken, SMDToken
+    export SetSemiToken
     export pastendsemitoken, beforestartsemitoken
     export pastendtoken, beforestarttoken
     export searchsortedafter, searchequalrange

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -323,11 +323,7 @@ function Base.popfirst!(pq::PriorityQueue)
     return x
 end
 
-if isdefined(Base, :popat!)  # We will overload if it is defined, else we define on our own
-    import Base: popat!
-end
-
-function popat!(pq::PriorityQueue, key)
+function Base.popat!(pq::PriorityQueue, key)
     idx = pq.index[key]
     force_up!(pq, idx)
     popfirst!(pq)


### PR DESCRIPTION
 - Includes https://github.com/JuliaCollections/DataStructures.jl/pull/844 to "get rid of Compat dependency and bump Julia compat to 1.6"
 - Cleaned up the exports, though I'm not sure about `peek`