### PR TITLE
Fix deprecation of DisjointSets(xs...) to avoid warning on package load

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -6,7 +6,11 @@
 # Deprecations from #700
 Base.@deprecate_binding DisjointSets DisjointSet
 Base.@deprecate_binding IntDisjointSets IntDisjointSet
-@deprecate DisjointSets(xs...) DisjointSet(xs)
+# We won't want to make this `@deprecate DisjointSets(xs...) DisjointSet(xs)`
+# because then loading this package will trigger a deprecation warning when we
+# evaluate the deprrecated DisjointSets binding. This breaks any package that
+# tries to load DataStructures with --depwarn=error
+@deprecate DisjointSet(xs...) DisjointSet(xs)
 # Enqueue and dequeue deprecations
 @deprecate enqueue!(q::Queue, x) Base.push!(q, x)
 @deprecate enqueue!(q::PriorityQueue, x) Base.push!(q, x)


### PR DESCRIPTION
This deprecation broke JuMP and a bunch of related packages that test with `--depwarn=error` (to avoid using deprecated bindings): https://github.com/jump-dev/JuMP.jl/pull/4058

One downside to this PR is that it introduces a new (deprecated) `DisjointSet(xs...)` method. 

There is already a test that `DisjointSets(xs...)` is equivalent to `DisjointSet(xs...)` and then `DisjointSet(xs)`:
https://github.com/JuliaCollections/DataStructures.jl/blob/bf5146d5b5b553ce724a0edca9a8f2da1725bf1d/test/test_disjoint_set.jl#L168