### PR TITLE
Backport invalidation fixes to 0.18.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.18"
+version = "0.18.19"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -55,8 +55,6 @@ Base.setindex!(ct::Accumulator, x, v) = setindex!(ct.map, x, v)
 
 Base.haskey(ct::Accumulator, x) = haskey(ct.map, x)
 
-Base.keys(ct::Accumulator) = keys(ct.map)
-
 Base.values(ct::Accumulator) = values(ct.map)
 
 Base.sum(ct::Accumulator) = sum(values(ct.map))

--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -154,16 +154,12 @@ Return the number of elements currently in the buffer.
 """
 Base.length(cb::CircularBuffer) = cb.length
 
-Base.eltype(::Type{CircularBuffer{T}}) where T = T
-
 """
     size(cb::CircularBuffer)
 
 Return a tuple with the size of the buffer.
 """
 Base.size(cb::CircularBuffer) = (length(cb),)
-
-Base.convert(::Type{Array}, cb::CircularBuffer{T}) where {T} = T[x for x in cb]
 
 """
     isempty(cb::CircularBuffer)


### PR DESCRIPTION
As discussed in https://github.com/JuliaCollections/DataStructures.jl/pull/904#issuecomment-2051601857.