### PR TITLE
docs: document array-as-heap functions

### DIFF
--- a/docs/src/heaps.md
+++ b/docs/src/heaps.md
@@ -153,6 +153,20 @@ this ordering:
 DataStructures.nextreme(Base.Forward, n, a) # Equivalent to nsmallest(n, a)
 ```
 
+# Array-as-heap functions
+
+These functions treat an `AbstractArray` directly as a binary heap, mirroring
+the C++ `std::push_heap`/`pop_heap`/`make_heap` family. They operate in place
+on the array rather than wrapping it in a heap type.
+
+```@docs
+heappush!
+heappop!
+heapify!
+heapify
+isheap
+```
+
 
 # Improving performance with Float data
 

--- a/src/heaps/arrays_as_heaps.jl
+++ b/src/heaps/arrays_as_heaps.jl
@@ -87,6 +87,7 @@ In-place [`heapify`](@ref).
     return xs
 end
 
+# Todo, benchmarking shows copy(xs) outperforms copyto!(similar(xs), xs) for 10^6 Float64
 """
     heapify(v, ord::Ordering=Forward)
 
@@ -95,7 +96,7 @@ Returns a new vector in binary heap order, optionally using the given ordering.
 julia> a = [1,3,4,5,2];
 
 julia> heapify(a)
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  1
  2
  4
@@ -103,7 +104,7 @@ julia> heapify(a)
  3
 
 julia> heapify(a, Base.Order.Reverse)
-5-element Array{Int64,1}:
+5-element Vector{Int64}:
  5
  3
  4
@@ -111,7 +112,6 @@ julia> heapify(a, Base.Order.Reverse)
  2
 ```
 """
-# Todo, benchmarking shows copy(xs) outperforms copyto!(similar(xs), xs) for 10^6 Float64
 heapify(xs::AbstractArray, o::Ordering=Forward) = heapify!(copyto!(similar(xs), xs), o)
 
 """


### PR DESCRIPTION

`heappush!`, `heappop!`, `heapify!`, `heapify`, and `isheap` are exported with
docstrings but no manual page lists them, so they never render. Add an `@docs`
block for the five under a new "Array-as-heap functions" heading in `heaps.md`.

`heapify` also had no attached docstring at all: a `# Todo` comment between its
docstring and definition detached it, so the `@docs` entry and `heapify!`'s
`@ref` to it could not resolve. Move the comment above the docstring and refresh
its jldoctest output for current Julia.

Fixes #957
