### PR TITLE
fix append! iterable to MutableLinkedList

### DIFF
--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -215,6 +215,14 @@ function Base.push!(l::MutableLinkedList{T}, data) where T
     return l
 end
 
+function Base.push!(l::MutableLinkedList{T}, data1, data...) where T
+    push!(l, data1)
+    for v in data
+        push!(l, v)
+    end
+    return l
+end
+
 function Base.pushfirst!(l::MutableLinkedList{T}, data) where T
     oldfirst = l.node.next
     node = ListNode{T}(data)

--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -165,7 +165,9 @@ end
 
 function Base.append!(l::MutableLinkedList, elts...)
     for elt in elts
-        push!(l, elt)
+        for v in elt
+            push!(l, v)
+        end
     end
     return l
 end

--- a/test/test_mutable_list.jl
+++ b/test/test_mutable_list.jl
@@ -101,9 +101,13 @@
                     @test l2 == MutableLinkedList{Int}()
                     @test collect(l) == collect(MutableLinkedList{Int}(1:2n...))
                     l3 = MutableLinkedList{Int}(1:n...)
-                    append!(l3, n+1:2n...)
+                    append!(l3, n+1:2n)
                     @test l3 == MutableLinkedList{Int}(1:2n...)
                     @test collect(l3) == collect(MutableLinkedList{Int}(1:2n...))
+                    l4 = MutableLinkedList{Int}(1:n...)
+                    push!(l4, n+1:2n...)
+                    @test l4 == MutableLinkedList{Int}(1:2n...)
+                    @test collect(l4) == collect(MutableLinkedList{Int}(1:2n...))
                 end
 
                 @testset "delete" begin


### PR DESCRIPTION
Currently `append!(MutableLinkedList{Int}(), [3])` would try to push the vector into the linked list instead of pushing elements into the linked list. 