### PR TITLE
Fix runtime dispatch in Deque

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -114,8 +114,8 @@ module DataStructures
     include("deprecations.jl")
 
     @static if VERSION <= v"1.3"
-        _unsetindex!(a, i) = a
+        const _unsetindex!(a, i) = a
     else
-        _unsetindex! = Base._unsetindex!
+        const _unsetindex! = Base._unsetindex!
     end
 end


### PR DESCRIPTION
Hi,

In the current version 0.18.20 of DataStructures, using `dequeue!` leads to runtime dispatches affecting performance.
The error can be fixed by declaring a used alias as const.

Small example reproducing the error:

```Julia
using JET
using Pkg
Pkg.activate(".")
using DataStructures
q = Queue{Int}()
enqueue!(q, 1)
@report_opt dequeue!(q)
```

results in 

´´´
═════ 1 possible error found ═════
┌ dequeue!(s::Queue{Int64}) @ DataStructures /home/marius/repos/DataStructures.jl/src/queue.jl:37
│┌ popfirst!(q::Deque{Int64}) @ DataStructures /home/marius/repos/DataStructures.jl/src/deque.jl:305
││ runtime dispatch detected: %33::Any(%34::Vector{Int64}, %35::Int64)::Any
│└────────────────────
´´´