### PR TITLE
Fix append!(l1, l2) for empty MutableLinkedList l2

### DIFF
--- a/src/mutable_list.jl
+++ b/src/mutable_list.jl
@@ -151,6 +151,7 @@ function Base.setindex!(l::MutableLinkedList{T}, data, idx::Int) where T
 end
 
 function Base.append!(l1::MutableLinkedList{T}, l2::MutableLinkedList{T}) where T
+    isempty(l2) && return l1
     l1.node.prev.next = l2.node.next # l1's last's next is now l2's first
     l2.node.prev.next = l1.node # l2's last's next is now l1.node
     l2.node.next.prev = l1.node.prev # l2's first's prev is now l1's last

--- a/test/test_mutable_list.jl
+++ b/test/test_mutable_list.jl
@@ -108,6 +108,14 @@
                     push!(l4, n+1:2n...)
                     @test l4 == MutableLinkedList{Int}(1:2n...)
                     @test collect(l4) == collect(MutableLinkedList{Int}(1:2n...))
+                    l5 = copy(l)
+                    l6 = MutableLinkedList{Int}()
+                    append!(l5, l6)
+                    @test collect(l5) == 1:2n
+                    @test l6 == MutableLinkedList{Int}()
+                    append!(l6, l5)
+                    @test collect(l6) == 1:2n
+                    @test l5 == MutableLinkedList{Int}()
                 end
 
                 @testset "delete" begin


### PR DESCRIPTION
This PR addresses #941 and short circuits `append(l1::MutableLinkedList, l2::MutableLinkedList)` if `l2` is empty.
Previously, `l2.node` would repeat infinitely.

There are also simple new tests to verify that appending from & to an empty MutableLinkedList gives the correct result.