### PR TITLE
[backport] remove tests for `sort(::Dict)`

### DIFF
--- a/test/test_sorting.jl
+++ b/test/test_sorting.jl
@@ -29,16 +29,9 @@
             @test d == rev
         end
 
-        @testset "sort unordered" begin
-            unordered = Dict(zip('a':'z', 26:-1:1))
-            @test sort(unordered) == forward
-            @test sort(unordered; rev=true) == rev
-            @test sort(unordered; byvalue=true) == rev
-            @test sort(unordered; byvalue=true, rev=true) == forward
-        end
     end
 
     @testset "Bug DataStructures.jl/#394" begin
-        @test sort(Dict(k=>string(k) for k in 1:3))[1] == "1"
+        @test sort(OrderedDict(k=>string(k) for k in 1:3))[1] == "1"
     end
 end


### PR DESCRIPTION
backport of #881 to the `release-0.18` branch, so tests don't start failing there if we do https://github.com/JuliaCollections/OrderedCollections.jl/pull/110#issuecomment-1837216764