### PR TITLE
Update disjoint_set.jl

### DIFF
--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -182,6 +182,8 @@ Base.empty(s::DisjointSet{T}, ::Type{U}=T) where {T,U} = DisjointSet{U}()
 function Base.sizehint!(s::DisjointSet, n::Integer)
     sizehint!(s.intmap, n)
     sizehint!(s.revmap, n)
+    sizehint!(s.internal.parents, n)
+    sizehint!(s.internal.ranks, n)
     return s
 end
 

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -32,6 +32,11 @@ end
 IntDisjointSet(n::T) where {T<:Integer} = IntDisjointSet{T}(collect(Base.OneTo(n)), zeros(T, n), n)
 IntDisjointSet{T}(n::Integer) where {T<:Integer} = IntDisjointSet{T}(collect(Base.OneTo(T(n))), zeros(T, T(n)), T(n))
 Base.length(s::IntDisjointSet) = length(s.parents)
+function Base.sizehint!(s::IntDisjointSet, n::Integer)
+    sizehint!(s.parents, n)
+    sizehint!(s.ranks, n)
+    return s
+end
 
 """
     num_groups(s::IntDisjointSet)

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -182,8 +182,7 @@ Base.empty(s::DisjointSet{T}, ::Type{U}=T) where {T,U} = DisjointSet{U}()
 function Base.sizehint!(s::DisjointSet, n::Integer)
     sizehint!(s.intmap, n)
     sizehint!(s.revmap, n)
-    sizehint!(s.internal.parents, n)
-    sizehint!(s.internal.ranks, n)
+    sizehint!(s.internal, n)
     return s
 end
 


### PR DESCRIPTION
Improve `sizehint!(DisjointSets)` such that we can also preallocate the vectors needed by the internal `IntDisjointSets`.