### PR TITLE
fix: fix `DisjointSets` deprecations

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -6,7 +6,7 @@
 # Deprecations from #700
 Base.@deprecate_binding DisjointSets DisjointSet
 Base.@deprecate_binding IntDisjointSets IntDisjointSet
-@deprecate DisjointSets(xs...) DisjointSet(xs)
+@deprecate DisjointSet(xs...) DisjointSet(xs)
 # Enqueue and dequeue deprecations
 @deprecate enqueue!(q::Queue, x) Base.push!(q, x)
 @deprecate enqueue!(q::PriorityQueue, x) Base.push!(q, x)


### PR DESCRIPTION
This deprecation was phrased incorrectly - the binding `DisjointSets` is already deprecated to `DisjointSet`, so when the `@deprecate` macro defines a method for `DisjointSets(xs...)` it triggers a depwarn. This causes CI failures under `--depwarn=error` such as in https://github.com/jump-dev/JuMP.jl/actions/runs/17155175599/job/48670237345?pr=4057#step:6:146.