### PR TITLE
Fix splay tree amortized time issues (resolves #923)

### DIFF
--- a/benchmark/bench_trees.jl
+++ b/benchmark/bench_trees.jl
@@ -1,0 +1,69 @@
+module BenchTrees
+
+using DataStructures
+using BenchmarkTools
+using Random
+
+suite = BenchmarkGroup()
+
+rand_setup =  (
+	Random.seed!(1234);
+	idx1 = rand(1:30000, 1000);
+	didx1 = rand(1:1000, 500);
+)
+
+# insert a bunch of keys, search for all of them, delete half of them randomly,
+# then search for all of them again.
+function test_rand(T)
+    t = T{Int}()
+    for i in idx1
+        push!(t, i)
+    end
+    for i in idx1
+        haskey(t, i)
+    end
+    for i in didx1
+        delete!(t, idx1[i])
+    end
+    for i in idx1
+        haskey(t, i)
+    end
+end
+
+# insert 1, ..., N, then push 1 many times. tests a regression from an older
+# splay tree implementation where splays didn't happen on redundant pushes.
+function test_redundant(T, N=100000)
+    t = T{Int}()
+    for i in 1:N
+        push!(t, i)
+    end
+    for i in 1:N
+        push!(t, 1)
+    end
+end
+
+# insert 1, ..., N, then access element 1 for N iterations. splay trees should
+# perform best here.
+function test_biased(T, N=100000)
+    t = T{Int}()
+    for i in 1:N
+        push!(t, i)
+    end
+    for _ in 1:N
+        haskey(t, 1)
+    end
+end
+
+trees = Dict("splay" => SplayTree, "avl" => AVLTree, "rb" => RBTree)
+for (T_name, T) in trees
+    suite[T_name]["rand"] =
+        @benchmarkable test_rand($(T)) setup=rand_setup
+    suite[T_name]["redundant"] =
+        @benchmarkable test_redundant($(T))
+    suite[T_name]["biased"] =
+        @benchmarkable test_biased($T)
+end
+
+end  # module
+
+BenchTrees.suite

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,3 +12,4 @@ const SUITE = BenchmarkGroup()
 
 SUITE["heap"] = include("bench_heap.jl")
 SUITE["SparseIntSet"] = include("bench_sparse_int_set.jl")
+SUITE["trees"] = include("bench_trees.jl")

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -51,7 +51,7 @@ module DataStructures
     export DiBitVector
 
     export RBTree, search_node, minimum_node
-    export SplayTree, maximum_node
+    export SplayTree, search_node!, maximum_node
     export AVLTree, sorted_rank
     export SplayTree, maximum_node
 

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -53,7 +53,6 @@ module DataStructures
     export RBTree, search_node, minimum_node
     export SplayTree, search_node!, maximum_node
     export AVLTree, sorted_rank
-    export SplayTree, maximum_node
 
     export findkey
 

--- a/src/splay_tree.jl
+++ b/src/splay_tree.jl
@@ -126,7 +126,7 @@ function _join!(tree::SplayTree, s::Union{SplayTreeNode, Nothing}, t::Union{Spla
     end
 end
 
-function search_node(tree::SplayTree{K}, d::K) where K
+function search_node!(tree::SplayTree{K}, d::K) where K
     node = tree.root
     prev = nothing
     while node != nothing && node.data != d
@@ -137,7 +137,9 @@ function search_node(tree::SplayTree{K}, d::K) where K
             node = node.leftChild
         end
     end
-    return (node == nothing) ? prev : node
+    last = (node == nothing) ? prev : node
+    (last == nothing) || splay!(tree, last)
+    return last
 end
 
 function Base.haskey(tree::SplayTree{K}, d::K) where K
@@ -145,11 +147,9 @@ function Base.haskey(tree::SplayTree{K}, d::K) where K
     if node === nothing
         return false
     else
-        node = search_node(tree, d)
+        node = search_node!(tree, d)
         (node === nothing) && return false
-        is_found = (node.data == d)
-        is_found && splay!(tree, node)
-        return is_found
+        return (node.data == d)
     end
 end
 
@@ -157,12 +157,10 @@ Base.in(key, tree::SplayTree) = haskey(tree, key)
 
 function Base.delete!(tree::SplayTree{K}, d::K) where K
     node = tree.root
-    x = search_node(tree, d)
-    (x == nothing) && return tree
+    x = search_node!(tree, d)
+    (x == nothing || x.data != d) && return tree
     t = nothing
     s = nothing
-
-    splay!(tree, x)
 
     if x.rightChild !== nothing
         t = x.rightChild
@@ -183,7 +181,7 @@ end
 
 function Base.push!(tree::SplayTree{K}, d0) where K
     d = convert(K, d0)
-    is_present = search_node(tree, d)
+    is_present = search_node!(tree, d)
     if (is_present !== nothing) && (is_present.data == d)
         return tree
     end

--- a/test/test_splay_tree.jl
+++ b/test/test_splay_tree.jl
@@ -42,6 +42,28 @@
         @test length(t) == 100
     end
 
+    @testset "deleting missing values" begin
+        t = SplayTree{Int}()
+        for i in 1:100
+            push!(t, i)
+        end
+        for i in 101:200
+            delete!(t, i)
+        end
+
+        @test length(t) == 100
+
+        for i in 1:100
+            @test haskey(t, i)
+        end
+
+        for i in 101:200
+            push!(t, i)
+        end
+
+        @test length(t) == 200
+    end
+
     @testset "handling different cases of delete!" begin
         t2 = SplayTree()
         for i in 1:100000
@@ -84,16 +106,16 @@
         @test !in('c', t4)
     end
 
-    @testset "search_node" begin 
+    @testset "search_node!" begin
         t5 = SplayTree()
         for i in 1:32
             push!(t5, i)
         end
-        n1 = search_node(t5, 21)
+        n1 = search_node!(t5, 21)
         @test n1.data == 21
-        n2 = search_node(t5, 35)
+        n2 = search_node!(t5, 35)
         @test n2.data == 32
-        n3 = search_node(t5, 0)
+        n3 = search_node!(t5, 0)
         @test n3.data == 1
     end 
 


### PR DESCRIPTION
Per discussion in #923, this PR ensures that the splay tree's `search_node!` now always splays the last-seen node. This means that `push!` will reorganize the tree even if the push is already present, and `haskey` will reorganize the tree even if the key is not present. This resolves a performance issue.

In addition, I think I found a correctness bug in `delete!`, where it doesn't check that the node returned by `search_node!` actually has the requested key (`search_node!` seems to return the last visited node during the traversal, whether or not it was actually the node we searched for). I fixed this and added a regression test. You can check that it fails on the old splay tree implementation using this branch: https://github.com/matthewsot/DataStructures.jl/tree/regression

A few things that came up in the process that I'm not 100% sure how you all want to handle:
1. It seems like `search_node` was part of the public API, but now it's been renamed to `search_node!` for splay trees as suggested in the discussion in #923, which could be a breaking change. Is that intended?
2. `splay_tree.jl` had a few places using `== nothing` and a few other places using `=== nothing`. I'm not totally sure what the difference is, so I tried to basically just do whatever the most similar code was doing before.

Feedback welcome!