### PR TITLE
Fix issue 969, creation of balanced tree from empty sorted data

### DIFF
--- a/src/balanced_tree.jl
+++ b/src/balanced_tree.jl
@@ -1015,6 +1015,9 @@ function BalancedTree23{K,D,Ord}(::Val{true},
         push!(m.useddatacells, lengthdata)
         firsttrip = false
     end
+    if firsttrip # no data items in tree, so return empty m.
+        return m
+    end
     resize!(m.tree, 0)
     height = 0
     belowlevlength = lengthdata
@@ -1055,6 +1058,7 @@ function BalancedTree23{K,D,Ord}(::Val{true},
                               child_belowaddress[3], 0,
                               m.data[child_keyaddress[2]].k,
                               m.data[child_keyaddress[3]].k))
+                
             myaddress = length(m.tree)
             if height == 0
                 replaceparent!(m.data, child_belowaddress[1], myaddress)

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -300,13 +300,15 @@ function testSortedDictMethods()
     my_assert(typeof(m09a) == SortedDict{Int,Any,ForwardOrdering})
     m09b = SortedDict([(1,2), (3,'a')])  # test issue 239
     my_assert(typeof(m09a) == SortedDict{Int,Any,ForwardOrdering})
-
     my_assert(m0 == m02)
     my_assert(isequal(m0, m02))
     my_assert(m1 == m01)
     my_assert(isequal(m1, m01))
     my_assert(m1 == m11)
     my_assert(isequal(m1, m11))
+
+    m10 = union(SortedDict(), SortedDict())  # test issue 969
+    my_assert(length(m10) == 0)
 
     # Test Exceptions
     @test_throws ArgumentError SortedDict([1,2,3,4])

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -307,7 +307,7 @@ function testSortedDictMethods()
     my_assert(m1 == m11)
     my_assert(isequal(m1, m11))
 
-    m10 = union(SortedDict(), SortedDict())  # test issue 969
+    m10 = union(SortedSet(), SortedSet())  # test issue 969
     my_assert(length(m10) == 0)
 
     # Test Exceptions


### PR DESCRIPTION
When creating a balanced tree from pre-sorted but empty data, must skip the tree-building logic because the sentinel nodes are uninitialized.  (Addresses #969)