### PR TITLE
release v0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,57 @@
 Changelog is now in the [Github Release Notes](https://github.com/JuliaCollections/DataStructures.jl/releases).
 
+Starting from version 0.19.0, CHANGELOG.md is managed in a format that follows <https://keepachangelog.com/en/1.1.0/>.
 
-## Old Changelong (pre-2018)
+<!-- links start -->
+[Unreleased]: https://github.com/JuliaCollections/DataStructures.jl/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/JuliaCollections/DataStructures.jl/compare/v0.18.22...v0.19.0
+<!-- links end -->
+
+[0.19.0] - 2025-07-31
+=====================
+
+## Added
+- New `Queue` and `Stack` as separate types with enhanced documentation
+- Add `empty!` method for heaps (JuliaCollections/DataStructures.jl#932)
+- Support for recursive `DefaultDict` creation
+- Add `find_prefixes` method to `Trie` for finding all keys that are prefixes of a given string (JuliaCollections/DataStructures.jl#933)
+- Improved constructors for `CircularBuffer` allowing initialization with an iterable and capacity
+- Add `resize!` method for `CircularBuffer`
+- Enhanced documentation with doctests and improved examples throughout (JuliaCollections/DataStructures.jl#931)
+
+## Changed
+- Minimum Julia version requirement raised to 1.6 (JuliaCollections/DataStructures.jl#874)
+- `DisjointSets` renamed to `DisjointSet` (singular form) (JuliaCollections/DataStructures.jl#700)
+- `IntDisjointSets` renamed to `IntDisjointSet` (singular form) (JuliaCollections/DataStructures.jl#700)
+- PriorityQueue API updated to use standard Julia interfaces:
+  - `enqueue!` → `push!`
+  - `dequeue!` → `popfirst!`
+  - `dequeue_pair!` → `popfirst!`
+  - `peek` → `first`
+- Renamed methods in sorted containers:
+  - `startof` → `firstindex`
+  - `endof` → `lastindex`
+  - `insert!` → `push_return_semitoken!`
+- `Accumulator` constructor behavior changed to properly accumulate values when initialized with pairs
+- Documentation significantly expanded and reorganized
+- Performance improvements in heaps and various other data structures (JuliaCollections/DataStructures.jl#907)
+
+## Deprecated
+- `enqueue!` and `dequeue!` methods (use `push!` and `popfirst!` instead)
+- `peek` for PriorityQueue (use `first` instead)
+- `DisjointSets` (use `DisjointSet` instead) (JuliaCollections/DataStructures.jl#700)
+- `IntDisjointSets` (use `IntDisjointSet` instead) (JuliaCollections/DataStructures.jl#700)
+- `startof` and `endof` (use `firstindex` and `lastindex` instead)
+
+## Fixed
+- Memory management improvements using `Base._unsetindex!` in several data structures (JuliaCollections/DataStructures.jl#884)
+- Fixed `append!` behavior in `MutableLinkedList` to properly handle multiple arguments
+- Various bug fixes and correctness improvements
+
+## Removed
+- Dependency on Compat.jl
+- Dependency on InteractiveUtils.jl
+- Support for Julia versions < 1.6 (JuliaCollections/DataStructures.jl#874)
 
 0.7.0 / 2017-09-02
 ==================

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataStructures"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.19.0-DEV"
+version = "0.19.0"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"


### PR DESCRIPTION
It's been nearly 5 years since the last release, so let's definitely release a new version.

This release appears to be quite breaking. I used CLAUDE to write release notes that follow the [Keep a
changelog](https://keepachangelog.com/en/1.1.0/) format.