### PR TITLE
Allow other int types for type container size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/site/
 docs/Manifest.toml
 Manifest.toml
 benchmark/*.json
+.vscode

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -12,6 +12,7 @@ end
 Create a double-ended queue of maximum capacity `n`, implemented as a circular buffer. The element type is `T`.
 """
 CircularDeque{T}(n::Int) where {T} = CircularDeque(Vector{T}(undef, n), n, 0, 1, n)
+CircularDeque{T}(n::Integer) where {T} = CircularDeque(Vector{T}(undef, Int(n)), Int(n), 0, 1, Int(n))
 
 Base.length(D::CircularDeque) = D.n
 Base.eltype(::Type{CircularDeque{T}}) where {T} = T

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -19,18 +19,21 @@ mutable struct CircularBuffer{T} <: AbstractVector{T}
         len <= length(buf) || throw(ArgumentError("Value of 'length' must be <= length of buffer"))
         return new{T}(length(buf), f, len, buf)
     end
+
+    # Convert any `Integer` to whatever `Int` is on the relevant machine
+    CircularBuffer{T}(f::Integer, len::Integer, buf::Integer) where {T} = CircularBuffer{T}(Int(f), Int(len), Int(buf))
 end
 
-function CircularBuffer{T}(iter, capacity::Int) where {T}
+function CircularBuffer{T}(iter, capacity::Integer) where {T}
     vec = copyto!(Vector{T}(undef,capacity), iter)
     CircularBuffer{T}(1, length(iter),vec)
 end
 
-CircularBuffer(capacity::Int) = CircularBuffer{Any}(capacity)
+CircularBuffer(capacity::Integer) = CircularBuffer{Any}(capacity)
 
-CircularBuffer{T}(capacity::Int) where {T} = CircularBuffer{T}(T[],capacity)
+CircularBuffer{T}(capacity::Integer) where {T} = CircularBuffer{T}(T[],capacity)
 
-CircularBuffer(iter,capacity::Int) =  CircularBuffer{eltype(iter)}(iter,capacity)
+CircularBuffer(iter,capacity::Integer) =  CircularBuffer{eltype(iter)}(iter,capacity)
 
 function CircularBuffer{T}(iter) where {T}
   vec = reshape(collect(T,iter),:) 

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -20,13 +20,16 @@ mutable struct DequeBlock{T}
         blk.next = blk
         return blk
     end
+
+    # Convert any `Integer` to whatever `Int` is on the relevant machine
+    DequeBlock{T}(capa::Integer, front::Integer) where T = DequeBlock{T}(Int(capa), Int(front))
 end
 
 # block at the rear of the chain, elements towards the front
-rear_deque_block(ty::Type{T}, n::Int) where {T} = DequeBlock{T}(n, 1)
+rear_deque_block(ty::Type{T}, n::Integer) where {T} = DequeBlock{T}(n, 1)
 
 # block at the head of the train, elements towards the back
-head_deque_block(ty::Type{T}, n::Int) where {T} = DequeBlock{T}(n, n+1)
+head_deque_block(ty::Type{T}, n::Integer) where {T} = DequeBlock{T}(n, n+1)
 
 capacity(blk::DequeBlock) = blk.capa
 Base.length(blk::DequeBlock) = blk.back - blk.front + 1
@@ -80,7 +83,7 @@ mutable struct Deque{T}
     head::DequeBlock{T}
     rear::DequeBlock{T}
 
-    function Deque{T}(blksize::Int) where T
+    function Deque{T}(blksize::Integer) where T
         head = rear = rear_deque_block(T, blksize)
         new{T}(1, blksize, 0, head, rear)
     end

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -40,7 +40,7 @@ isrear(blk::DequeBlock) =  blk.next === blk
 
 # reset the block to empty, and position
 
-function reset!(blk::DequeBlock{T}, front::Int) where T
+function reset!(blk::DequeBlock{T}, front::Integer) where T
     empty!(blk.data)
     resize!(blk.data, blk.capa)
     blk.front = front


### PR DESCRIPTION
This PR aims to solve https://github.com/JuliaCollections/DataStructures.jl/issues/891, and check if this issue occurs for other types as well. For the types listed [in the documentation](), the results are seen in the drop-down below.

<details>
Deque (implemented with an unrolled linked list)
errors on `Deque{Float64}(Int32(10))`. Fixed

CircularBuffer
Silent error on CircularBuffer{Float32}(Int32(10)). Fixed

CircularDeque (based on a circular buffer)
errors on CircularDeque{Float32}(Int32(10)). Fixed

Stack
errors on Stack{Float64}(Int32(5)). Got fixed, I think with Deque

Queue
errors on Queue{Float64}(Int32(5)). Got fixed, I think with Deque

Priority Queue
No length parameter upon initialization

Fenwick Tree
Works for FenwickTree{Float64}(Int32(5)) and FenwickTree{Float64}(Int16(5))

No length parameter upon initialization for the following types
    Accumulators and Counters (i.e. Multisets / Bags)
    Disjoint Sets
    Binary Heap
    Mutable Binary Heap
    Ordered Dicts and Sets
    RobinDict and OrderedRobinDict (implemented with Robin Hood Hashing)
    SwissDict (inspired from SwissTables)
    Dictionaries with Defaults
    Trie
    Linked List and Mutable Linked List
    Sorted Dict, Sorted Multi-Dict and Sorted Set
    DataStructures.IntSet
    SparseIntSet
    DiBitVector
    Red Black Tree
    AVL Tree
    Splay Tree
</details>