### PR TITLE
Delete unnecessary methods to fix invalidations

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -61,8 +61,6 @@ Base.setindex!(ct::Accumulator, x, v) = setindex!(ct.map, x, v)
 
 Base.haskey(ct::Accumulator, x) = haskey(ct.map, x)
 
-Base.keys(ct::Accumulator) = keys(ct.map)
-
 Base.values(ct::Accumulator) = values(ct.map)
 
 Base.sum(ct::Accumulator) = sum(values(ct.map))

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -182,16 +182,12 @@ Return the number of elements currently in the buffer.
 """
 Base.length(cb::CircularBuffer) = cb.length
 
-Base.eltype(::Type{CircularBuffer{T}}) where T = T
-
 """
     size(cb::CircularBuffer)
 
 Return a tuple with the size of the buffer.
 """
 Base.size(cb::CircularBuffer) = (length(cb),)
-
-Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
 
 """
     isempty(cb::CircularBuffer)


### PR DESCRIPTION
- `Base.keys()` already works on `AbstractDict`'s so we don't need one for `Accumulator`.
- `Base.eltype()` is already defined for `AbstractArray`'s and `CircularBuffer` is an `AbstractVector` so it doesn't need to define it again.
- A `Base.convert()` method from `AbstractArray` to `Array` is already defined: https://github.com/JuliaLang/julia/blob/1ae41a2c0a3ba49d4b39dc4933dddf952b5f7f3c/base/array.jl#L612

I found these through looking at invalidations from Dagger.jl (CC @jpsamaroo). Before:
```julia
julia> include("test/invalidations.jl")                                                                                                                                                                                                        
Precompiling Dagger                                                                                                                                                                                                                            
  2 dependencies successfully precompiled in 25 seconds. 92 already precompiled.                                                                                                                                                               
[ Info: Precompiling GraphVizSimpleExt [8f367522-86d3-5221-bdf5-df974a7b0ff8]                                                                                                                                                                  
length(uinvalidated(invalidations)) = 238                                                                                                                                                                                                      
[ Info: 238 methods invalidated for 27 functions                                                                                                                                                                                               
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐                                                     
│ <file name>:<line number>                                                                                                         │  Function Name   │ Invalidations │ Invalidations % │                                                     
│                                                                                                                                   │                  │               │     (xᵢ/∑x)     │                                                     
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2377 │       _all       │      35       │       14        │                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2375 │       _any       │      35       │       14        │                                                     
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:157                                                       │      eltype      │      33       │       13        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:88                                                               │     convert      │      25       │       10        │                                                     
│ /home/james/.julia/packages/DataStructures/jFDPC/src/container_loops.jl:233                                                       │       keys       │      23       │        9        │                                                     
│ /home/james/.julia/packages/FillArrays/3N7FG/src/FillArrays.jl:708                                                                │ print_matrix_row │      18       │        7        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SArray.jl:71                                                                   │  unsafe_convert  │      16       │        6        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:25                                                                │      _axes       │      14       │        5        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:78                                                                │      _bcs1       │      11       │        4        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:85                                                                │      _bcs1       │      10       │        4        │                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:33       │     resize!      │       7       │        3        │                                                     
│ /home/james/.julia/packages/FillArrays/3N7FG/src/fillalgebra.jl:396                                                               │   reduce_first   │       6       │        2        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:82                                                               │     convert      │       4       │        2        │                                                     
│ /home/james/.julia/dev/Dagger/src/array/darray.jl:31                                                                              │     getindex     │       3       │        1        │                                                     
│ /home/james/.julia/packages/FillArrays/3N7FG/src/fillbroadcast.jl:258                                                             │   broadcasted    │       3       │        1        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:178                                                           │      rdims       │       2       │        1        │                                                     
│ /home/james/.julia/packages/MemPool/jCpTk/src/read_write_lock.jl:133                                                              │      unlock      │       2       │        1        │                                                     
│ /home/james/.julia/packages/MemPool/jCpTk/src/read_write_lock.jl:119                                                              │       lock       │       2       │        1        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:177                                                           │      rdims       │       1       │        0        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:16                                                            │    eachindex     │       1       │        0        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SOneTo.jl:57                                                                   │   getproperty    │       1       │        0        │                                                     
│ /home/james/.julia/packages/DataStructures/jFDPC/src/sparse_int_set.jl:213                                                        │       zip        │       1       │        0        │                                                     
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:166                                                       │     convert      │       1       │        0        │                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:17       │    eachindex     │       1       │        0        │                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SharedArrays/src/SharedArrays.jl:575  │       map!       │       1       │        0        │                                                     
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/indexing.jl:413                                                                │     SubArray     │       0       │        0        │                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/Profile/src/Profile.jl:13             │      lookup      │       0       │        0        │                                                     
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴───────────────┴─────────────────┘ 
```

After:
```julia
julia> include("test/invalidations.jl")
Precompiling Dagger
  10 dependencies successfully precompiled in 30 seconds. 84 already precompiled.
[ Info: Precompiling GraphVizSimpleExt [8f367522-86d3-5221-bdf5-df974a7b0ff8]
length(uinvalidated(invalidations)) = 225
[ Info: 225 methods invalidated for 25 functions
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐
│ <file name>:<line number>                                                                                                         │  Function Name   │ Invalidations │ Invalidations % │
│                                                                                                                                   │                  │               │     (xᵢ/∑x)     │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2377 │       _all       │      35       │       15        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2375 │       _any       │      35       │       15        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:88                                                               │     convert      │      26       │       11        │
│ /home/james/.julia/dev/DataStructures/src/sorted_container_iteration.jl:620                                                       │       keys       │      23       │       10        │
│ /home/james/.julia/packages/FillArrays/3N7FG/src/FillArrays.jl:708                                                                │ print_matrix_row │      18       │        8        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SArray.jl:71                                                                   │  unsafe_convert  │      16       │        7        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:25                                                                │      _axes       │      14       │        6        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:78                                                                │      _bcs1       │      11       │        5        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:85                                                                │      _bcs1       │      10       │        4        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/indexing.jl:413                                                                │     SubArray     │      10       │        4        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:33       │     resize!      │       7       │        3        │
│ /home/james/.julia/packages/FillArrays/3N7FG/src/fillalgebra.jl:396                                                               │   reduce_first   │       6       │        3        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:82                                                               │     convert      │       4       │        2        │
│ /home/james/.julia/dev/Dagger/src/array/darray.jl:31                                                                              │     getindex     │       3       │        1        │
│ /home/james/.julia/packages/FillArrays/3N7FG/src/fillbroadcast.jl:258                                                             │   broadcasted    │       3       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:178                                                           │      rdims       │       2       │        1        │
│ /home/james/.julia/packages/MemPool/jCpTk/src/read_write_lock.jl:133                                                              │      unlock      │       2       │        1        │
│ /home/james/.julia/packages/MemPool/jCpTk/src/read_write_lock.jl:119                                                              │       lock       │       2       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:177                                                           │      rdims       │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:16                                                            │    eachindex     │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SOneTo.jl:57                                                                   │   getproperty    │       1       │        0        │
│ /home/james/.julia/dev/DataStructures/src/sparse_int_set.jl:213                                                                   │       zip        │       1       │        0        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:17       │    eachindex     │       1       │        0        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SharedArrays/src/SharedArrays.jl:575  │       map!       │       1       │        0        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/Profile/src/Profile.jl:13             │      lookup      │       0       │        0        │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴───────────────┴─────────────────┘
```

There are still some invalidations left, but AFAICT they're necessary and/or would require changes to Base to fix.