### PR TITLE
Make LinkedList a Union instead of Abstract type

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -1,14 +1,15 @@
-abstract type LinkedList{T} end
+
+
+struct Nil{T} end
+
+struct Cons{T}
+    head::T
+    tail::Union{Nil{T}, Cons{T}}
+end
+
+const LinkedList{T} = Union{Nil{T}, Cons{T}}
 
 Base.eltype(::Type{<:LinkedList{T}}) where T = T
-
-mutable struct Nil{T} <: LinkedList{T}
-end
-
-mutable struct Cons{T} <: LinkedList{T}
-    head::T
-    tail::LinkedList{T}
-end
 
 cons(h, t::LinkedList{T}) where {T} = Cons{T}(h, t)
 


### PR DESCRIPTION
Hello. I have a proposal for an improvement of the implementation of the linked list data structure.

The way the LinkedList is implemented right now `LinkedList` is an abstract datatype, and `Cons` contains a field of type `LinkedList`. This means that any operation on LinkedLists result in a ton of unavoidable runtime-dispatch.

I noticed that a small redesign where `Nil` and `Cons` are standalone types and `LinkedList` just refers to their Union provides a speedup of more than an order of magnitude, as the compiler can create very efficient code for simple Unions of a concrete and a singleton type. The only disadvantage I see in this is that users can no longer extend the LinkedList type with new types, but it may be argued that this would not be intended behavior anyway.
I also made the two types immutable. They used to be mutable, but the mutability was never utilized. If there is some reason to make these mutable (like forcing the compiler to put them on the heap) let me know. 

