### PR TITLE
Fix naming of DisjointSet in documentation and tests

### DIFF
--- a/docs/src/disjoint_sets.md
+++ b/docs/src/disjoint_sets.md
@@ -9,7 +9,7 @@ set forest* (disjoint sets).
 Usage:
 
 ```julia
-a = IntDisjointSets(10)  # creates a forest comprised of 10 singletons
+a = IntDisjointSet(10)  # creates a forest comprised of 10 singletons
 union!(a, 3, 5)          # merges the sets that contain 3 and 5 into one and returns the root of the new set
 root_union!(a, x, y)     # merges the sets that have root x and y into one and returns the root of the new set
 find_root!(a, 3)         # finds the root element of the subset that contains 3
@@ -22,14 +22,14 @@ num_groups(a)            # returns the number of sets
 One may also use other element types:
 
 ```julia
-a = DisjointSets{AbstractString}(["a", "b", "c", "d"])
+a = DisjointSet{AbstractString}(["a", "b", "c", "d"])
 union!(a, "a", "b")
 in_same_set(a, "c", "d")
 push!(a, "f")
 ```
 
-Note that the internal implementation of `IntDisjointSets` is based on
-vectors, and is very efficient. `DisjointSets{T}` is a wrapper of
-`IntDisjointSets`, which uses a dictionary to map input elements to an
-internal index. Note for `DisjointSets`, `union!`, `root_union!` and
+Note that the internal implementation of `IntDisjointSet` is based on
+vectors, and is very efficient. `DisjointSet{T}` is a wrapper of
+`IntDisjointSet`, which uses a dictionary to map input elements to an
+internal index. Note for `DisjointSet`, `union!`, `root_union!` and
 `find_root!` return the index of the root.

--- a/test/bench_disjoint_set.jl
+++ b/test/bench_disjoint_set.jl
@@ -8,13 +8,13 @@ const n =  2 * (10^6)
 const T0 = 10
 const T = 10^6
 
-function batch_union!(s::IntDisjointSets, x::Vector{Int}, y::Vector{Int})
+function batch_union!(s::IntDisjointSet, x::Vector{Int}, y::Vector{Int})
     for i = 1 : length(x)
         @inbounds union!(s, x[i], y[i])
     end
 end
 
-s = IntDisjointSets(n)
+s = IntDisjointSet(n)
 
 # warming
 


### PR DESCRIPTION
`DisjointSet` and `IntDisjointSet` were renamed in #700 but the documentation was still referring to the old name