### PR TITLE
Improve performance of sizehint! on BinaryHeap

### DIFF
--- a/src/heaps/arrays_as_heaps.jl
+++ b/src/heaps/arrays_as_heaps.jl
@@ -75,7 +75,7 @@ end
 
 In-place [`heapify`](@ref).
 """
-function heapify!(xs::AbstractArray, o::Ordering=Forward)
+@inline function heapify!(xs::AbstractArray, o::Ordering=Forward)
     for i in heapparent(length(xs)):-1:1
         percolate_down!(xs, i, o)
     end

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -39,7 +39,7 @@ mutable struct BinaryHeap{T, O <: Base.Ordering} <: AbstractHeap{T}
     end
 
     function BinaryHeap{T}(ordering::Base.Ordering, xs::AbstractVector) where T
-        valtree = heapify(xs, ordering)
+        valtree = @inline heapify!(copyto!(similar(xs), xs), ordering)
         new{T, typeof(ordering)}(ordering, valtree)
     end
 end

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -39,7 +39,7 @@ mutable struct BinaryHeap{T, O <: Base.Ordering} <: AbstractHeap{T}
     end
 
     function BinaryHeap{T}(ordering::Base.Ordering, xs::AbstractVector) where T
-        valtree = @inline heapify(xs, ordering)
+        valtree = heapify(xs, ordering)
         new{T, typeof(ordering)}(ordering, valtree)
     end
 end

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -39,7 +39,7 @@ mutable struct BinaryHeap{T, O <: Base.Ordering} <: AbstractHeap{T}
     end
 
     function BinaryHeap{T}(ordering::Base.Ordering, xs::AbstractVector) where T
-        valtree = @inline heapify!(copyto!(similar(xs), xs), ordering)
+        valtree = @inline heapify(xs, ordering)
         new{T, typeof(ordering)}(ordering, valtree)
     end
 end


### PR DESCRIPTION
Noticed that sizehint! was actually worsening a lot of the performance of some of my heaps, with this change it is much faster:

e.g. with

```julia
using DataStructures, BenchmarkTools
function with_sizehint(T, n)
    value = BinaryHeap(Base.Order.ForwardOrdering(), T[])
    sizehint!(value, n)
end
```

before:

```julia
julia> @btime with_sizehint(Int, 1);
  861.250 ns (5 allocations: 256 bytes)
```

after:

```julia
julia> @btime with_sizehint(Int, 1);
  64.790 ns (4 allocations: 224 bytes)
```



