### PR TITLE
Use `Base._unsetindex!` in `pop!` and `popfirst!`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -64,6 +64,7 @@ end
 
 @inline Base.@propagate_inbounds function Base.pop!(D::CircularDeque)
     v = last(D)
+    Base._unsetindex!(D.buffer, D.last) # see issue/884
     D.n -= 1
     tmp = D.last - 1
     D.last = ifelse(tmp < 1, D.capacity, tmp)
@@ -91,6 +92,7 @@ Remove the element at the front.
 """
 @inline Base.@propagate_inbounds function Base.popfirst!(D::CircularDeque)
     v = first(D)
+    Base._unsetindex!(D.buffer, D.first) # see issue/884
     D.n -= 1
     tmp = D.first + 1
     D.first = ifelse(tmp > D.capacity, 1, tmp)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -297,6 +297,7 @@ function Base.pop!(d::Deque{T}) where T
     @assert rear.back >= rear.front
 
     @inbounds x = rear.data[rear.back]
+    Base._unsetindex!(rear.data, rear.back) # see issue/884
     rear.back -= 1
     if rear.back < rear.front
         if d.nblocks > 1
@@ -322,6 +323,7 @@ function Base.popfirst!(d::Deque{T}) where T
     @assert head.back >= head.front
 
     @inbounds x = head.data[head.front]
+    Base._unsetindex!(head.data, head.front) # see issue/884
     head.front += 1
     if head.back < head.front
         if d.nblocks > 1

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -81,6 +81,29 @@
         for i in 1:5 push!(D, i) end
         @test collect([i for i in D]) == collect(1:5)
     end
+
+    @testset "pop! and popfirst! do not leak" begin
+        D = CircularDeque{String}(5)
+
+        @testset "pop! doesn't leak" begin
+            push!(D,"foo")
+            push!(D,"bar")
+            ss2 = Base.summarysize(D)
+            pop!(D)
+            GC.gc(true)
+            ss1 = Base.summarysize(D)
+            @test ss1 < ss2
+        end
+        @testset "popfirst! doesn't leak" begin
+            push!(D,"baz")
+            push!(D,"bug")
+            ss2 = Base.summarysize(D)
+            popfirst!(D)
+            GC.gc(true)
+            ss1 = Base.summarysize(D)
+            @test ss1 < ss2
+        end
+    end
 end
 
 nothing

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -212,4 +212,28 @@
         @test last(q) == 3
         @test num_blocks(q) == 1
     end
+
+    @testset "pop! and popfirst! don't leak" begin
+        q = Deque{String}(5)
+        GC.gc(true)
+
+        @testset "pop! doesn't leak" begin
+            push!(q,"foo")
+            push!(q,"bar")
+            ss2 = Base.summarysize(q.head)
+            pop!(q)
+            GC.gc(true)
+            ss1 = Base.summarysize(q.head)
+            @test ss1 < ss2
+        end
+        @testset "popfirst! doesn't leak" begin
+            push!(q,"baz")
+            push!(q,"bug")
+            ss2 = Base.summarysize(q.head)
+            popfirst!(q)
+            GC.gc(true)
+            ss1 = Base.summarysize(q.head)
+            @test ss1 < ss2
+        end
+    end
 end # @testset Deque


### PR DESCRIPTION
For `Deque` and `CircularDeque`. So that popped elements are not rooted by the deque and can be GCed when they drop out of caller scope.

Completes the fix of #884.