### PR TITLE
dicts: improve performance for non-concrete values and keys

### DIFF
--- a/src/ordered_robin_dict.jl
+++ b/src/ordered_robin_dict.jl
@@ -430,18 +430,18 @@ function get_next_filled_index(h::OrderedRobinDict, index)
     return -1
 end
 
-Base.@propagate_inbounds function Base.iterate(h::OrderedRobinDict)
+Base.@propagate_inbounds function Base.iterate(h::OrderedRobinDict{K,V}) where {K,V}
     isempty(h) && return nothing
     check_for_rehash(h) && rehash!(h)
     index = get_first_filled_index(h)
-    return (Pair(h.keys[index], h.vals[index]), index+1)
+    @inbounds return (Pair{K,V}(h.keys[index], h.vals[index]), index+1)
 end
 
-Base.@propagate_inbounds function Base.iterate(h::OrderedRobinDict, i)
+Base.@propagate_inbounds function Base.iterate(h::OrderedRobinDict{K,V}, i) where {K,V}
     length(h.keys) < i && return nothing
     index = get_next_filled_index(h, i)
     (index < 0) && return nothing
-    return (Pair(h.keys[index], h.vals[index]), index+1)
+    @inbounds return (Pair{K,V}(h.keys[index], h.vals[index]), index+1)
 end
 
 Base.filter!(f, d::Union{RobinDict, OrderedRobinDict}) = Base.filter_in_one_pass!(f, d)

--- a/src/swiss_dict.jl
+++ b/src/swiss_dict.jl
@@ -636,11 +636,11 @@ function Base.delete!(h::SwissDict, key)
     return h
 end
 
-Base.@propagate_inbounds function Base.iterate(h::SwissDict, state = h.idxfloor)
+Base.@propagate_inbounds function Base.iterate(h::SwissDict{K,V}, state = h.idxfloor) where {K,V}
     is = _iterslots(h, state)
     is === nothing && return nothing
     i, s = is
-    @inbounds p = h.keys[i] => h.vals[i]
+    @inbounds p = Pair{K,V}(h.keys[i], h.vals[i])
     return (p, s)
 end
 


### PR DESCRIPTION
Same as https://github.com/JuliaCollections/OrderedCollections.jl/pull/166

Benchmark:

```julia
  using DataStructures
  using BenchmarkTools

  const N = 1000
  pairs = [i => (iseven(i) ? i : Float64(i)) for i in 1:N]

  d_base  = Dict{Int,Number}(pairs)
  d_robin = RobinDict{Int,Number}(pairs)
  d_ord   = OrderedRobinDict{Int,Number}(pairs)
  d_swiss = SwissDict{Int,Number}(pairs)

  function sumvals(d)
      s = 0.0
      for (k, v) in d
          s += v
      end
      return s
  end

  print("Dict (base):       "); @btime sumvals($d_base)
  print("RobinDict:         "); @btime sumvals($d_robin)
  print("OrderedRobinDict:  "); @btime sumvals($d_ord)
  print("SwissDict:         "); @btime sumvals($d_swiss)
```

Results:

```
  Dict (base):         15.870 μs (1000 allocations: 15.62 KiB)

  Before
  OrderedRobinDict:    145.245 μs (3234 allocations: 66.16 KiB)
  SwissDict:           142.385 μs (3234 allocations: 66.16 KiB)

  After
  OrderedRobinDict:    13.913 μs (1000 allocations: 15.62 KiB)
  SwissDict:           13.795 μs (1000 allocations: 15.62 KiB)
```