### PR TITLE
move stack to Vector

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -7,24 +7,23 @@ Create a `Stack` object containing elements of type `T` for **Last In, First Out
 
 # Parameters
 - `T::Type` Stack element data type.
-- `blksize::Integer` Unrolled linked-list block size (in bytes) used in the
-    underlying representation of the stack. Default = 1024. 
+- `blksize::Integer` unused
 
 # Examples
 ```jldoctest
 julia> s_int = Stack{Int64}() # create a stack with Int64 elements
-Stack{Int64}(Deque [Int64[]])
+Stack{Int64}([Int64[]])
 
 julia> s_float = Stack{Float64}() # create a stack with Float64 elements
-Stack{Float64}(Deque [Float64[]])
+Stack{Float64}(Float64[])
 ```
 """
-mutable struct Stack{T}
-    store::Deque{T}
+struct Stack{T}
+    store::Vector{T}
 end
 
-Stack{T}() where {T} = Stack(Deque{T}())
-Stack{T}(blksize::Integer) where {T} = Stack(Deque{T}(blksize))
+Stack{T}() where {T} = Stack(Vector{T}())
+Stack{T}(blksize::Integer) where {T} = Stack{T}()
 
 """
     isempty(s::Stack)
@@ -60,14 +59,14 @@ the stack).
 # Example
 ```jldoctest
 julia> s = Stack{Float32}()
-Stack{Float32}(Deque [Float32[]])
+Stack{Float32}([Float32[]])
 
 julia> for i in range(1, 0.2, 5)
            push!(s, i)
        end
 
 julia> s
-Stack{Float32}(Deque [Float32[1.0, 0.8, 0.6, 0.4, 0.2]])
+Stack{Float32}[Float32[1.0, 0.8, 0.6, 0.4, 0.2])
 
 julia> first(s)
 0.2f0
@@ -84,14 +83,14 @@ element will be the at bottom of the stack.
 # Example
 ```jldoctest
 julia> s = Stack{Float32}()
-Stack{Float32}(Deque [Float32[]])
+Stack{Float32}(Float32[])
 
 julia> for i in range(1, 0.2, 5)
            push!(s, i)
        end
 
 julia> s
-Stack{Float32}(Deque [Float32[1.0, 0.8, 0.6, 0.4, 0.2]])
+Stack{Float32}(Float32[1.0, 0.8, 0.6, 0.4, 0.2])
 
 julia> last(s)
 1.0f0
@@ -141,7 +140,7 @@ formed by the elements of `x` and `y` in the order they appear in the stack.
 # Example
 ```jldoctest
 julia> s1, s2 = Stack{String}(), Stack{String}()
-(Stack{String}(Deque [String[]]), Stack{String}(Deque [String[]]))
+(Stack{String}(String[]), Stack{String}(String[]))
 
 julia> for string in ["foo", "bar", "42"]
           push!(s1, string)
@@ -159,7 +158,7 @@ false
 ```
 ```jldoctest
 julia> a, b = Stack{Int}(), Stack{Int}()
-(Stack{Int64}(Deque [Int64[]]), Stack{Int64}(Deque [Int64[]]))
+(Stack{Int64}(Int64[]), Stack{Int64}(Int64[]))
 
 julia> for num in [1, 2, 3, 4] push!(a, num) end
 


### PR DESCRIPTION
By my measurements, it's a bunch faster for this workload (this may be new as of Julia 1.11)
```
julia> function f3(d, n)
           for i in 1:n
               push!(d, i)
               pop!(d)
           end
       end
f3 (generic function with 1 method)

julia> @benchmark f3(d, 1000) evals=1 setup = (d=Vector{Int}())
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  789.000 ns …  10.042 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     797.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   823.878 ns ± 158.991 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▅▁▅▄           ▂  ▁▄▃                                     ▂ ▁
  ███████▆▆▄▁▁▁▁▁▁▇██▃███▇▇▆▇█▆▆▅▄▄▄▄▄▅▄▅▄▆▇▇▆▆▇▆▆▆▅▅▄▁▄▁▃▃▄▅██ █
  789 ns        Histogram: log(frequency) by time       1.07 μs <

 Memory estimate: 96 bytes, allocs estimate: 1.

julia> @benchmark f3(d, 1000) evals=1 setup = (d=Deque{Int}())
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  3.667 μs …  28.349 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.803 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.930 μs ± 489.972 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁▆█▄▇▅▃▃▂▁▁▂▅▃ ▁  ▁▁       ▁                                ▂
  ████████████████▇▇██▇▇▆▇█▇███▇▇▆█▇▄▅▄▆▆▆▆▇▇▅▅▅▄▅▅▆▅▄▅▄▄▄▄▆▅ █
  3.67 μs      Histogram: log(frequency) by time      5.66 μs <

```