### PR TITLE
Add `Integer` type annotation to `sizehint!` overloads

### DIFF
--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -170,7 +170,7 @@ function rehash!(h::OrderedRobinDict{K, V}) where {K, V}
     return h
 end
 
-function Base.sizehint!(d::OrderedRobinDict, newsz)
+function Base.sizehint!(d::OrderedRobinDict, newsz::Integer)
     oldsz = length(d)
     # grow at least 25%
     if newsz < (oldsz*5)>>2
@@ -232,7 +232,7 @@ end
 function Base.get!(default::Base.Callable, h::OrderedRobinDict{K,V}, key0) where {K,V}
     index = get(h.dict, key0, -2)
     index > 0 && return @inbounds h.vals[index]
-    
+
     v = convert(V, default())
     setindex!(h, v, key0)
     return v

--- a/src/robin_dict.jl
+++ b/src/robin_dict.jl
@@ -225,7 +225,7 @@ function rehash!(h::RobinDict{K,V}, newsz = length(h.keys)) where {K, V}
     return h
 end
 
-function Base.sizehint!(d::RobinDict, newsz)
+function Base.sizehint!(d::RobinDict, newsz::Integer)
     newsz = _tablesz(newsz*2)  # *2 for keys and values in same array
     oldsz = length(d.keys)
     # grow at least 25%

--- a/src/swiss_dict.jl
+++ b/src/swiss_dict.jl
@@ -274,7 +274,7 @@ function maybe_rehash_shrink!(h::SwissDict)
    end
 end
 
-function Base.sizehint!(d::SwissDict, newsz)
+function Base.sizehint!(d::SwissDict, newsz::Integer)
     newsz = _tablesz(newsz*2)  # *2 for keys and values in same array
     oldsz = length(d.keys)
     # grow at least 25%


### PR DESCRIPTION
JuliaLang/julia#59168 changed the base signature of `sizehint` to use `::Integer` instead of `::Any` for the second argument, thus packages also overload against the signature instead in order to avoid method ambiguity error.